### PR TITLE
Adding a minimalistic IIIF Image API 1.1 support and corresponding test files

### DIFF
--- a/packages/annotation/src/schemas/shared.ts
+++ b/packages/annotation/src/schemas/shared.ts
@@ -2,4 +2,4 @@ import { z } from 'zod'
 
 export const PointSchema = z.tuple([z.number(), z.number()])
 
-export const ImageServiceSchema = z.enum(['ImageService2', 'ImageService3'])
+export const ImageServiceSchema = z.enum(['ImageService1', 'ImageService2', 'ImageService3'])

--- a/packages/iiif-parser/src/classes/iiif.ts
+++ b/packages/iiif-parser/src/classes/iiif.ts
@@ -1,11 +1,12 @@
 import {
+  Image1Schema,
   Image2Schema,
   Image3Schema,
   // TODO: add Canvas!
   Manifest2Schema,
   Manifest3Schema,
   Collection2Schema,
-  Collection3Schema
+  Collection3Schema,
 } from '../schemas/iiif.js'
 
 import { Image } from './image.js'
@@ -16,7 +17,10 @@ import type { MajorVersion } from '../lib/types.js'
 
 export class IIIF {
   static parse(iiifData: any, majorVersion: MajorVersion | null = null) {
-    if (majorVersion === 2 || '@id' in iiifData) {
+    if (majorVersion === 1 || ('@context' in iiifData && iiifData['@context'] === 'http://library.stanford.edu/iiif/image-api/1.1/context.json')) {
+      const parsedImage = Image1Schema.parse(iiifData)
+      return new Image(parsedImage)
+    } else if (majorVersion === 2 || '@id' in iiifData) {
       if (iiifData.protocol === 'http://iiif.io/api/image') {
         const parsedImage = Image2Schema.parse(iiifData)
         return new Image(parsedImage)

--- a/packages/iiif-parser/src/classes/image.ts
+++ b/packages/iiif-parser/src/classes/image.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { Image2Schema, Image3Schema, ImageSchema } from '../schemas/iiif.js'
+import { Image1Schema, Image2Schema, Image3Schema, ImageSchema } from '../schemas/iiif.js'
 import { ImageResource2Schema } from '../schemas/presentation.2.js'
 import { AnnotationBody3Schema } from '../schemas/presentation.3.js'
 
@@ -61,8 +61,14 @@ export class EmbeddedImage {
 
       if ('type' in imageService && imageService.type === 'ImageService3') {
         this.majorVersion = 3
-      } else {
+      } else if (
+        ('type' in imageService && imageService.type === 'ImageService2') || 
+        ('@type' in imageService && imageService['@type'] === 'ImageService2') || 
+        ('@context' in imageService && imageService['@context'] === "http://iiif.io/api/image/2/context.json")) {
         this.majorVersion = 2
+      } else {
+        // console.log('imageService=',imageService)
+        this.majorVersion = 1
       }
 
       const profileProperties = getProfileProperties(imageService)
@@ -83,8 +89,13 @@ export class EmbeddedImage {
 
       if ('type' in parsedImage && parsedImage.type === 'ImageService3') {
         this.majorVersion = 3
-      } else {
+      } else if (
+        ('@type' in parsedImage && parsedImage['@type'] === 'iiif:Image')||
+        ('@context' in parsedImage && parsedImage['@context'] === "http://iiif.io/api/image/2/context.json")) {
         this.majorVersion = 2
+      } else {
+        // console.log('parsedImage=',parsedImage)
+        this.majorVersion = 1
       }
 
       if ('profile' in parsedImage) {
@@ -221,7 +232,9 @@ export class Image extends EmbeddedImage {
   static parse(iiifData: any, majorVersion: MajorVersion | null = null) {
     let parsedImage
 
-    if (majorVersion === 2) {
+    if (majorVersion === 1) {
+      parsedImage = Image1Schema.parse(iiifData)
+    } else if (majorVersion === 2) {
       parsedImage = Image2Schema.parse(iiifData)
     } else if (majorVersion === 3) {
       parsedImage = Image3Schema.parse(iiifData)

--- a/packages/iiif-parser/src/lib/profile.ts
+++ b/packages/iiif-parser/src/lib/profile.ts
@@ -5,6 +5,7 @@ import { ImageServiceSchema } from '../schemas/image-service.js'
 import { Image2ProfileDescriptionSchema } from '../schemas/image.2.js'
 import { ProfileProperties } from '../lib/types.js'
 
+import { image1ProfileUriRegex } from '../schemas/image.1.js'
 import { image2ProfileUriRegex } from '../schemas/image.2.js'
 
 const anyRegionAndSizeFeatures = ['regionByPx', 'sizeByWh']
@@ -22,7 +23,13 @@ function parseProfileUri(uri: string): number {
     const level = parseInt(match.groups.level)
     return level
   } else {
-    throw new Error('Unsupported IIIF Image Profile')
+    const match1 = uri.match(image1ProfileUriRegex)
+    if (match1 && match1.groups) {
+      const level = parseInt(match1.groups.level)
+      return level
+    } else {  
+      throw new Error('Unsupported IIIF Image Profile')
+    }
   }
 }
 

--- a/packages/iiif-parser/src/lib/strings.ts
+++ b/packages/iiif-parser/src/lib/strings.ts
@@ -28,22 +28,40 @@ export function parseVersion2String(str: StringValue2Type): StringValue3Type {
         if (!strings['none']) {
           strings['none'] = []
         }
-
         strings['none'].push(item)
       } else if (typeof item === 'object') {
-        strings = { ...strings, ...parseVersion2String(item) }
+        console.log("strings before = ", strings)
+        const itemStrings = parseVersion2String(item)
+        console.log("  itemStrings = ", itemStrings)
+        for (const key in itemStrings) {
+          if (key in strings) {
+            strings[key] = strings[key].concat(itemStrings[key])
+          } else {
+            strings[key] = itemStrings[key]
+          }
+        }
+        // strings = { ...strings, ...parseVersion2String(item) }
+        console.log("strings after = ", strings)
       } else {
         throw new Error('Unable to parse string')
       }
     })
+    console.log("strings = ", strings)
 
     return strings
   } else if (str && typeof str === 'object') {
     const language = str['@language']
     const value = str['@value']
 
-    return {
-      [language]: Array.isArray(value) ? value : [value]
+    if (language === undefined) {
+      console.log("Value = ", value)
+      return {
+        none: Array.isArray(value) ? value : [value]
+      }
+    } else {
+      return {
+        [language]: Array.isArray(value) ? value : [value]
+      }
     }
   } else {
     throw new Error('Unable to parse string')

--- a/packages/iiif-parser/src/lib/types.ts
+++ b/packages/iiif-parser/src/lib/types.ts
@@ -22,7 +22,7 @@ export interface ImageRequest {
   size?: Size
 }
 
-export type MajorVersion = 2 | 3
+export type MajorVersion = 1 | 2 | 3
 
 export interface TileZoomLevel {
   scaleFactor: number

--- a/packages/iiif-parser/src/schemas/iiif.ts
+++ b/packages/iiif-parser/src/schemas/iiif.ts
@@ -1,3 +1,4 @@
+import { Image1Schema } from './image.1.js'
 import { Image2Schema } from './image.2.js'
 import { Image3Schema } from './image.3.js'
 
@@ -13,12 +14,12 @@ import {
   Collection3Schema
 } from './presentation.3.js'
 
-export { Image2Schema, Image3Schema }
+export { Image1Schema, Image2Schema, Image3Schema }
 export { Canvas2Schema, Canvas3Schema }
 export { Manifest2Schema, Manifest3Schema }
 export { Collection2Schema, Collection3Schema }
 
-export const ImageSchema = Image2Schema.or(Image3Schema)
+export const ImageSchema = Image1Schema.or(Image2Schema).or(Image3Schema)
 export const CanvasSchema = Canvas2Schema.or(Canvas3Schema)
 export const ManifestSchema = Manifest2Schema.or(Manifest3Schema)
 export const CollectionSchema = Collection2Schema.or(Collection3Schema)

--- a/packages/iiif-parser/src/schemas/image-service.2.ts
+++ b/packages/iiif-parser/src/schemas/image-service.2.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod'
-
-import { Image2ProfileSchema } from './image.2.js'
+import { Image1ProfileSchema, Image1Context } from './image.1.js'
+import { Image2ProfileSchema, Image2Context } from './image.2.js'
 
 // TODO: also support Presentation API 2 with Image API 3
-
+// TODO: also support Image3Context (a string or an array of strings)
 export const ImageService2Schema = z.object({
   '@id': z.string().url(),
-  profile: Image2ProfileSchema
+  profile: Image1ProfileSchema.or(Image2ProfileSchema),
+  '@context': Image1Context.or(z.literal('http://iiif.io/api/image/1/context.json')).or(Image2Context)
 })

--- a/packages/iiif-parser/src/schemas/image-service.3.ts
+++ b/packages/iiif-parser/src/schemas/image-service.3.ts
@@ -4,13 +4,17 @@ import { Image2ProfileSchema } from './image.2.js'
 
 export const complianceLevels = ['level0', 'level1', 'level2'] as const
 
-export const imageServiceTypes = ['ImageService2', 'ImageService3'] as const
+export const imageServiceTypes = ['ImageService1', 'ImageService2', 'ImageService3'] as const
 
 export const Presentation3ImageService2Schema = z.object({
   id: z.string().url(),
   type: z.literal('ImageService2'),
   profile: Image2ProfileSchema
-})
+}).or(z.object({
+  '@id': z.string().url(),
+  '@type': z.literal('ImageService2'),
+  profile: Image2ProfileSchema
+}))
 
 export const Presentation3ImageService3Schema = z.object({
   id: z.string().url(),

--- a/packages/iiif-parser/src/schemas/image.1.ts
+++ b/packages/iiif-parser/src/schemas/image.1.ts
@@ -1,0 +1,45 @@
+// Image API 1.1
+// https://iiif.io/api/image/1.1/#image-information
+
+import { z } from 'zod'
+import { TilesetSchema, SizeSchema } from './shared.js'
+// export const Image1ProfileSchema = z.union([
+//   z.literal('http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level0'),
+//   z.literal('http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level1'),
+//   z.literal('http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2')
+// ])
+export const image1ProfileUriRegex =
+  /^https?:\/\/library.stanford.edu\/iiif\/image-api\/1.1\/compliance.html#level(?<level>[012])$/
+
+export const Image1ProfileUri = z.string().regex(image1ProfileUriRegex)
+
+export const Image1ProfileSchema = Image1ProfileUri
+
+export const Image1Context = z.literal('http://library.stanford.edu/iiif/image-api/1.1/context.json')
+
+export const Image1Schema = z.object({
+  '@context': Image1Context,
+  '@id': z.string().url(),
+  width: z.number().int(),
+  height: z.number().int(),
+  scale_factors: z.number().array().optional(),
+  tile_width: z.number().optional(),
+  tile_height: z.number().optional(),
+  formats: z.array(z.union([
+    z.literal('jpg'),
+    z.literal('png'),
+    z.literal('tif'),
+    z.literal('gif'),
+    z.literal('pdf'),
+    z.literal('jp2')
+  ])).optional(),
+  qualities: z.array(z.union([
+    z.literal('native'),
+    z.literal('color'),
+    z.literal('grey'),
+    z.literal('bitonal')
+  ])).optional(),
+  profile: Image1ProfileUri,
+  sizes: SizeSchema.array().optional(),
+  tiles: TilesetSchema.array().optional()
+})

--- a/packages/iiif-parser/src/schemas/image.2.ts
+++ b/packages/iiif-parser/src/schemas/image.2.ts
@@ -42,9 +42,12 @@ export const Image2ProfileSchema = Image2ProfileUri.or(
   )
 )
 
+export const Image2Context = z.literal('http://iiif.io/api/image/2/context.json')
+
 export const Image2Schema = z.object({
   '@id': z.string().url(),
   '@type': z.literal('iiif:Image').optional(),
+  '@context': Image2Context,
   protocol: z.literal('http://iiif.io/api/image'),
   width: z.number().int(),
   height: z.number().int(),

--- a/packages/iiif-parser/src/schemas/presentation.2.ts
+++ b/packages/iiif-parser/src/schemas/presentation.2.ts
@@ -8,7 +8,7 @@ import { ImageServiceSchema } from './image-service.js'
 export const SingleStringValue2Schema = z.string().or(z.string().array())
 
 export const LanguageString2Schema = z.object({
-  '@language': z.string(),
+  '@language': z.string().optional(),
   '@value': SingleStringValue2Schema
 })
 

--- a/packages/iiif-parser/test/input/image.1.gallica.bnf.12148.btv1b53243704g.f1.json
+++ b/packages/iiif-parser/test/input/image.1.gallica.bnf.12148.btv1b53243704g.f1.json
@@ -1,0 +1,1 @@
+{"profile":"http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2","width":7900,"height":11060,"@context":"http://library.stanford.edu/iiif/image-api/1.1/context.json","@id":"https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f1"}

--- a/packages/iiif-parser/test/input/manifest.2.gallica.bnf.12148.btv1b53243704g.f1.json
+++ b/packages/iiif-parser/test/input/manifest.2.gallica.bnf.12148.btv1b53243704g.f1.json
@@ -1,0 +1,1994 @@
+{
+  "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/manifest.json",
+  "label" : "BnF, département Cartes et plans, GE DD-2998",
+  "attribution" : "Bibliothèque nationale de France",
+  "license" : "https://gallica.bnf.fr/html/und/conditions-dutilisation-des-contenus-de-gallica",
+  "logo" : "https://gallica.bnf.fr/mbImage/logos/logo-bnf.png",
+  "related" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g",
+  "seeAlso" : [ "http://oai.bnf.fr/oai2/OAIHandler?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:bnf.fr:gallica/ark:/12148/btv1b53243704g" ],
+  "description" : "Atlas du plan général de la ville de Paris / Levé géométriquement par le Citoyen Verniquet... ; dessiné et gravé par les Citoyens Bartholomé et Mathieu",
+  "metadata" : [ {
+    "label" : "Repository",
+    "value" : "Bibliothèque nationale de France"
+  }, {
+    "label" : "Digitised by",
+    "value" : "Bibliothèque nationale de France"
+  }, {
+    "label" : "Source Images",
+    "value" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g"
+  }, {
+    "label" : "Metadata Source",
+    "value" : "http://oai.bnf.fr/oai2/OAIHandler?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:bnf.fr:gallica/ark:/12148/btv1b53243704g"
+  }, {
+    "label" : "Shelfmark",
+    "value" : "Bibliothèque nationale de France, département Cartes et plans, GE DD-2998"
+  }, {
+    "label" : "Title",
+    "value" : "Atlas du plan général de la ville de Paris / Levé géométriquement par le Citoyen Verniquet... ; dessiné et gravé par les Citoyens Bartholomé et Mathieu"
+  }, {
+    "label" : "Date",
+    "value" : "179."
+  }, {
+    "label" : "Language",
+    "value" : "français"
+  }, {
+    "label" : "Format",
+    "value" : [ {
+      "@value" : "71 flles : en noir ; 68 x 46 cm"
+    }, {
+      "@value" : "image/jpeg"
+    }, {
+      "@value" : "Nombre total de vues :  74"
+    } ]
+  }, {
+    "label" : "Creator",
+    "value" : [ {
+      "@value" : "Verniquet, Edme (1727-1804). Auteur du texte"
+    }, {
+      "@value" : "Bartholomé, Paul-Thomas (17..-18..). Auteur du texte"
+    }, {
+      "@value" : "Mathieu, A. J. (17..-18.. ; dessinateur). Auteur du texte"
+    } ]
+  }, {
+    "label" : "Relation",
+    "value" : "Notice du catalogue : http://catalogue.bnf.fr/ark:/12148/cb40708746v"
+  }, {
+    "label" : "Type",
+    "value" : "Carte"
+  } ],
+  "sequences" : [ {
+    "canvases" : [ {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f1",
+      "label" : "NP",
+      "height" : 11060,
+      "width" : 7900,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f1",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f1"
+          },
+          "height" : 11060,
+          "width" : 7900,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f1/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f1.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f2",
+      "label" : "NP",
+      "height" : 6834,
+      "width" : 5182,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f2",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f2"
+          },
+          "height" : 6834,
+          "width" : 5182,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f2/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f2.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f3",
+      "label" : "NP",
+      "height" : 8046,
+      "width" : 10490,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f3",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f3"
+          },
+          "height" : 8046,
+          "width" : 10490,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f3/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f3.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f4",
+      "label" : "NP",
+      "height" : 7974,
+      "width" : 11088,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f4",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f4"
+          },
+          "height" : 7974,
+          "width" : 11088,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f4/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f4.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f5",
+      "label" : "NP",
+      "height" : 8006,
+      "width" : 11228,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f5",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f5"
+          },
+          "height" : 8006,
+          "width" : 11228,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f5/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f5.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f6",
+      "label" : "NP",
+      "height" : 8020,
+      "width" : 11148,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f6",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f6"
+          },
+          "height" : 8020,
+          "width" : 11148,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f6/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f6.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f7",
+      "label" : "NP",
+      "height" : 8002,
+      "width" : 11138,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f7",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f7"
+          },
+          "height" : 8002,
+          "width" : 11138,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f7/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f7.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f8",
+      "label" : "NP",
+      "height" : 8016,
+      "width" : 11180,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f8",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f8"
+          },
+          "height" : 8016,
+          "width" : 11180,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f8/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f8.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f9",
+      "label" : "NP",
+      "height" : 7958,
+      "width" : 11092,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f9",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f9"
+          },
+          "height" : 7958,
+          "width" : 11092,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f9/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f9.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f10",
+      "label" : "NP",
+      "height" : 7978,
+      "width" : 11060,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f10",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f10"
+          },
+          "height" : 7978,
+          "width" : 11060,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f10/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f10.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f11",
+      "label" : "NP",
+      "height" : 8066,
+      "width" : 10782,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f11",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f11"
+          },
+          "height" : 8066,
+          "width" : 10782,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f11/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f11.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f12",
+      "label" : "NP",
+      "height" : 8006,
+      "width" : 11132,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f12",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f12"
+          },
+          "height" : 8006,
+          "width" : 11132,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f12/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f12.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f13",
+      "label" : "NP",
+      "height" : 7984,
+      "width" : 10998,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f13",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f13"
+          },
+          "height" : 7984,
+          "width" : 10998,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f13/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f13.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f14",
+      "label" : "NP",
+      "height" : 8222,
+      "width" : 11184,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f14",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f14"
+          },
+          "height" : 8222,
+          "width" : 11184,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f14/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f14.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f15",
+      "label" : "NP",
+      "height" : 7966,
+      "width" : 11024,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f15",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f15"
+          },
+          "height" : 7966,
+          "width" : 11024,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f15/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f15.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f16",
+      "label" : "NP",
+      "height" : 8038,
+      "width" : 11142,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f16",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f16"
+          },
+          "height" : 8038,
+          "width" : 11142,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f16/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f16.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f17",
+      "label" : "NP",
+      "height" : 7988,
+      "width" : 11118,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f17",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f17"
+          },
+          "height" : 7988,
+          "width" : 11118,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f17/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f17.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f18",
+      "label" : "NP",
+      "height" : 7970,
+      "width" : 11242,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f18",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f18"
+          },
+          "height" : 7970,
+          "width" : 11242,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f18/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f18.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f19",
+      "label" : "NP",
+      "height" : 8118,
+      "width" : 10918,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f19",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f19"
+          },
+          "height" : 8118,
+          "width" : 10918,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f19/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f19.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f20",
+      "label" : "NP",
+      "height" : 7944,
+      "width" : 11102,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f20",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f20"
+          },
+          "height" : 7944,
+          "width" : 11102,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f20/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f20.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f21",
+      "label" : "NP",
+      "height" : 7950,
+      "width" : 11120,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f21",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f21"
+          },
+          "height" : 7950,
+          "width" : 11120,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f21/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f21.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f22",
+      "label" : "NP",
+      "height" : 7952,
+      "width" : 11166,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f22",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f22"
+          },
+          "height" : 7952,
+          "width" : 11166,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f22/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f22.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f23",
+      "label" : "NP",
+      "height" : 7970,
+      "width" : 11290,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f23",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f23"
+          },
+          "height" : 7970,
+          "width" : 11290,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f23/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f23.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f24",
+      "label" : "NP",
+      "height" : 7958,
+      "width" : 11130,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f24",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f24"
+          },
+          "height" : 7958,
+          "width" : 11130,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f24/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f24.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f25",
+      "label" : "NP",
+      "height" : 7972,
+      "width" : 11122,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f25",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f25"
+          },
+          "height" : 7972,
+          "width" : 11122,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f25/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f25.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f26",
+      "label" : "NP",
+      "height" : 7974,
+      "width" : 11144,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f26",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f26"
+          },
+          "height" : 7974,
+          "width" : 11144,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f26/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f26.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f27",
+      "label" : "NP",
+      "height" : 8050,
+      "width" : 10764,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f27",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f27"
+          },
+          "height" : 8050,
+          "width" : 10764,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f27/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f27.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f28",
+      "label" : "NP",
+      "height" : 7990,
+      "width" : 11164,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f28",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f28"
+          },
+          "height" : 7990,
+          "width" : 11164,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f28/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f28.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f29",
+      "label" : "NP",
+      "height" : 8050,
+      "width" : 11114,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f29",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f29"
+          },
+          "height" : 8050,
+          "width" : 11114,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f29/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f29.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f30",
+      "label" : "NP",
+      "height" : 8000,
+      "width" : 11168,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f30",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f30"
+          },
+          "height" : 8000,
+          "width" : 11168,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f30/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f30.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f31",
+      "label" : "NP",
+      "height" : 8004,
+      "width" : 11124,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f31",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f31"
+          },
+          "height" : 8004,
+          "width" : 11124,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f31/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f31.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f32",
+      "label" : "NP",
+      "height" : 7994,
+      "width" : 11054,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f32",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f32"
+          },
+          "height" : 7994,
+          "width" : 11054,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f32/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f32.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f33",
+      "label" : "NP",
+      "height" : 8018,
+      "width" : 11156,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f33",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f33"
+          },
+          "height" : 8018,
+          "width" : 11156,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f33/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f33.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f34",
+      "label" : "NP",
+      "height" : 8002,
+      "width" : 11114,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f34",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f34"
+          },
+          "height" : 8002,
+          "width" : 11114,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f34/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f34.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f35",
+      "label" : "NP",
+      "height" : 7956,
+      "width" : 11062,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f35",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f35"
+          },
+          "height" : 7956,
+          "width" : 11062,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f35/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f35.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f36",
+      "label" : "NP",
+      "height" : 8040,
+      "width" : 11202,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f36",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f36"
+          },
+          "height" : 8040,
+          "width" : 11202,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f36/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f36.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f37",
+      "label" : "NP",
+      "height" : 8026,
+      "width" : 11186,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f37",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f37"
+          },
+          "height" : 8026,
+          "width" : 11186,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f37/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f37.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f38",
+      "label" : "NP",
+      "height" : 8010,
+      "width" : 11076,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f38",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f38"
+          },
+          "height" : 8010,
+          "width" : 11076,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f38/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f38.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f39",
+      "label" : "NP",
+      "height" : 8010,
+      "width" : 11136,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f39",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f39"
+          },
+          "height" : 8010,
+          "width" : 11136,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f39/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f39.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f40",
+      "label" : "NP",
+      "height" : 8000,
+      "width" : 11150,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f40",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f40"
+          },
+          "height" : 8000,
+          "width" : 11150,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f40/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f40.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f41",
+      "label" : "NP",
+      "height" : 8012,
+      "width" : 11180,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f41",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f41"
+          },
+          "height" : 8012,
+          "width" : 11180,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f41/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f41.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f42",
+      "label" : "NP",
+      "height" : 8014,
+      "width" : 11118,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f42",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f42"
+          },
+          "height" : 8014,
+          "width" : 11118,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f42/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f42.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f43",
+      "label" : "NP",
+      "height" : 7954,
+      "width" : 11016,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f43",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f43"
+          },
+          "height" : 7954,
+          "width" : 11016,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f43/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f43.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f44",
+      "label" : "NP",
+      "height" : 8028,
+      "width" : 11122,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f44",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f44"
+          },
+          "height" : 8028,
+          "width" : 11122,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f44/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f44.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f45",
+      "label" : "NP",
+      "height" : 7992,
+      "width" : 11110,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f45",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f45"
+          },
+          "height" : 7992,
+          "width" : 11110,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f45/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f45.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f46",
+      "label" : "NP",
+      "height" : 8014,
+      "width" : 11134,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f46",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f46"
+          },
+          "height" : 8014,
+          "width" : 11134,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f46/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f46.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f47",
+      "label" : "NP",
+      "height" : 7968,
+      "width" : 11078,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f47",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f47"
+          },
+          "height" : 7968,
+          "width" : 11078,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f47/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f47.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f48",
+      "label" : "NP",
+      "height" : 7968,
+      "width" : 11156,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f48",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f48"
+          },
+          "height" : 7968,
+          "width" : 11156,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f48/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f48.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f49",
+      "label" : "NP",
+      "height" : 7970,
+      "width" : 11078,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f49",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f49"
+          },
+          "height" : 7970,
+          "width" : 11078,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f49/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f49.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f50",
+      "label" : "NP",
+      "height" : 7964,
+      "width" : 11116,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f50",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f50"
+          },
+          "height" : 7964,
+          "width" : 11116,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f50/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f50.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f51",
+      "label" : "NP",
+      "height" : 7996,
+      "width" : 11082,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f51",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f51"
+          },
+          "height" : 7996,
+          "width" : 11082,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f51/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f51.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f52",
+      "label" : "NP",
+      "height" : 7960,
+      "width" : 11138,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f52",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f52"
+          },
+          "height" : 7960,
+          "width" : 11138,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f52/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f52.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f53",
+      "label" : "NP",
+      "height" : 7980,
+      "width" : 11172,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f53",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f53"
+          },
+          "height" : 7980,
+          "width" : 11172,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f53/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f53.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f54",
+      "label" : "NP",
+      "height" : 7994,
+      "width" : 11104,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f54",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f54"
+          },
+          "height" : 7994,
+          "width" : 11104,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f54/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f54.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f55",
+      "label" : "NP",
+      "height" : 8000,
+      "width" : 11162,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f55",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f55"
+          },
+          "height" : 8000,
+          "width" : 11162,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f55/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f55.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f56",
+      "label" : "NP",
+      "height" : 8028,
+      "width" : 11194,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f56",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f56"
+          },
+          "height" : 8028,
+          "width" : 11194,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f56/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f56.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f57",
+      "label" : "NP",
+      "height" : 7982,
+      "width" : 11212,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f57",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f57"
+          },
+          "height" : 7982,
+          "width" : 11212,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f57/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f57.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f58",
+      "label" : "NP",
+      "height" : 7982,
+      "width" : 11076,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f58",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f58"
+          },
+          "height" : 7982,
+          "width" : 11076,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f58/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f58.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f59",
+      "label" : "NP",
+      "height" : 7994,
+      "width" : 11004,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f59",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f59"
+          },
+          "height" : 7994,
+          "width" : 11004,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f59/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f59.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f60",
+      "label" : "NP",
+      "height" : 7988,
+      "width" : 11132,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f60",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f60"
+          },
+          "height" : 7988,
+          "width" : 11132,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f60/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f60.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f61",
+      "label" : "NP",
+      "height" : 7960,
+      "width" : 11142,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f61",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f61"
+          },
+          "height" : 7960,
+          "width" : 11142,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f61/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f61.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f62",
+      "label" : "NP",
+      "height" : 7998,
+      "width" : 11148,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f62",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f62"
+          },
+          "height" : 7998,
+          "width" : 11148,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f62/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f62.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f63",
+      "label" : "NP",
+      "height" : 8000,
+      "width" : 11156,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f63",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f63"
+          },
+          "height" : 8000,
+          "width" : 11156,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f63/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f63.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f64",
+      "label" : "NP",
+      "height" : 7968,
+      "width" : 11034,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f64",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f64"
+          },
+          "height" : 7968,
+          "width" : 11034,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f64/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f64.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f65",
+      "label" : "NP",
+      "height" : 8030,
+      "width" : 11170,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f65",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f65"
+          },
+          "height" : 8030,
+          "width" : 11170,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f65/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f65.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f66",
+      "label" : "NP",
+      "height" : 8140,
+      "width" : 11088,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f66",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f66"
+          },
+          "height" : 8140,
+          "width" : 11088,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f66/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f66.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f67",
+      "label" : "NP",
+      "height" : 7990,
+      "width" : 10950,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f67",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f67"
+          },
+          "height" : 7990,
+          "width" : 10950,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f67/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f67.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f68",
+      "label" : "NP",
+      "height" : 7970,
+      "width" : 11206,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f68",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f68"
+          },
+          "height" : 7970,
+          "width" : 11206,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f68/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f68.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f69",
+      "label" : "NP",
+      "height" : 8040,
+      "width" : 11104,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f69",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f69"
+          },
+          "height" : 8040,
+          "width" : 11104,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f69/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f69.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f70",
+      "label" : "NP",
+      "height" : 8034,
+      "width" : 11072,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f70",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f70"
+          },
+          "height" : 8034,
+          "width" : 11072,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f70/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f70.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f71",
+      "label" : "NP",
+      "height" : 8008,
+      "width" : 11102,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f71",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f71"
+          },
+          "height" : 8008,
+          "width" : 11102,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f71/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f71.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f72",
+      "label" : "NP",
+      "height" : 8050,
+      "width" : 11082,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f72",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f72"
+          },
+          "height" : 8050,
+          "width" : 11082,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f72/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f72.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f73",
+      "label" : "NP",
+      "height" : 7982,
+      "width" : 11068,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f73",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f73"
+          },
+          "height" : 7982,
+          "width" : 11068,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f73/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f73.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    }, {
+      "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f74",
+      "label" : "NP",
+      "height" : 8036,
+      "width" : 11088,
+      "images" : [ {
+        "motivation" : "sc:painting",
+        "on" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f74",
+        "resource" : {
+          "format" : "image/jpeg",
+          "service" : {
+            "profile" : "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "@context" : "http://iiif.io/api/image/1/context.json",
+            "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f74"
+          },
+          "height" : 8036,
+          "width" : 11088,
+          "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f74/full/full/0/native.jpg",
+          "@type" : "dctypes:Image"
+        },
+        "@type" : "oa:Annotation"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g/f74.thumbnail"
+      },
+      "@type" : "sc:Canvas"
+    } ],
+    "label" : "Current Page Order",
+    "@type" : "sc:Sequence",
+    "@id" : "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/sequence/default"
+  } ],
+  "thumbnail" : {
+    "@id" : "https://gallica.bnf.fr/ark:/12148/btv1b53243704g.thumbnail"
+  },
+  "@type" : "sc:Manifest",
+  "@context" : "http://iiif.io/api/presentation/2/context.json"
+}

--- a/packages/iiif-parser/test/output/image.1.gallica.bnf.12148.btv1b53243704g.f1.parsed.json
+++ b/packages/iiif-parser/test/output/image.1.gallica.bnf.12148.btv1b53243704g.f1.parsed.json
@@ -1,0 +1,65 @@
+{
+  "embedded": false,
+  "type": "image",
+  "supportsAnyRegionAndSize": true,
+  "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f1",
+  "majorVersion": 1,
+  "width": 7900,
+  "height": 11060,
+  "tileZoomLevels": [
+    {
+      "scaleFactor": 1,
+      "width": 256,
+      "height": 256,
+      "originalWidth": 256,
+      "originalHeight": 256,
+      "columns": 31,
+      "rows": 44
+    },
+    {
+      "scaleFactor": 2,
+      "width": 256,
+      "height": 256,
+      "originalWidth": 512,
+      "originalHeight": 512,
+      "columns": 16,
+      "rows": 22
+    },
+    {
+      "scaleFactor": 4,
+      "width": 256,
+      "height": 256,
+      "originalWidth": 1024,
+      "originalHeight": 1024,
+      "columns": 8,
+      "rows": 11
+    },
+    {
+      "scaleFactor": 8,
+      "width": 256,
+      "height": 256,
+      "originalWidth": 2048,
+      "originalHeight": 2048,
+      "columns": 4,
+      "rows": 6
+    },
+    {
+      "scaleFactor": 16,
+      "width": 256,
+      "height": 256,
+      "originalWidth": 4096,
+      "originalHeight": 4096,
+      "columns": 2,
+      "rows": 3
+    },
+    {
+      "scaleFactor": 32,
+      "width": 256,
+      "height": 256,
+      "originalWidth": 8192,
+      "originalHeight": 8192,
+      "columns": 1,
+      "rows": 2
+    }
+  ]
+}

--- a/packages/iiif-parser/test/output/manifest.2.gallica.bnf.12148.btv1b53243704g.f1.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.gallica.bnf.12148.btv1b53243704g.f1.parsed.json
@@ -1,0 +1,1648 @@
+{
+  "embedded": false,
+  "type": "manifest",
+  "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/manifest.json",
+  "majorVersion": 2,
+  "label": {
+    "none": [
+      "BnF, département Cartes et plans, GE DD-2998"
+    ]
+  },
+  "canvases": [
+    {
+      "type": "canvas",
+      "width": 7900,
+      "height": 11060,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f1",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f1",
+        "majorVersion": 1,
+        "width": 7900,
+        "height": 11060
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 5182,
+      "height": 6834,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f2",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f2",
+        "majorVersion": 1,
+        "width": 5182,
+        "height": 6834
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 10490,
+      "height": 8046,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f3",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f3",
+        "majorVersion": 1,
+        "width": 10490,
+        "height": 8046
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11088,
+      "height": 7974,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f4",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f4",
+        "majorVersion": 1,
+        "width": 11088,
+        "height": 7974
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11228,
+      "height": 8006,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f5",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f5",
+        "majorVersion": 1,
+        "width": 11228,
+        "height": 8006
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11148,
+      "height": 8020,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f6",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f6",
+        "majorVersion": 1,
+        "width": 11148,
+        "height": 8020
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11138,
+      "height": 8002,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f7",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f7",
+        "majorVersion": 1,
+        "width": 11138,
+        "height": 8002
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11180,
+      "height": 8016,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f8",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f8",
+        "majorVersion": 1,
+        "width": 11180,
+        "height": 8016
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11092,
+      "height": 7958,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f9",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f9",
+        "majorVersion": 1,
+        "width": 11092,
+        "height": 7958
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11060,
+      "height": 7978,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f10",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f10",
+        "majorVersion": 1,
+        "width": 11060,
+        "height": 7978
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 10782,
+      "height": 8066,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f11",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f11",
+        "majorVersion": 1,
+        "width": 10782,
+        "height": 8066
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11132,
+      "height": 8006,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f12",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f12",
+        "majorVersion": 1,
+        "width": 11132,
+        "height": 8006
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 10998,
+      "height": 7984,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f13",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f13",
+        "majorVersion": 1,
+        "width": 10998,
+        "height": 7984
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11184,
+      "height": 8222,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f14",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f14",
+        "majorVersion": 1,
+        "width": 11184,
+        "height": 8222
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11024,
+      "height": 7966,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f15",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f15",
+        "majorVersion": 1,
+        "width": 11024,
+        "height": 7966
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11142,
+      "height": 8038,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f16",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f16",
+        "majorVersion": 1,
+        "width": 11142,
+        "height": 8038
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11118,
+      "height": 7988,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f17",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f17",
+        "majorVersion": 1,
+        "width": 11118,
+        "height": 7988
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11242,
+      "height": 7970,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f18",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f18",
+        "majorVersion": 1,
+        "width": 11242,
+        "height": 7970
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 10918,
+      "height": 8118,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f19",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f19",
+        "majorVersion": 1,
+        "width": 10918,
+        "height": 8118
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11102,
+      "height": 7944,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f20",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f20",
+        "majorVersion": 1,
+        "width": 11102,
+        "height": 7944
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11120,
+      "height": 7950,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f21",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f21",
+        "majorVersion": 1,
+        "width": 11120,
+        "height": 7950
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11166,
+      "height": 7952,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f22",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f22",
+        "majorVersion": 1,
+        "width": 11166,
+        "height": 7952
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11290,
+      "height": 7970,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f23",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f23",
+        "majorVersion": 1,
+        "width": 11290,
+        "height": 7970
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11130,
+      "height": 7958,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f24",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f24",
+        "majorVersion": 1,
+        "width": 11130,
+        "height": 7958
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11122,
+      "height": 7972,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f25",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f25",
+        "majorVersion": 1,
+        "width": 11122,
+        "height": 7972
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11144,
+      "height": 7974,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f26",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f26",
+        "majorVersion": 1,
+        "width": 11144,
+        "height": 7974
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 10764,
+      "height": 8050,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f27",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f27",
+        "majorVersion": 1,
+        "width": 10764,
+        "height": 8050
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11164,
+      "height": 7990,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f28",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f28",
+        "majorVersion": 1,
+        "width": 11164,
+        "height": 7990
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11114,
+      "height": 8050,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f29",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f29",
+        "majorVersion": 1,
+        "width": 11114,
+        "height": 8050
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11168,
+      "height": 8000,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f30",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f30",
+        "majorVersion": 1,
+        "width": 11168,
+        "height": 8000
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11124,
+      "height": 8004,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f31",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f31",
+        "majorVersion": 1,
+        "width": 11124,
+        "height": 8004
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11054,
+      "height": 7994,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f32",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f32",
+        "majorVersion": 1,
+        "width": 11054,
+        "height": 7994
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11156,
+      "height": 8018,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f33",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f33",
+        "majorVersion": 1,
+        "width": 11156,
+        "height": 8018
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11114,
+      "height": 8002,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f34",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f34",
+        "majorVersion": 1,
+        "width": 11114,
+        "height": 8002
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11062,
+      "height": 7956,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f35",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f35",
+        "majorVersion": 1,
+        "width": 11062,
+        "height": 7956
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11202,
+      "height": 8040,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f36",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f36",
+        "majorVersion": 1,
+        "width": 11202,
+        "height": 8040
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11186,
+      "height": 8026,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f37",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f37",
+        "majorVersion": 1,
+        "width": 11186,
+        "height": 8026
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11076,
+      "height": 8010,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f38",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f38",
+        "majorVersion": 1,
+        "width": 11076,
+        "height": 8010
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11136,
+      "height": 8010,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f39",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f39",
+        "majorVersion": 1,
+        "width": 11136,
+        "height": 8010
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11150,
+      "height": 8000,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f40",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f40",
+        "majorVersion": 1,
+        "width": 11150,
+        "height": 8000
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11180,
+      "height": 8012,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f41",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f41",
+        "majorVersion": 1,
+        "width": 11180,
+        "height": 8012
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11118,
+      "height": 8014,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f42",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f42",
+        "majorVersion": 1,
+        "width": 11118,
+        "height": 8014
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11016,
+      "height": 7954,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f43",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f43",
+        "majorVersion": 1,
+        "width": 11016,
+        "height": 7954
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11122,
+      "height": 8028,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f44",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f44",
+        "majorVersion": 1,
+        "width": 11122,
+        "height": 8028
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11110,
+      "height": 7992,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f45",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f45",
+        "majorVersion": 1,
+        "width": 11110,
+        "height": 7992
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11134,
+      "height": 8014,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f46",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f46",
+        "majorVersion": 1,
+        "width": 11134,
+        "height": 8014
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11078,
+      "height": 7968,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f47",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f47",
+        "majorVersion": 1,
+        "width": 11078,
+        "height": 7968
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11156,
+      "height": 7968,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f48",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f48",
+        "majorVersion": 1,
+        "width": 11156,
+        "height": 7968
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11078,
+      "height": 7970,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f49",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f49",
+        "majorVersion": 1,
+        "width": 11078,
+        "height": 7970
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11116,
+      "height": 7964,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f50",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f50",
+        "majorVersion": 1,
+        "width": 11116,
+        "height": 7964
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11082,
+      "height": 7996,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f51",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f51",
+        "majorVersion": 1,
+        "width": 11082,
+        "height": 7996
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11138,
+      "height": 7960,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f52",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f52",
+        "majorVersion": 1,
+        "width": 11138,
+        "height": 7960
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11172,
+      "height": 7980,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f53",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f53",
+        "majorVersion": 1,
+        "width": 11172,
+        "height": 7980
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11104,
+      "height": 7994,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f54",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f54",
+        "majorVersion": 1,
+        "width": 11104,
+        "height": 7994
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11162,
+      "height": 8000,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f55",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f55",
+        "majorVersion": 1,
+        "width": 11162,
+        "height": 8000
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11194,
+      "height": 8028,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f56",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f56",
+        "majorVersion": 1,
+        "width": 11194,
+        "height": 8028
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11212,
+      "height": 7982,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f57",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f57",
+        "majorVersion": 1,
+        "width": 11212,
+        "height": 7982
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11076,
+      "height": 7982,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f58",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f58",
+        "majorVersion": 1,
+        "width": 11076,
+        "height": 7982
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11004,
+      "height": 7994,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f59",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f59",
+        "majorVersion": 1,
+        "width": 11004,
+        "height": 7994
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11132,
+      "height": 7988,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f60",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f60",
+        "majorVersion": 1,
+        "width": 11132,
+        "height": 7988
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11142,
+      "height": 7960,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f61",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f61",
+        "majorVersion": 1,
+        "width": 11142,
+        "height": 7960
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11148,
+      "height": 7998,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f62",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f62",
+        "majorVersion": 1,
+        "width": 11148,
+        "height": 7998
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11156,
+      "height": 8000,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f63",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f63",
+        "majorVersion": 1,
+        "width": 11156,
+        "height": 8000
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11034,
+      "height": 7968,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f64",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f64",
+        "majorVersion": 1,
+        "width": 11034,
+        "height": 7968
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11170,
+      "height": 8030,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f65",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f65",
+        "majorVersion": 1,
+        "width": 11170,
+        "height": 8030
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11088,
+      "height": 8140,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f66",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f66",
+        "majorVersion": 1,
+        "width": 11088,
+        "height": 8140
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 10950,
+      "height": 7990,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f67",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f67",
+        "majorVersion": 1,
+        "width": 10950,
+        "height": 7990
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11206,
+      "height": 7970,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f68",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f68",
+        "majorVersion": 1,
+        "width": 11206,
+        "height": 7970
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11104,
+      "height": 8040,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f69",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f69",
+        "majorVersion": 1,
+        "width": 11104,
+        "height": 8040
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11072,
+      "height": 8034,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f70",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f70",
+        "majorVersion": 1,
+        "width": 11072,
+        "height": 8034
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11102,
+      "height": 8008,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f71",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f71",
+        "majorVersion": 1,
+        "width": 11102,
+        "height": 8008
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11082,
+      "height": 8050,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f72",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f72",
+        "majorVersion": 1,
+        "width": 11082,
+        "height": 8050
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11068,
+      "height": 7982,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f73",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f73",
+        "majorVersion": 1,
+        "width": 11068,
+        "height": 7982
+      }
+    },
+    {
+      "type": "canvas",
+      "width": 11088,
+      "height": 8036,
+      "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/canvas/f74",
+      "label": {
+        "none": [
+          "NP"
+        ]
+      },
+      "image": {
+        "embedded": true,
+        "type": "image",
+        "supportsAnyRegionAndSize": true,
+        "uri": "https://gallica.bnf.fr/iiif/ark:/12148/btv1b53243704g/f74",
+        "majorVersion": 1,
+        "width": 11088,
+        "height": 8036
+      }
+    }
+  ],
+  "description": {
+    "none": [
+      "Atlas du plan général de la ville de Paris / Levé géométriquement par le Citoyen Verniquet... ; dessiné et gravé par les Citoyens Bartholomé et Mathieu"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "none": [
+          "Repository"
+        ]
+      },
+      "value": {
+        "none": [
+          "Bibliothèque nationale de France"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Digitised by"
+        ]
+      },
+      "value": {
+        "none": [
+          "Bibliothèque nationale de France"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Source Images"
+        ]
+      },
+      "value": {
+        "none": [
+          "https://gallica.bnf.fr/ark:/12148/btv1b53243704g"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Metadata Source"
+        ]
+      },
+      "value": {
+        "none": [
+          "http://oai.bnf.fr/oai2/OAIHandler?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:bnf.fr:gallica/ark:/12148/btv1b53243704g"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Shelfmark"
+        ]
+      },
+      "value": {
+        "none": [
+          "Bibliothèque nationale de France, département Cartes et plans, GE DD-2998"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Title"
+        ]
+      },
+      "value": {
+        "none": [
+          "Atlas du plan général de la ville de Paris / Levé géométriquement par le Citoyen Verniquet... ; dessiné et gravé par les Citoyens Bartholomé et Mathieu"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Date"
+        ]
+      },
+      "value": {
+        "none": [
+          "179."
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Language"
+        ]
+      },
+      "value": {
+        "none": [
+          "français"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Format"
+        ]
+      },
+      "value": {
+        "none": [
+          "71 flles : en noir ; 68 x 46 cm",
+          "image/jpeg",
+          "Nombre total de vues :  74"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Creator"
+        ]
+      },
+      "value": {
+        "none": [
+          "Verniquet, Edme (1727-1804). Auteur du texte",
+          "Bartholomé, Paul-Thomas (17..-18..). Auteur du texte",
+          "Mathieu, A. J. (17..-18.. ; dessinateur). Auteur du texte"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Relation"
+        ]
+      },
+      "value": {
+        "none": [
+          "Notice du catalogue : http://catalogue.bnf.fr/ark:/12148/cb40708746v"
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": [
+          "Type"
+        ]
+      },
+      "value": {
+        "none": [
+          "Carte"
+        ]
+      }
+    }
+  ]
+}

--- a/packages/iiif-parser/test/test-thumbnails.js
+++ b/packages/iiif-parser/test/test-thumbnails.js
@@ -50,7 +50,7 @@ const tests = [
     // Expected size: 105 × 124
   },
   {
-    filename: 'image.2.si-NASM-NASM2013-00143.json',
+    filename: 'image.2.si-nasm-nasm2013-00143.json',
     thumbnailSize: { width: 400, height: 400 },
     expectedUrl:
       'https://ids.si.edu/ids/iiif/NASM-NASM2013-00143/full/400,/0/default.jpg'


### PR DESCRIPTION
Tested with gallica iiif. I will try to deploy a working version for proof (if I can figure out how to deploy) ;)