### PR TITLE
@allmaps/leaflet - Update README.md

### DIFF
--- a/packages/leaflet/README.md
+++ b/packages/leaflet/README.md
@@ -114,7 +114,7 @@ You can listen to them in the typical Leaflet way. Here's an example:
 map.on(
   'warpedmapadded',
   (event) => {
-    console.log(event.mapId, warpedMapSource.getBounds())
+    console.log(event.mapId, warpedMapLayer.getBounds())
   },
   map
 )


### PR DESCRIPTION
Just a simple documentation fix here. 

In the @allmaps/leaflet plugin's README file, inside the event listener example, it should be `warpedMapLayer` not `warpedMapSource`. I believe `warpedMapSource` is only available in the @allmaps/openlayers plugin.