### PR TITLE
Fix makeFakeStraightAnnotation() requires offset

### DIFF
--- a/apps/editor/src/app.d.ts
+++ b/apps/editor/src/app.d.ts
@@ -1,13 +1,13 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
-	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
-	}
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface PageState {}
+    // interface Platform {}
+  }
 }
 
-export {};
+export {}

--- a/apps/editor/src/app.html
+++ b/apps/editor/src/app.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
 </html>

--- a/apps/editor/src/lib/annotation.ts
+++ b/apps/editor/src/lib/annotation.ts
@@ -5,9 +5,7 @@ export function makeFakeStraightAnnotation(
   width: number,
   height: number
 ) {
-  const offsetLng = 0.01
-  const offsetLat = 0
-
+  const scale = 10_000
   const georeferencedMap = [
     {
       '@context': 'https://schemas.allmaps.org/map/2/context.json',
@@ -27,15 +25,15 @@ export function makeFakeStraightAnnotation(
       gcps: [
         {
           resource: [0, 0],
-          geo: [offsetLng, offsetLat + height / 10_000]
+          geo: [0, height / scale]
         },
         {
           resource: [width, 0],
-          geo: [offsetLng + width / 10_000, offsetLat + height / 10_000]
+          geo: [width / scale, height / scale]
         },
         {
           resource: [width, height],
-          geo: [offsetLng + width / 10_000, offsetLat]
+          geo: [width / scale, 0]
         }
       ]
     }

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -87,7 +87,7 @@
     // draw.setMode('')
     draw.setMode('point')
 
-    draw.on('finish', (event) => {
+    draw.on('finish', () => {
       if (draw.getMode() === 'polygon') {
         draw.setMode('select')
       }

--- a/packages/stdlib/src/projection.ts
+++ b/packages/stdlib/src/projection.ts
@@ -6,11 +6,8 @@ import type { Point } from '@allmaps/types'
 export function lonLatToWebMecator([lon, lat]: Point): Point {
   const rMajor = 6378137.0
   const x = rMajor * degreesToRadians(lon)
-  const scale = x / lon
   const y =
-    (180.0 / Math.PI) *
-    Math.log(Math.tan(Math.PI / 4.0 + (lat * (Math.PI / 180.0)) / 2.0)) *
-    scale
+    rMajor * Math.log(Math.tan(Math.PI / 4.0 + (lat * (Math.PI / 180.0)) / 2.0))
 
   return [x, y]
 }


### PR DESCRIPTION
- Prettier
- Fix straight annotation at origin requiring offset: improve lonLatToWebMecator handling [0, 0] input
