### PR TITLE
Faster rendering, TileServer cleanups and other small changes.

### DIFF
--- a/apps/tileserver/src/index.ts
+++ b/apps/tileserver/src/index.ts
@@ -67,9 +67,9 @@ router.get('/tiles.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const templateUrl = `${env.TILE_SERVER_BASE_URL}/{z}/{x}/{y}.png${url.search}`
+  const urlTemplate = `${env.TILE_SERVER_BASE_URL}/{z}/{x}/{y}.png${url.search}`
 
-  return json(generateTileJson(templateUrl, maps, options))
+  return json(generateTileJson(maps, options, urlTemplate))
 })
 
 router.get('/maps/:mapId/tiles.json', async (req, env) => {
@@ -80,7 +80,7 @@ router.get('/maps/:mapId/tiles.json', async (req, env) => {
   const url = new URL(req.url)
   const urlTemplate = `${env.TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}.png${url.search}`
 
-  return json(generateTileJson(urlTemplate, maps, options))
+  return json(generateTileJson(maps, options, urlTemplate))
 })
 
 router.get('/images/:imageId/tiles.json', async (req, env) => {
@@ -91,7 +91,7 @@ router.get('/images/:imageId/tiles.json', async (req, env) => {
   const url = new URL(req.url)
   const urlTemplate = `${env.TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}.png${url.search}`
 
-  return json(generateTileJson(urlTemplate, maps, options))
+  return json(generateTileJson(maps, options, urlTemplate))
 })
 
 router.get('/manifests/:manifestId/tiles.json', async (req, env) => {
@@ -102,7 +102,7 @@ router.get('/manifests/:manifestId/tiles.json', async (req, env) => {
   const url = new URL(req.url)
   const urlTemplate = `${env.TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}.png${url.search}`
 
-  return json(generateTileJson(urlTemplate, maps, options))
+  return json(generateTileJson(maps, options, urlTemplate))
 })
 
 // -------------------------------------------------------------------------------------------
@@ -115,7 +115,7 @@ router.get('/:z/:x/:y.png', async (req) => {
   const { x, y, z } = xyzFromParams(req.params)
   const options = optionsFromQuery(req)
 
-  return createWarpedTileResponse(maps, { x, y, z }, options)
+  return createWarpedTileResponse(maps, options, { x, y, z })
 })
 
 router.get('/maps/:mapId/:z/:x/:y.png', async (req, env) => {
@@ -123,7 +123,7 @@ router.get('/maps/:mapId/:z/:x/:y.png', async (req, env) => {
   const { x, y, z } = xyzFromParams(req.params)
   const options = optionsFromQuery(req)
 
-  return createWarpedTileResponse(maps, { x, y, z }, options)
+  return createWarpedTileResponse(maps, options, { x, y, z })
 })
 
 router.get('/images/:imageId/:z/:x/:y.png', async (req, env) => {
@@ -131,7 +131,7 @@ router.get('/images/:imageId/:z/:x/:y.png', async (req, env) => {
   const { x, y, z } = xyzFromParams(req.params)
   const options = optionsFromQuery(req)
 
-  return createWarpedTileResponse(maps, { x, y, z }, options)
+  return createWarpedTileResponse(maps, options, { x, y, z })
 })
 
 router.get('/manifests/:manifestId/:z/:x/:y.png', async (req, env) => {
@@ -139,7 +139,7 @@ router.get('/manifests/:manifestId/:z/:x/:y.png', async (req, env) => {
   const { x, y, z } = xyzFromParams(req.params)
   const options = optionsFromQuery(req)
 
-  return createWarpedTileResponse(maps, { x, y, z }, options)
+  return createWarpedTileResponse(maps, options, { x, y, z })
 })
 
 // -------------------------------------------------------------------------------------------

--- a/apps/tileserver/src/tilejson.ts
+++ b/apps/tileserver/src/tilejson.ts
@@ -4,17 +4,17 @@ import bbox from '@turf/bbox'
 
 import type { Tilejson, TilejsonOptions } from './types.js'
 
-import type { Map } from '@allmaps/annotation'
+import type { Map as GeoreferencedMap } from '@allmaps/annotation'
 
 // See https://github.com/mapbox/tilejson-spec/blob/master/3.0.0/example/osm.json
 export function generateTileJson(
-  urlTemplate: string,
-  maps: Map[],
-  options: TilejsonOptions
+  georeferencedMaps: GeoreferencedMap[],
+  options: TilejsonOptions,
+  urlTemplate: string
 ): Tilejson {
   const geoMasks = []
 
-  for (const map of maps) {
+  for (const map of georeferencedMaps) {
     const transformer = new GcpTransformer(
       map.gcps,
       options['transformation.type'] || map.transformation?.type,

--- a/apps/tileserver/src/warped-tile-response.ts
+++ b/apps/tileserver/src/warped-tile-response.ts
@@ -13,22 +13,10 @@ import type { XYZTile, TilejsonOptions } from './types.js'
 
 const TILE_SIZE = 256
 
-function getImageData(input: Uint8ClampedArray) {
-  return decodeJpeg(input, { useTArray: true })
-}
-
-function getImageDataValue(decodedJpeg: UintArrRet, index: number) {
-  return decodedJpeg.data[index]
-}
-
-function getImageDataSize(decodedJpeg: UintArrRet): Size {
-  return [decodedJpeg.width, decodedJpeg.height]
-}
-
 export async function createWarpedTileResponse(
   georeferencedMaps: GeoreferencedMap[],
-  { x, y, z }: XYZTile,
-  options: TilejsonOptions
+  options: TilejsonOptions,
+  { x, y, z }: XYZTile
 ): Promise<Response> {
   if (!(x >= 0 && y >= 0 && z >= 0)) {
     throw new Error('x, y and z must be positive integers')
@@ -68,4 +56,16 @@ export async function createWarpedTileResponse(
 
   const pngBuffer = encodePng([warpedTile.buffer], TILE_SIZE, TILE_SIZE, 0)
   return png(pngBuffer)
+}
+
+function getImageData(input: Uint8ClampedArray) {
+  return decodeJpeg(input, { useTArray: true })
+}
+
+function getImageDataValue(decodedJpeg: UintArrRet, index: number) {
+  return decodedJpeg.data[index]
+}
+
+function getImageDataSize(decodedJpeg: UintArrRet): Size {
+  return [decodedJpeg.width, decodedJpeg.height]
 }

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -66,9 +66,9 @@ For a complete example, see the source code of the Allmaps plugins for [Leaflet]
     *   [Parameters](#parameters)
 *   [computeProjectedGeoRectangle](#computeprojectedgeorectangle)
     *   [Parameters](#parameters-1)
-*   [newViewportFromWarpedMapList](#newviewportfromwarpedmaplist)
+*   [fromWarpedMapList](#fromwarpedmaplist)
     *   [Parameters](#parameters-2)
-*   [newViewportFromProjectedGeoBbox](#newviewportfromprojectedgeobbox)
+*   [fromProjectedGeoBbox](#fromprojectedgeobbox)
     *   [Parameters](#parameters-3)
 *   [constructor](#constructor-1)
     *   [Parameters](#parameters-4)
@@ -247,8 +247,8 @@ Creates an instance of Viewport.
 *   `e` &#x20;
 *   `t` &#x20;
 *   `o` &#x20;
-*   `s` &#x20;
-*   `i`   (optional, default `1`)
+*   `r` &#x20;
+*   `s`   (optional, default `1`)
 *   `viewportSize` **Size** Size of the viewport in viewport pixels, as \[width, height].
 *   `projectedGeoCenter` **Point** Center point of the viewport, in projected coordinates.
 *   `projectedGeoPerViewportScale` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Resolution of the viewport, in projection coordinates per viewport pixel.
@@ -264,9 +264,9 @@ Returns a rotated rectangle in projected geo coordinates
 *   `e` &#x20;
 *   `t` &#x20;
 *   `o` &#x20;
-*   `s` &#x20;
+*   `r` &#x20;
 
-### newViewportFromWarpedMapList
+### fromWarpedMapList
 
 Alternative Viewport constructor, specifying projectedGeo using a WarpedMapList
 
@@ -275,7 +275,8 @@ Alternative Viewport constructor, specifying projectedGeo using a WarpedMapList
 *   `e` &#x20;
 *   `t` &#x20;
 *   `o` &#x20;
-*   `s`   (optional, default `"contain"`)
+*   `r`   (optional, default `"contain"`)
+*   `s`   (optional, default `1`)
 *   `viewportSize` **Size** Size of the viewport in viewport pixels, as \[width, height].
 *   `warpedMapList` **WarpedMapList\<W>** A WarpedMapList.
 *   `devicePixelRatio` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)??** The devicePixelRatio of the viewport.
@@ -283,7 +284,7 @@ Alternative Viewport constructor, specifying projectedGeo using a WarpedMapList
 
 Returns **Viewport** A new Viewport object
 
-### newViewportFromProjectedGeoBbox
+### fromProjectedGeoBbox
 
 Alternative Viewport constructor, specifying projectedGeo using a projectedGeoBbox
 
@@ -292,7 +293,7 @@ Alternative Viewport constructor, specifying projectedGeo using a projectedGeoBb
 *   `e` &#x20;
 *   `t` &#x20;
 *   `o` &#x20;
-*   `s`   (optional, default `"contain"`)
+*   `r`   (optional, default `"contain"`)
 *   `viewportSize` **Size** Size of the viewport in viewport pixels, as \[width, height].
 *   `projectedGeoBbox` **WarpedMapList\<W>** A projectedGeoBbox.
 *   `devicePixelRatio` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)??** The devicePixelRatio of the viewport.

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -558,12 +558,12 @@ Creates an instance of WebGL2WarpedMap.
 *   `i` &#x20;
 *   `r` &#x20;
 *   `s` &#x20;
-*   `n` &#x20;
+*   `a` &#x20;
 *   `mapId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ID of the map
 *   `georeferencedMap` **GeoreferencedMap** Georeferende map this warped map is build on
-*   `imageInfoCache` **Cache??** Cache of the image info of this image
 *   `gl` **WebGL2RenderingContext** the WebGL2 rendering context
 *   `program` **[WebGLProgram](https://developer.mozilla.org/docs/Web/API/WebGLProgram)** the WebGL2 program
+*   `options` **Partial\<WarpedMapOptions>** WarpedMapOptions
 
 ### updateVertexBuffers
 

--- a/packages/render/src/maps/WebGL2WarpedMap.ts
+++ b/packages/render/src/maps/WebGL2WarpedMap.ts
@@ -74,9 +74,9 @@ export default class WebGL2WarpedMap extends TriangulatedWarpedMap {
    * @constructor
    * @param {string} mapId - ID of the map
    * @param {GeoreferencedMap} georeferencedMap - Georeferende map this warped map is build on
-   * @param {?Cache} [imageInfoCache] - Cache of the image info of this image
    * @param {WebGL2RenderingContext} gl - the WebGL2 rendering context
    * @param {WebGLProgram} program - the WebGL2 program
+   * @param {Partial<WarpedMapOptions>} options - WarpedMapOptions
    */
   constructor(
     mapId: string,

--- a/packages/render/src/maps/WebGL2WarpedMap.ts
+++ b/packages/render/src/maps/WebGL2WarpedMap.ts
@@ -193,24 +193,26 @@ export default class WebGL2WarpedMap extends TriangulatedWarpedMap {
 
     // Previous and New Distortion
 
-    const previousTrianglePointsDistortion =
-      this.previousTrianglePointsDistortion
-    createBuffer(
-      this.gl,
-      this.program,
-      new Float32Array(previousTrianglePointsDistortion),
-      1,
-      'a_previousTrianglePointDistortion'
-    )
+    if (this.distortionMeasure) {
+      const previousTrianglePointsDistortion =
+        this.previousTrianglePointsDistortion
+      createBuffer(
+        this.gl,
+        this.program,
+        new Float32Array(previousTrianglePointsDistortion),
+        1,
+        'a_previousTrianglePointDistortion'
+      )
 
-    const trianglePointsDistortion = this.trianglePointsDistortion
-    createBuffer(
-      this.gl,
-      this.program,
-      new Float32Array(trianglePointsDistortion),
-      1,
-      'a_trianglePointDistortion'
-    )
+      const trianglePointsDistortion = this.trianglePointsDistortion
+      createBuffer(
+        this.gl,
+        this.program,
+        new Float32Array(trianglePointsDistortion),
+        1,
+        'a_trianglePointDistortion'
+      )
+    }
 
     // Triangle index
 

--- a/packages/render/src/renderers/WebGL2Renderer.ts
+++ b/packages/render/src/renderers/WebGL2Renderer.ts
@@ -720,6 +720,12 @@ export default class WebGL2Renderer
 
       // Distortion
 
+      const distortionLocation = gl.getUniformLocation(
+        this.program,
+        'u_distortion'
+      )
+      gl.uniform1f(distortionLocation, warpedMap.distortionMeasure ? 1 : 0)
+
       if (warpedMap.distortionMeasure) {
         const distortionOptionsDistortionMeasureLocation =
           gl.getUniformLocation(

--- a/packages/render/src/shaders/fragment-shader.glsl
+++ b/packages/render/src/shaders/fragment-shader.glsl
@@ -19,6 +19,7 @@ uniform bool u_grid;
 uniform float u_opacity;
 uniform float u_saturation;
 
+uniform bool u_distortion;
 uniform int u_distortionOptionsdistortionMeasure;
 
 uniform int u_bestScaleFactor;
@@ -156,31 +157,34 @@ void main() {
     color = vec4(color.rgb * u_opacity, color.a * u_opacity);
 
     // Distortion
-    // color = colorWhite; // TODO: Add option to not display image
-    // color = colorTransparant; // TODO: Add option to not display image
 
-    float trianglePointDistortion = v_trianglePointDistortion;
-    trianglePointDistortion = floor(trianglePointDistortion * 10.0f) / 10.0f; // TODO: Add component to toggle stepwise vs continuous
+    if(u_distortion) {
+      // color = colorWhite; // TODO: Add option to not display image
+      // color = colorTransparant; // TODO: Add option to not display image
 
-    switch (u_distortionOptionsdistortionMeasure) {
-      case 0:
-        if (trianglePointDistortion > 0.0f) {
-          color = spectral_mix(color, colorRed500, trianglePointDistortion);
-        } else {
-          color = spectral_mix(color, colorBlue500, abs(trianglePointDistortion));
-        }
-        break;
-      case 1:
-        color = spectral_mix(color, colorGreen500, trianglePointDistortion);
-        break;
-      case 2:
-        color = spectral_mix(color, colorYellow500, trianglePointDistortion);
-        break;
-      case 3:
-        color = trianglePointDistortion == -1.0f ? colorRed300 : color;
-        break;
-      default:
-        color = color;
+      float trianglePointDistortion = v_trianglePointDistortion;
+      trianglePointDistortion = floor(trianglePointDistortion * 10.0f) / 10.0f; // TODO: Add component to toggle stepwise vs continuous
+
+      switch (u_distortionOptionsdistortionMeasure) {
+        case 0:
+          if (trianglePointDistortion > 0.0f) {
+            color = spectral_mix(color, colorRed500, trianglePointDistortion);
+          } else {
+            color = spectral_mix(color, colorBlue500, abs(trianglePointDistortion));
+          }
+          break;
+        case 1:
+          color = spectral_mix(color, colorGreen500, trianglePointDistortion);
+          break;
+        case 2:
+          color = spectral_mix(color, colorYellow500, trianglePointDistortion);
+          break;
+        case 3:
+          color = trianglePointDistortion == -1.0f ? colorRed300 : color;
+          break;
+        default:
+          color = color;
+      }
     }
 
     // Triangles

--- a/packages/render/src/shaders/fragment-shader.glsl
+++ b/packages/render/src/shaders/fragment-shader.glsl
@@ -64,8 +64,8 @@ void main() {
   vec4 colorGrey500 = vec4(0.4196f, 0.4470f, 0.5019f, 1.0f);
 
   // The treated triangle point
-  int resourceTrianglePointX = int(round(v_resourceTrianglePoint.x));
-  int resourceTrianglePointY = int(round(v_resourceTrianglePoint.y));
+  float resourceTrianglePointX = v_resourceTrianglePoint.x;
+  float resourceTrianglePointY = v_resourceTrianglePoint.y;
 
   // Reading information on packed tiles from textures
   int packedTilesCount = textureSize(u_packedTilesPositionsTexture, 0).y;
@@ -93,11 +93,11 @@ void main() {
     float packedTilePositionX = float(packedTilePosition.r);
     float packedTilePositionY = float(packedTilePosition.g);
 
-    int packedTileResourcePositionX = packedTileResourcePositionAndDimension.r;
-    int packedTileResourcePositionY = packedTileResourcePositionAndDimension.g;
+    float packedTileResourcePositionX = float(packedTileResourcePositionAndDimension.r);
+    float packedTileResourcePositionY = float(packedTileResourcePositionAndDimension.g);
 
-    int packedTileDimensionWidth = packedTileResourcePositionAndDimension.b;
-    int packedTileDimensionHeight = packedTileResourcePositionAndDimension.a;
+    float packedTileDimensionWidth = float(packedTileResourcePositionAndDimension.b);
+    float packedTileDimensionHeight = float(packedTileResourcePositionAndDimension.a);
 
     // If the treated triangle point is inside the tile, consider to use the tile:
     // if the scale factor is closer to the best scale factor for this map then currently known one
@@ -116,14 +116,14 @@ void main() {
         smallestScaleFactorDiff = scaleFactorDiff;
         bestScaleFactor = packedTileScaleFactor;
 
-        float packedTilePointX = float(resourceTrianglePointX - packedTileResourcePositionX) / float(bestScaleFactor);
-        float packedTilePointY = float(resourceTrianglePointY - packedTileResourcePositionY) / float(bestScaleFactor);
+        float packedTilePointX = (resourceTrianglePointX - packedTileResourcePositionX) / float(bestScaleFactor);
+        float packedTilePointY = (resourceTrianglePointY - packedTileResourcePositionY) / float(bestScaleFactor);
 
         float packedTilesPointX = packedTilePositionX + packedTilePointX;
         float packedTilesPointY = packedTilePositionY + packedTilePointY;
 
-        float packedTilesTexturePointX = round(packedTilesPointX) / float(packedTilesTextureSize.x);
-        float packedTilesTexturePointY = round(packedTilesPointY) / float(packedTilesTextureSize.y);
+        float packedTilesTexturePointX = packedTilesPointX / float(packedTilesTextureSize.x);
+        float packedTilesTexturePointY = packedTilesPointY / float(packedTilesTextureSize.y);
 
         packedTilesTexturePoint = vec2(packedTilesTexturePointX, packedTilesTexturePointY);
       }

--- a/packages/render/src/shared/tiles.ts
+++ b/packages/render/src/shared/tiles.ts
@@ -268,11 +268,61 @@ export function tileCenter(tile: Tile): Point {
   return [(bbox[2] - bbox[0]) / 2 + bbox[0], (bbox[3] - bbox[1]) / 2 + bbox[1]]
 }
 
+/**
+ *
+ * @export
+ * @param {Tile} tile
+ * @returns {Point}
+ */
 export function tilePosition(tile: Tile): Point {
   const resourceTilePositionX = tile.column * tile.tileZoomLevel.originalWidth
   const resourceTilePositionY = tile.row * tile.tileZoomLevel.originalHeight
 
   return [resourceTilePositionX, resourceTilePositionY]
+}
+
+export function pointToTilePoint(
+  resourcePoint: Point,
+  tile: Tile,
+  clip = true
+): Point | undefined {
+  const resourceTilePosition = tilePosition(tile)
+  const tilePoint = [
+    (resourcePoint[0] - resourceTilePosition[0]) /
+      tile.tileZoomLevel.scaleFactor,
+    (resourcePoint[1] - resourceTilePosition[1]) /
+      tile.tileZoomLevel.scaleFactor
+  ] as Point
+
+  if (
+    !clip ||
+    pointInTile(resourcePoint, tile)
+    // && pointInImage(resourcePoint, tile)
+  ) {
+    return tilePoint
+  }
+}
+
+export function pointInTile(resourcePoint: Point, tile: Tile): boolean {
+  const resourceTilePosition = tilePosition(tile)
+
+  return (
+    resourcePoint[0] >= resourceTilePosition[0] &&
+    resourcePoint[0] <=
+      resourceTilePosition[0] + tile.tileZoomLevel.originalWidth &&
+    resourcePoint[1] >= resourceTilePosition[1] &&
+    resourcePoint[1] <=
+      resourceTilePosition[1] + tile.tileZoomLevel.originalHeight
+  )
+}
+
+export function pointInImage(resourcePoint: Point, tile: Tile): boolean {
+  return (
+    resourcePoint[0] > 0 &&
+    resourcePoint[0] <= tile.imageSize[0] &&
+    resourcePoint[1] > 0 &&
+    resourcePoint[1] <= tile.imageSize[1]
+  )
 }
 
 export function computeBboxTile(tile: Tile): Bbox {
@@ -293,34 +343,4 @@ export function computeBboxTile(tile: Tile): Bbox {
     resourceTileMaxX,
     resourceTileMaxY
   ]
-}
-
-// Currently unused
-export function resourcePointToTilePoint(
-  tile: Tile,
-  resourcePoint: Point,
-  clip = true
-): Point | undefined {
-  const resourceTilePosition = tilePosition(tile)
-
-  const tilePointX =
-    (resourcePoint[0] - resourceTilePosition[0]) /
-    tile.tileZoomLevel.scaleFactor
-  const tilePointY =
-    (resourcePoint[1] - resourceTilePosition[1]) /
-    tile.tileZoomLevel.scaleFactor
-
-  if (
-    !clip ||
-    (resourcePoint[0] >= resourceTilePosition[0] &&
-      resourcePoint[0] <=
-        resourceTilePosition[0] + tile.tileZoomLevel.originalWidth &&
-      resourcePoint[1] >= resourceTilePosition[1] &&
-      resourcePoint[1] <=
-        resourceTilePosition[1] + tile.tileZoomLevel.originalHeight &&
-      resourcePoint[0] <= tile.imageSize[0] &&
-      resourcePoint[1] <= tile.imageSize[1])
-  ) {
-    return [tilePointX, tilePointY]
-  }
 }

--- a/packages/stdlib/src/bbox.ts
+++ b/packages/stdlib/src/bbox.ts
@@ -105,6 +105,10 @@ export function bboxToLine(bbox: Bbox): Line {
   ]
 }
 
+export function bboxToPoint(bbox: Bbox): Point {
+  return [bbox[0], bbox[1]]
+}
+
 export function bboxToDiameter(bbox: Bbox): number {
   return distance(bboxToLine(bbox))
 }

--- a/packages/stdlib/src/geometry.ts
+++ b/packages/stdlib/src/geometry.ts
@@ -17,7 +17,8 @@ import type {
   GeojsonMultiPoint,
   GeojsonMultiLineString,
   GeojsonMultiPolygon,
-  GeojsonGeometry
+  GeojsonGeometry,
+  Size
 } from '@allmaps/types'
 
 // Assert
@@ -267,6 +268,32 @@ export function isEqualPointArrayArray(
 }
 
 // Compute
+
+export function pointToPixel(
+  point: Point,
+  translate: Point = [0, 0],
+  size?: Size
+): Point {
+  return point.map((coordinate, index) => {
+    let result = Math.floor(coordinate + translate[index])
+    if (size) {
+      result = Math.max(result, 0)
+      result = Math.min(result, size[index] - 1)
+    }
+    return result
+  }) as Point
+}
+
+export function pixelToIntArrayIndex(
+  pixel: Point,
+  size: Size,
+  channels: number,
+  flipY = false
+): number {
+  const column = pixel[0]
+  const row = flipY ? size[1] - 1 - pixel[1] : pixel[1]
+  return (row * size[0] + column) * channels
+}
 
 export function flipX(point: Point): Point {
   return [-point[0], point[1]]


### PR DESCRIPTION
- Cleanup render-to-int-array.ts
- Render Readme
- TileServer GeoreferencedMap
- Fix slow rendering: only pass distortion info to shader if distortionMeasure set
- WebGL2WarpedMap small JSDoc change
- Use floats where possible in fragment shader
