### PR TITLE
Improve maplibre rendering

### DIFF
--- a/apps/cli/src/commands/script/geotiff.ts
+++ b/apps/cli/src/commands/script/geotiff.ts
@@ -170,8 +170,8 @@ export function geotiff() {
         })),
         geojsonMaskPolygon,
         transformationType,
-        projectedGcpTransformerOptions.internalProjection?.definition,
-        projectedGcpTransformerOptions.projection?.definition,
+        String(projectedGcpTransformerOptions.internalProjection?.definition),
+        String(projectedGcpTransformerOptions.projection?.definition),
         Number(options.jpgQuality),
         size
       )

--- a/apps/explore/src/routes/+page.svelte
+++ b/apps/explore/src/routes/+page.svelte
@@ -136,7 +136,6 @@
       center: [14.2437, 40.8384],
       zoom: 7,
       maxPitch: 0,
-      preserveDrawingBuffer: true,
       hash: true
     })
 

--- a/apps/homepage/src/components/Libraries.mdx
+++ b/apps/homepage/src/components/Libraries.mdx
@@ -12,8 +12,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
       center: [-73.9337, 40.8011],
       zoom: 11.5,
       // These options are required for the Allmaps plugin:
-      maxPitch: 0,
-      preserveDrawingBuffer: true
+      maxPitch: 0
     })
 
     const annotationUrl =

--- a/apps/homepage/src/components/WarpedMap.svelte
+++ b/apps/homepage/src/components/WarpedMap.svelte
@@ -75,7 +75,6 @@
       style: makeStyleTransparent(style),
       bounds: bounds,
       maxPitch: 0,
-      preserveDrawingBuffer: true,
       attributionControl: false
     })
 

--- a/apps/viewer/src/lib/shared/stores/openlayers.ts
+++ b/apps/viewer/src/lib/shared/stores/openlayers.ts
@@ -262,7 +262,7 @@ export function addMapToVectorSource(mapId: string) {
     const feature = new GeoJSON().readFeature(
       geometryToGeojsonGeometry([warpedMap.projectedGeoMask]),
       {
-        dataProjection: warpedMap.projection.definition
+        dataProjection: String(warpedMap.projection.definition)
       }
     ) as Feature
     feature.setId(warpedMap.mapId)

--- a/packages/bearing/src/index.ts
+++ b/packages/bearing/src/index.ts
@@ -16,15 +16,13 @@ export function computeGeoreferencedMapBearing(map: GeoreferencedMap) {
   let projectedTransformer: ProjectedGcpTransformer
 
   if (map.gcps.length < 2) {
-    // Not enough points for polynomial transformation
     throw new Error('Not enough GCPs to compute bearing')
-  } else if (map.gcps.length === 2) {
-    projectedTransformer = new ProjectedGcpTransformer(map.gcps, 'helmert')
   } else {
-    // Using polynomial transformation, not map transformation type,
-    // since faster when many gcps and accurate enough
+    // Using helmert transformation, not map transformation type,
+    // since possible for any amount of points, consistent,
+    // faster when many gcps and accurate when showing original image
     projectedTransformer = ProjectedGcpTransformer.fromGeoreferencedMap(map, {
-      transformationType: 'polynomial',
+      transformationType: 'helmert',
       projection: lonLatProjection
     })
   }

--- a/packages/maplibre/README.md
+++ b/packages/maplibre/README.md
@@ -62,10 +62,7 @@ const map = new maplibregl.Map({
   center: [-73.9337, 40.8011],
   zoom: 11.5,
   // Pitch is currently not supported by the Allmaps plugin for MapLibre
-  maxPitch: 0,
-  // This is needed to improve rendering
-  // Future versions of the plugin might not need this
-  preserveDrawingBuffer: true
+  maxPitch: 0
 })
 
 const annotationUrl = 'https://annotations.allmaps.org/images/d180902cb93d5bf2'

--- a/packages/maplibre/examples/skypack.html
+++ b/packages/maplibre/examples/skypack.html
@@ -28,13 +28,7 @@
         style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
         center: [-73.9337, 40.8011],
         zoom: 11.5,
-        maxPitch: 0,
-        // preserveDrawingBuffer is needed to fix error that causes base map to disappear
-        // Don't know a better way to fix this currently.
-        // Related GitHub issues:
-        // - https://github.com/mapbox/mapbox-gl-js/issues/9499
-        // - https://github.com/mapbox/mapbox-gl-js/issues/8936
-        preserveDrawingBuffer: true
+        maxPitch: 0
       })
 
       let mapLoaded = false

--- a/packages/maplibre/index.html
+++ b/packages/maplibre/index.html
@@ -6,10 +6,10 @@
     <title>@allmaps/maplibre</title>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/maplibre-gl@4.0.0/dist/maplibre-gl.css"
+      href="https://unpkg.com/maplibre-gl@5.0.0/dist/maplibre-gl.css"
       type="text/css"
     />
-    <script src="https://unpkg.com/maplibre-gl@4.0.0/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/maplibre-gl@5.0.0/dist/maplibre-gl.js"></script>
     <link rel="stylesheet" href="examples/style.css" type="text/css" />
     <script src="examples/controls.js"></script>
   </head>
@@ -17,26 +17,18 @@
     <div id="map"></div>
     <div id="controls"></div>
     <script type="module">
-      import { Map, NavigationControl } from 'maplibre-gl'
-
       import { WarpedMapLayer } from './src/index.ts'
 
-      const map = new Map({
+      const map = new maplibregl.Map({
         container: 'map',
         style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
         center: [-73.9337, 40.8011],
         zoom: 11.5,
-        maxPitch: 0,
-        // preserveDrawingBuffer is needed to fix error that causes base map to disappear
-        // Don't know a better way to fix this currently.
-        // Related GitHub issues:
-        // - https://github.com/mapbox/mapbox-gl-js/issues/9499
-        // - https://github.com/mapbox/mapbox-gl-js/issues/8936
-        preserveDrawingBuffer: true
+        maxPitch: 0
       })
 
       let mapLoaded = false
-      let nav = new NavigationControl()
+      let nav = new maplibregl.NavigationControl()
       map.addControl(nav, 'top-left')
 
       const warpedMapLayer = new WarpedMapLayer()

--- a/packages/maplibre/src/WarpedMapLayer.ts
+++ b/packages/maplibre/src/WarpedMapLayer.ts
@@ -104,7 +104,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     const results =
       await this.renderer.warpedMapList.addGeoreferenceAnnotation(annotation)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
 
     return results
   }
@@ -121,7 +121,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     const results =
       await this.renderer.warpedMapList.removeGeoreferenceAnnotation(annotation)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
 
     return results
   }
@@ -169,7 +169,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     const result =
       this.renderer.warpedMapList.addGeoreferencedMap(georeferencedMap)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
 
     return result
   }
@@ -186,7 +186,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     const result =
       this.renderer.warpedMapList.removeGeoreferencedMap(georeferencedMap)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
 
     return result
   }
@@ -220,7 +220,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.showMaps([mapId])
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -231,7 +231,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.showMaps(mapIds)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -242,7 +242,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.hideMaps([mapId])
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -253,7 +253,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.hideMaps(mapIds)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -276,7 +276,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.setMapResourceMask(resourceMask, mapId)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -293,7 +293,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     this.renderer.warpedMapList.setMapsTransformationType(transformation, {
       mapIds
     })
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -310,7 +310,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     this.renderer.warpedMapList.setMapsDistortionMeasure(distortionMeasure, {
       mapIds
     })
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -339,7 +339,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.bringMapsToFront(mapIds)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -350,7 +350,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.sendMapsToBack(mapIds)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -361,7 +361,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.bringMapsForward(mapIds)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -372,7 +372,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.warpedMapList.sendMapsBackward(mapIds)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -419,7 +419,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.setOpacity(opacity)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -429,7 +429,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetOpacity()
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -463,7 +463,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.setMapOpacity(mapId, opacity)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -474,7 +474,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetMapOpacity(mapId)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -485,7 +485,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.setSaturation(saturation)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -495,7 +495,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetSaturation()
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -507,7 +507,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.setMapSaturation(mapId, saturation)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -518,7 +518,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetMapSaturation(mapId)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -542,7 +542,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
       threshold: options.threshold,
       hardness: options.hardness
     })
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -552,7 +552,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetRemoveColorOptions()
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -578,7 +578,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
       threshold: options.threshold,
       hardness: options.hardness
     })
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -601,7 +601,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     const color = hexToFractionalRgb(hexColor)
     if (color) {
       this.renderer.setColorizeOptions({ color })
-      this.map?.triggerRepaint()
+      this.triggerRepaint()
     }
   }
 
@@ -612,7 +612,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetColorizeOptions()
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -626,7 +626,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     const color = hexToFractionalRgb(hexColor)
     if (color) {
       this.renderer.setMapColorizeOptions(mapId, { color })
-      this.map?.triggerRepaint()
+      this.triggerRepaint()
     }
   }
 
@@ -638,7 +638,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.resetMapColorizeOptions(mapId)
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -648,7 +648,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
     assertRenderer(this.renderer)
 
     this.renderer.clear()
-    this.map?.triggerRepaint()
+    this.triggerRepaint()
   }
 
   /**
@@ -663,6 +663,13 @@ export class WarpedMapLayer implements CustomLayerInterface {
    */
   disableRepaintAfterRender(): void {
     this.shouldRepaintAfterRender = false
+  }
+
+  /**
+   * Trigger repaint.
+   */
+  triggerRepaint(): void {
+    this.map?.triggerRepaint()
   }
 
   /**
@@ -773,7 +780,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     this.renderer.addEventListener(
       WarpedMapEventType.CHANGED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
 
     this.renderer.addEventListener(
@@ -788,7 +795,7 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     this.renderer.addEventListener(
       WarpedMapEventType.IMAGEINFOLOADED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
 
     this.renderer.addEventListener(
@@ -828,12 +835,12 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     this.renderer.warpedMapList.addEventListener(
       WarpedMapEventType.VISIBILITYCHANGED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
 
     this.renderer.warpedMapList.addEventListener(
       WarpedMapEventType.CLEARED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
   }
 
@@ -847,12 +854,12 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     this.renderer.removeEventListener(
       WarpedMapEventType.CHANGED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
 
     this.renderer.removeEventListener(
       WarpedMapEventType.IMAGEINFOLOADED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
 
     this.renderer.removeEventListener(
@@ -892,12 +899,12 @@ export class WarpedMapLayer implements CustomLayerInterface {
 
     this.renderer.warpedMapList.removeEventListener(
       WarpedMapEventType.VISIBILITYCHANGED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
 
     this.renderer.warpedMapList.removeEventListener(
       WarpedMapEventType.CLEARED,
-      this.render.bind(this)
+      this.triggerRepaint.bind(this)
     )
   }
 

--- a/packages/maplibre/src/WarpedMapLayer.ts
+++ b/packages/maplibre/src/WarpedMapLayer.ts
@@ -51,6 +51,8 @@ export class WarpedMapLayer implements CustomLayerInterface {
   renderer?: WebGL2Renderer
   options?: Partial<MapLibreWarpedMapLayerOptions>
 
+  shouldRepaintAfterRender: boolean
+
   /**
    * Creates a WarpedMapLayer instance
    *
@@ -62,6 +64,8 @@ export class WarpedMapLayer implements CustomLayerInterface {
       this.id = id
     }
     this.options = options
+
+    this.shouldRepaintAfterRender = false
   }
 
   /**
@@ -648,6 +652,20 @@ export class WarpedMapLayer implements CustomLayerInterface {
   }
 
   /**
+   * Enable repaint after render.
+   */
+  enableRepaintAfterRender(): void {
+    this.shouldRepaintAfterRender = true
+  }
+
+  /**
+   * Disable repaint after render.
+   */
+  disableRepaintAfterRender(): void {
+    this.shouldRepaintAfterRender = false
+  }
+
+  /**
    * Prepare rendering the layer.
    */
   preparerender(): void {
@@ -731,6 +749,10 @@ export class WarpedMapLayer implements CustomLayerInterface {
     )
 
     this.renderer.render(viewport)
+
+    if (this.shouldRepaintAfterRender) {
+      this.map.triggerRepaint()
+    }
   }
 
   private contextLost() {
@@ -752,6 +774,16 @@ export class WarpedMapLayer implements CustomLayerInterface {
     this.renderer.addEventListener(
       WarpedMapEventType.CHANGED,
       this.render.bind(this)
+    )
+
+    this.renderer.addEventListener(
+      WarpedMapEventType.TRANSITIONSTARTED,
+      this.enableRepaintAfterRender.bind(this)
+    )
+
+    this.renderer.addEventListener(
+      WarpedMapEventType.TRANSITIONFINISHED,
+      this.disableRepaintAfterRender.bind(this)
     )
 
     this.renderer.addEventListener(

--- a/packages/project/README.md
+++ b/packages/project/README.md
@@ -327,12 +327,12 @@ Projections are defined as follows:
 ```ts
 export type Projection = {
   name?: string
-  definition: string
+  definition: string | proj4.PROJJSONDefinition
 }
 ```
 
 Projection definitions can be anything compatible with [Proj4js](https://github.com/proj4js/proj4js), e.g.
-`'EPSG:3857'` or `'+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs'`
+one of the two default named projections `'EPSG:3857'` `'EPSG:4326'`, a proj4-string `'+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs'`, a WKT-string or (since Proj4js version 2.19) a [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) definition.
 
 ## Benchmark
 
@@ -532,7 +532,7 @@ Create a Projected GCP Transformer from a Georeferenced Map
 
 ###### Parameters
 
-* `georeferencedMap` (`{ type: "GeoreferencedMap"; resource: { type: "ImageService1" | "ImageService2" | "ImageService3" | "Canvas"; id: string; height?: number | undefined; width?: number | undefined; partOf?: ({ type: string; id: string; label?: Record<string, (string | number | boolean)[]> | undefined; } & { partOf?: ({ type: string; i...`)
+* `georeferencedMap` (`{ type: "GeoreferencedMap"; gcps: { resource: [number, number]; geo: [number, number]; }[]; resource: { type: "ImageService1" | "ImageService2" | "ImageService3" | "Canvas"; id: string; partOf?: ({ type: string; id: string; label?: Record<string, (string | number | boolean)[]> | undefined; } & { partOf?: ({ type: st...`)
   * A Georeferenced Map
 * `options?` (`Partial<{ internalProjection: Projection; projection: Projection; } & { differentHandedness: boolean; } & { maxDepth: number; minOffsetRatio: number; minOffsetDistance: number; minLineDistance: number; ... 4 more ...; preToResource: ProjectionFunction; } & MultiGeometryOptions & TransformationTypeInputs> | undefined`)
   * Options, including Projected GCP Transformer Options, and a transformation type to overrule the type defined in the Georeferenced Map
@@ -561,21 +561,21 @@ GcpsInputs & TransformationTypeInputs & InternalProjectionInputs
 
 ###### Fields
 
-* `definition` (`string`)
+* `definition` (`Definition`)
 * `name?` (`string`)
 
 ### `defaultProjectedGcpTransformOptions`
 
 ###### Fields
 
-* `projection` (`{name?: string; definition: ProjectionDefinition}`)
+* `projection` (`{name?: string; definition: string}`)
 
 ### `defaultProjectedGcpTransformerOptions`
 
 ###### Fields
 
-* `internalProjection` (`{name?: string; definition: ProjectionDefinition}`)
-* `projection` (`{name?: string; definition: ProjectionDefinition}`)
+* `internalProjection` (`{name?: string; definition: string}`)
+* `projection` (`{name?: string; definition: string}`)
 
 ### `isEqualProjection(projection0, projection1)`
 
@@ -586,7 +586,7 @@ GcpsInputs & TransformationTypeInputs & InternalProjectionInputs
 
 ###### Returns
 
-`boolean`.
+`boolean | undefined`.
 
 ### `lonLatProjection`
 

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './shared/project-functions.js'
 
 export {
+  ProjectionDefinition,
   Projection,
   ProjectedGcpTransformOptions,
   ProjectedGcpTransformerOptions,

--- a/packages/project/src/shared/project-functions.ts
+++ b/packages/project/src/shared/project-functions.ts
@@ -24,11 +24,11 @@ const webMercatorEquivalentDefinitions = [
   'EPSG:102113'
 ]
 
-export const lonLatProjection: Projection = {
+export const lonLatProjection: Projection<string> = {
   name: 'EPSG:4326',
   definition: lonLatEquivalentDefinitions[0]
 }
-export const webMercatorProjection: Projection = {
+export const webMercatorProjection: Projection<string> = {
   name: 'EPSG:3857',
   definition: webMercatorEquivalentDefinitions[0]
 }
@@ -55,30 +55,36 @@ export const lonLatToWebMercator =
 export const webMercatorToLonLat =
   lonLatProjectionToWebMecatorProjectionConverter.inverse
 
-function projectionToAntialiasedDefinition(projection: Projection | undefined) {
-  if (projection === undefined) {
+function projectionDefinitionToAntialiasedDefinition(
+  stringProjectionDefinition: string | undefined
+): string | undefined {
+  if (stringProjectionDefinition === undefined) {
     return undefined
   }
 
-  const lonLatIndex = lonLatEquivalentDefinitions.indexOf(projection.definition)
+  const lonLatIndex = lonLatEquivalentDefinitions.indexOf(
+    stringProjectionDefinition
+  )
   const webMercatorIndex = webMercatorEquivalentDefinitions.indexOf(
-    projection.definition
+    stringProjectionDefinition
   )
   if (lonLatIndex != -1) {
     return lonLatProjection.definition
   } else if (webMercatorIndex != -1) {
     return webMercatorProjection.definition
   } else {
-    return projection.definition
+    return stringProjectionDefinition
   }
 }
 
 export function isEqualProjection(
   projection0: Projection | undefined,
   projection1: Projection | undefined
-) {
+): boolean | undefined {
   return (
-    projectionToAntialiasedDefinition(projection0) ==
-    projectionToAntialiasedDefinition(projection1)
+    projectionDefinitionToAntialiasedDefinition(
+      String(projection0?.definition)
+    ) ==
+    projectionDefinitionToAntialiasedDefinition(String(projection1?.definition))
   )
 }

--- a/packages/project/src/shared/types.ts
+++ b/packages/project/src/shared/types.ts
@@ -5,11 +5,13 @@ import {
   TransformationTypeInputs
 } from '@allmaps/transform'
 
-export type ProjectionDefinition = string
+import { PROJJSONDefinition } from 'proj4/dist/lib/core'
 
-export type Projection = {
+export type ProjectionDefinition = string | PROJJSONDefinition
+
+export type Projection<Definition = ProjectionDefinition> = {
   name?: string
-  definition: ProjectionDefinition
+  definition: Definition
 }
 
 export type ProjectedGcpTransformerOptions = {

--- a/packages/render/src/renderers/BaseRenderer.ts
+++ b/packages/render/src/renderers/BaseRenderer.ts
@@ -623,7 +623,6 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
   protected optionsChanged(event: Event): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
-  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   protected gcpsChanged(event: Event): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars

--- a/packages/render/src/renderers/WebGL2Renderer.ts
+++ b/packages/render/src/renderers/WebGL2Renderer.ts
@@ -1230,7 +1230,6 @@ export class WebGL2Renderer
   }
 
   private startTransformerTransition(mapIds: string[]) {
-    this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.TRANSITIONSTARTED))
     this.updateVertexBuffers(mapIds)
 
     if (this.lastAnimationFrameRequestId !== undefined) {
@@ -1255,6 +1254,9 @@ export class WebGL2Renderer
       this.animationProgress =
         (now - this.transformaterTransitionStart) / ANIMATION_DURATION
 
+      // First trigger a general repaint to clear canvas
+      this.changed()
+
       this.renderInternal()
 
       this.lastAnimationFrameRequestId = requestAnimationFrame(
@@ -1277,9 +1279,6 @@ export class WebGL2Renderer
     this.transformaterTransitionStart = undefined
 
     this.changed()
-    this.dispatchEvent(
-      new WarpedMapEvent(WarpedMapEventType.TRANSITIONFINISHED)
-    )
   }
 
   private changed() {

--- a/packages/render/src/renderers/WebGL2Renderer.ts
+++ b/packages/render/src/renderers/WebGL2Renderer.ts
@@ -1228,7 +1228,8 @@ export class WebGL2Renderer
     )
   }
 
-  private startTransformaterTransition(mapIds: string[]) {
+  private startTransformerTransition(mapIds: string[]) {
+    this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.TRANSITIONSTARTED))
     this.updateVertexBuffers(mapIds)
 
     if (this.lastAnimationFrameRequestId !== undefined) {
@@ -1262,11 +1263,11 @@ export class WebGL2Renderer
       )
     } else {
       // Animation ended
-      this.finishTransition(mapIds)
+      this.finishTransformerTransition(mapIds)
     }
   }
 
-  private finishTransition(mapIds: string[]) {
+  private finishTransformerTransition(mapIds: string[]) {
     this.resetPrevious(mapIds)
     this.updateVertexBuffers(mapIds)
 
@@ -1275,6 +1276,9 @@ export class WebGL2Renderer
     this.transformaterTransitionStart = undefined
 
     this.changed()
+    this.dispatchEvent(
+      new WarpedMapEvent(WarpedMapEventType.TRANSITIONFINISHED)
+    )
   }
 
   private changed() {
@@ -1355,7 +1359,7 @@ export class WebGL2Renderer
   protected optionsChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.finishTransition(mapIds)
+      this.finishTransformerTransition(mapIds)
     }
     this.changed()
   }
@@ -1363,7 +1367,7 @@ export class WebGL2Renderer
   protected gcpsChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.finishTransition(mapIds)
+      this.finishTransformerTransition(mapIds)
     }
     this.changed()
   }
@@ -1371,7 +1375,7 @@ export class WebGL2Renderer
   protected resourceMaskChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.finishTransition(mapIds)
+      this.finishTransformerTransition(mapIds)
     }
     this.changed()
   }
@@ -1379,28 +1383,28 @@ export class WebGL2Renderer
   protected transformationChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.startTransformaterTransition(mapIds)
+      this.startTransformerTransition(mapIds)
     }
   }
 
   protected distortionChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.startTransformaterTransition(mapIds)
+      this.startTransformerTransition(mapIds)
     }
   }
 
   protected internalProjectionChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.startTransformaterTransition(mapIds)
+      this.startTransformerTransition(mapIds)
     }
   }
 
   protected projectionChanged(event: Event) {
     if (event instanceof WarpedMapEvent) {
       const mapIds = event.data as string[]
-      this.finishTransition(mapIds)
+      this.finishTransformerTransition(mapIds)
     }
     this.changed()
   }

--- a/packages/render/src/renderers/WebGL2Renderer.ts
+++ b/packages/render/src/renderers/WebGL2Renderer.ts
@@ -74,6 +74,7 @@ const DEFAULT_OPACITY = 1
 const DEFAULT_SATURATION = 1
 const DEFAULT_REMOVE_COLOR_THRESHOLD = 0
 const DEFAULT_REMOVE_COLOR_HARDNESS = 0.7
+const SIGNIFICANT_VIEWPORT_EPSILON = 100 * Number.EPSILON
 const SIGNIFICANT_VIEWPORT_DISTANCE = 5
 const ANIMATION_DURATION = 750
 
@@ -760,7 +761,7 @@ export class WebGL2Renderer
         )
       }
       const maxSquaredDistance = Math.max(...rectangleSquaredDistances)
-      if (maxSquaredDistance === 0) {
+      if (maxSquaredDistance < SIGNIFICANT_VIEWPORT_EPSILON) {
         return true
       }
       if (maxSquaredDistance > Math.pow(SIGNIFICANT_VIEWPORT_DISTANCE, 2)) {

--- a/packages/render/src/shared/events.ts
+++ b/packages/render/src/shared/events.ts
@@ -30,6 +30,9 @@ export enum WarpedMapEventType {
   INTERNALPROJECTIONCHANGED = 'internalprojectionchanged',
   PROJECTIONCHANGED = 'projectionchanged',
 
+  TRANSITIONSTARTED = 'transitionstarted',
+  TRANSITIONFINISHED = 'transitionfinished',
+
   CHANGED = 'changed',
 
   CLEARED = 'cleared'

--- a/packages/render/src/shared/events.ts
+++ b/packages/render/src/shared/events.ts
@@ -30,9 +30,6 @@ export enum WarpedMapEventType {
   INTERNALPROJECTIONCHANGED = 'internalprojectionchanged',
   PROJECTIONCHANGED = 'projectionchanged',
 
-  TRANSITIONSTARTED = 'transitionstarted',
-  TRANSITIONFINISHED = 'transitionfinished',
-
   CHANGED = 'changed',
 
   CLEARED = 'cleared'

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -13,6 +13,8 @@ export { Projective } from './transformation-types/Projective.js'
 export { RBF } from './transformation-types/RBF.js'
 export { Straight } from './transformation-types/Straight.js'
 
+export { supportedtransformationTypes } from './shared/types.js'
+
 export {
   supportedDistortionMeasures,
   computeDistortionsFromPartialDerivatives

--- a/packages/transform/src/shared/types.ts
+++ b/packages/transform/src/shared/types.ts
@@ -34,9 +34,19 @@ export type TransformationType =
   | 'polynomial1'
   | 'polynomial2'
   | 'polynomial3'
-  | 'projective'
   | 'thinPlateSpline'
+  | 'projective'
   | 'linear'
+
+export const supportedtransformationTypes: TransformationType[] = [
+  'straight',
+  'helmert',
+  'polynomial', // Note: no 'polynomial1' here
+  'polynomial2',
+  'polynomial3',
+  'thinPlateSpline',
+  'projective'
+]
 
 // Stored here as object to facilitate parsing in CLI and elsewhere
 export type GcpsInputs = {


### PR DESCRIPTION
This fixes issues with part of the maps or background not rendering.

This was caused by the `preserveDrawingBuffer: true` setting moved since MapLibre 5.0.0 to the `canvasContextAttributes` options in `new maplibregl.Map()`. Following that move could also have solved issue, but this is a more structural fix: anways rerendering using `triggerRepaint()` instead of `render()`. This makes the `preserveDrawingBuffer: true` options unnecessary.