### PR TITLE
Improve scale computations for heavily inclided maps

### DIFF
--- a/packages/stdlib/src/bbox.ts
+++ b/packages/stdlib/src/bbox.ts
@@ -121,9 +121,9 @@ export function bboxToSize(bbox: Bbox): Size {
 // Scales
 
 export function sizesToScale(size0: Size, size1: Size): number {
-  const scaleX = size0[0] / size1[0]
-  const scaleY = size0[1] / size1[1]
-  return Math.min(scaleX, scaleY)
+  const scaleMin = Math.min(...size0) / Math.min(...size1)
+  const scaleMax = Math.max(...size0) / Math.max(...size1)
+  return Math.min(scaleMin, scaleMax)
 }
 
 export function bboxesToScale(bbox0: Bbox, bbox1: Bbox): number {


### PR DESCRIPTION
This improves computing scales from bboxes for heavily inclined maps (where the orientation of the map in resource and in viewport is very different).

For such maps, the resource bbox and the (canvas, and so) viewport bbox may have a different orientation. When computing scales from these bboxes one can not assume that the X coordinate of resource should be compared to the X coordinate of viewport.

Examples are:

Map of the coastline of India - very wide map that's turned and displayed horizontally in the viewport
https://annotations.allmaps.org/images/6b99cd166aeed9f5

Map of De Bijenkorf - map is rotated 90° between resource coordinates and the viewport
https://annotations.allmaps.org/images/3d3cb6e11cb24f96
