### PR TITLE
Add anti-meridian support by rendering multiple world copies in WebGL2

### DIFF
--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -41,7 +41,8 @@
     "lint": "prettier --ignore-path ../../.gitignore --check src && eslint src --ext .js,.ts",
     "types": "tsc --noEmit",
     "format": "prettier --ignore-path ../../.gitignore --write src",
-    "documentation": "remark . --output --use remark-api"
+    "documentation": "remark . --output --use remark-api",
+    "test": "NODE_ENV=test vitest run"
   },
   "homepage": "https://allmaps.org",
   "keywords": [
@@ -81,7 +82,8 @@
     "vite": "catalog:",
     "vite-plugin-dts": "^3.8.3",
     "vite-plugin-glsl": "^1.3.0",
-    "vite-plugin-no-bundle": "^4.0.0"
+    "vite-plugin-no-bundle": "^4.0.0",
+    "vitest": "^4.0.4"
   },
   "gitHead": "f372db912469ba4415c94f79ea2806c3866ff987"
 }

--- a/packages/render/src/renderers/WebGL2Renderer.ts
+++ b/packages/render/src/renderers/WebGL2Renderer.ts
@@ -46,6 +46,8 @@ import type { FetchableTile } from '../tilecache/FetchableTile.js'
 
 import type { FetchAndGetImageDataWorkerType } from '../workers/fetch-and-get-image-data.js'
 
+import type { HomogeneousTransform } from '@allmaps/types'
+
 import type {
   Renderer,
   SpecificWebGL2RenderOptions,
@@ -483,85 +485,111 @@ export class WebGL2Renderer
     gl.enable(gl.BLEND)
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
 
-    this.renderMapsInternal()
-    this.renderLinesInternal()
-    this.renderPointsInternal()
+    const worldClipTransforms = this.getWorldClipTransforms()
+
+    this.renderMapsInternal(worldClipTransforms)
+    this.renderLinesInternal(worldClipTransforms)
+    this.renderPointsInternal(worldClipTransforms)
   }
 
-  private renderMapsInternal(): void {
+  private renderMapsInternal(worldClipTransforms: HomogeneousTransform[]): void {
     if (!this.viewport) {
       return
     }
 
     this.setMapProgramUniforms()
 
-    for (const mapId of this.mapsWithFetchableTilesForViewport) {
-      const webgl2WarpedMap = this.warpedMapList.getWarpedMap(mapId)
+    for (const worldClipTransform of worldClipTransforms) {
+      for (const mapId of this.mapsWithFetchableTilesForViewport) {
+        const webgl2WarpedMap = this.warpedMapList.getWarpedMap(mapId)
 
-      if (!webgl2WarpedMap || !webgl2WarpedMap.shouldRenderMap()) {
-        continue
+        if (!webgl2WarpedMap || !webgl2WarpedMap.shouldRenderMap()) {
+          continue
+        }
+
+        this.setMapProgramMapUniforms(webgl2WarpedMap, worldClipTransform)
+
+        // Draw map
+        const count = webgl2WarpedMap.resourceTrianglePoints.length
+        const primitiveType = this.gl.TRIANGLES
+        const offset = 0
+        this.gl.bindVertexArray(webgl2WarpedMap.mapVao)
+        this.gl.drawArrays(primitiveType, offset, count)
       }
-
-      this.setMapProgramMapUniforms(webgl2WarpedMap)
-
-      // Draw map
-      const count = webgl2WarpedMap.resourceTrianglePoints.length
-      const primitiveType = this.gl.TRIANGLES
-      const offset = 0
-      this.gl.bindVertexArray(webgl2WarpedMap.mapVao)
-      this.gl.drawArrays(primitiveType, offset, count)
     }
   }
 
-  private renderLinesInternal(): void {
+  private renderLinesInternal(worldClipTransforms: HomogeneousTransform[]): void {
     this.setLinesProgramUniforms()
 
-    for (const mapId of this.mapsWithFetchableTilesForViewport) {
-      const webgl2WarpedMap = this.warpedMapList.getWarpedMap(mapId)
+    for (const worldClipTransform of worldClipTransforms) {
+      for (const mapId of this.mapsWithFetchableTilesForViewport) {
+        const webgl2WarpedMap = this.warpedMapList.getWarpedMap(mapId)
 
-      if (!webgl2WarpedMap || !webgl2WarpedMap.shouldRenderLines()) {
-        continue
+        if (!webgl2WarpedMap || !webgl2WarpedMap.shouldRenderLines()) {
+          continue
+        }
+
+        this.setLinesProgramMapUniforms(webgl2WarpedMap, worldClipTransform)
+
+        // Draw lines for each map
+        const count =
+          webgl2WarpedMap.lineGroups.reduce(
+            (accumulator: number, lineGroup) =>
+              accumulator + lineGroup.projectedGeoLines.length,
+            0
+          ) * 6
+        const primitiveType = this.gl.TRIANGLES
+        const offset = 0
+        this.gl.bindVertexArray(webgl2WarpedMap.linesVao)
+        this.gl.drawArrays(primitiveType, offset, count)
       }
-
-      this.setLinesProgramMapUniforms(webgl2WarpedMap)
-
-      // Draw lines for each map
-      const count =
-        webgl2WarpedMap.lineGroups.reduce(
-          (accumulator: number, lineGroup) =>
-            accumulator + lineGroup.projectedGeoLines.length,
-          0
-        ) * 6
-      const primitiveType = this.gl.TRIANGLES
-      const offset = 0
-      this.gl.bindVertexArray(webgl2WarpedMap.linesVao)
-      this.gl.drawArrays(primitiveType, offset, count)
     }
   }
 
-  private renderPointsInternal(): void {
+  private renderPointsInternal(worldClipTransforms: HomogeneousTransform[]): void {
     this.setPointsProgramUniforms()
 
-    for (const mapId of this.mapsWithFetchableTilesForViewport) {
-      const webgl2WarpedMap = this.warpedMapList.getWarpedMap(mapId)
+    for (const worldClipTransform of worldClipTransforms) {
+      for (const mapId of this.mapsWithFetchableTilesForViewport) {
+        const webgl2WarpedMap = this.warpedMapList.getWarpedMap(mapId)
 
-      if (!webgl2WarpedMap! || !webgl2WarpedMap.shouldRenderPoints()) {
-        continue
+        if (!webgl2WarpedMap! || !webgl2WarpedMap.shouldRenderPoints()) {
+          continue
+        }
+
+        this.setPointsProgramMapUniforms(webgl2WarpedMap, worldClipTransform)
+
+        // Draw points for each map
+        const count = webgl2WarpedMap.pointGroups.reduce(
+          (accumulator: number, pointGroup) =>
+            accumulator + pointGroup.projectedGeoPoints.length,
+          0
+        )
+        const primitiveType = this.gl.POINTS
+        const offset = 0
+        this.gl.bindVertexArray(webgl2WarpedMap.pointsVao)
+        this.gl.drawArrays(primitiveType, offset, count)
       }
-
-      this.setPointsProgramMapUniforms(webgl2WarpedMap)
-
-      // Draw points for each map
-      const count = webgl2WarpedMap.pointGroups.reduce(
-        (accumulator: number, pointGroup) =>
-          accumulator + pointGroup.projectedGeoPoints.length,
-        0
-      )
-      const primitiveType = this.gl.POINTS
-      const offset = 0
-      this.gl.bindVertexArray(webgl2WarpedMap.pointsVao)
-      this.gl.drawArrays(primitiveType, offset, count)
     }
+  }
+
+  private getWorldClipTransforms(): HomogeneousTransform[] {
+    if (!this.viewport) {
+      return [[1, 0, 0, 1, 0, 0]]
+    }
+
+    const transforms: HomogeneousTransform[] = []
+    for (let world = this.viewport.startWorld; world < this.viewport.endWorld; world++) {
+      const worldTranslation: HomogeneousTransform = [1, 0, 0, 1, world * this.viewport.worldWidth, 0]
+      transforms.push(
+        multiplyHomogeneousTransform(
+          this.viewport.projectedGeoToClipHomogeneousTransform,
+          worldTranslation
+        )
+      )
+    }
+    return transforms
   }
 
   private setMapProgramUniforms() {
@@ -578,7 +606,10 @@ export class WebGL2Renderer
     gl.uniform1f(animationProgressLocation, this.animationProgress)
   }
 
-  private setMapProgramMapUniforms(webgl2WarpedMap: WebGL2WarpedMap) {
+  private setMapProgramMapUniforms(
+    webgl2WarpedMap: WebGL2WarpedMap,
+    projectedGeoToClipTransform: HomogeneousTransform
+  ) {
     if (!this.viewport) {
       return
     }
@@ -589,7 +620,7 @@ export class WebGL2Renderer
 
     // Render Transform
     const renderHomogeneousTransform = multiplyHomogeneousTransform(
-      this.viewport.projectedGeoToClipHomogeneousTransform,
+      projectedGeoToClipTransform,
       webgl2WarpedMap.invertedRenderHomogeneousTransform
     )
     const renderHomogeneousTransformLocation = this.getUniformLocation(
@@ -867,7 +898,10 @@ export class WebGL2Renderer
     gl.uniform1f(animationProgressLocation, this.animationProgress)
   }
 
-  private setLinesProgramMapUniforms(webgl2WarpedMap: WebGL2WarpedMap) {
+  private setLinesProgramMapUniforms(
+    webgl2WarpedMap: WebGL2WarpedMap,
+    projectedGeoToClipTransform: HomogeneousTransform
+  ) {
     if (!this.viewport) {
       return
     }
@@ -878,7 +912,7 @@ export class WebGL2Renderer
 
     // Render Transform
     const renderHomogeneousTransform = multiplyHomogeneousTransform(
-      this.viewport.projectedGeoToClipHomogeneousTransform,
+      projectedGeoToClipTransform,
       webgl2WarpedMap.invertedRenderHomogeneousTransform
     )
     const renderHomogeneousTransformLocation = this.getUniformLocation(
@@ -919,7 +953,10 @@ export class WebGL2Renderer
     gl.uniform1f(devicePixelRatioLocation, this.viewport.devicePixelRatio)
   }
 
-  private setPointsProgramMapUniforms(webgl2WarpedMap: WebGL2WarpedMap) {
+  private setPointsProgramMapUniforms(
+    webgl2WarpedMap: WebGL2WarpedMap,
+    projectedGeoToClipTransform: HomogeneousTransform
+  ) {
     if (!this.viewport) {
       return
     }
@@ -930,7 +967,7 @@ export class WebGL2Renderer
 
     // Render Transform
     const renderHomogeneousTransform = multiplyHomogeneousTransform(
-      this.viewport.projectedGeoToClipHomogeneousTransform,
+      projectedGeoToClipTransform,
       webgl2WarpedMap.invertedRenderHomogeneousTransform
     )
     const renderHomogeneousTransformLocation = this.getUniformLocation(

--- a/packages/render/src/shared/web-mercator.ts
+++ b/packages/render/src/shared/web-mercator.ts
@@ -1,0 +1,12 @@
+/**
+ * Radius of WGS84 sphere, in meters.
+ *
+ * @see {@link https://github.com/openlayers/openlayers/blob/main/src/ol/proj/epsg3857.js}
+ */
+export const RADIUS = 6378137
+
+/**
+ * Half-width of the Web Mercator projection bounds, in meters.
+ */
+export const HALF_SIZE = Math.PI * RADIUS
+

--- a/packages/render/src/viewport/Viewport.ts
+++ b/packages/render/src/viewport/Viewport.ts
@@ -46,6 +46,8 @@ import type { Projection } from '@allmaps/project'
 import type { WarpedMap } from '../maps/WarpedMap.js'
 import type { ProjectionOptions, SelectionOptions } from '../shared/types.js'
 
+import { HALF_SIZE } from '../shared/web-mercator.js'
+
 export type ViewportOptions = {
   rotation: number
   devicePixelRatio: number
@@ -103,6 +105,10 @@ const defaultFitOptions = {
  * @property projectedGeoToCanvasHomogeneousTransform - Homogeneous Transform from projected geo coordinates to canvas pixels.
  * @property projectedGeoToClipHomogeneousTransform - Homogeneous Transform from projected geo coordinates to WebGL coordinates in the [-1, 1] range. Equivalent to OpenLayers projectionTransform.
  * @property viewportToClipHomogeneousTransform - Homogeneous Transform from viewport coordinates to WebGL coordinates in the [-1, 1] range.
+ * @property viewportToProjectedGeoHomogeneousTransform - Homogeneous Transform from viewport pixels to projected geospatial coordinates. Inverse of projectedGeoToViewportHomogeneousTransform.
+ * @property startWorld - Index of the first world copy to render, for anti-meridian wrapping (0 = primary world).
+ * @property endWorld - Index past the last world copy to render (exclusive), for anti-meridian wrapping.
+ * @property worldWidth - Width of one world in projected geospatial coordinates. 0 for non-wrapping projections.
  */
 export class Viewport {
   geoCenter: Point
@@ -145,7 +151,12 @@ export class Viewport {
   projectedGeoToClipHomogeneousTransform: HomogeneousTransform = [
     1, 0, 0, 1, 0, 0
   ]
+  viewportToProjectedGeoHomogeneousTransform: HomogeneousTransform = [1, 0, 0, 1, 0, 0]
   viewportToClipHomogeneousTransform: HomogeneousTransform = [1, 0, 0, 1, 0, 0]
+
+  startWorld: number
+  endWorld: number
+  worldWidth: number
 
   /**
    * Creates a new Viewport
@@ -193,14 +204,31 @@ export class Viewport {
     )
     this.projectedGeoResolution = sizeToResolution(this.projectedGeoSize)
 
-    // TODO: improve this with an interpolated back-projection, resulting in a ring
-    this.geoRectangle = this.projectedGeoRectangle.map((point) => {
-      return proj4(
-        this.projection.definition,
-        lonLatProjection.definition,
-        point
+    const canWrapX = typeof this.projection.definition === 'string' &&
+      this.projection.definition.includes('+proj=merc')
+
+    if (canWrapX) {
+      this.worldWidth = 2 * HALF_SIZE
+      this.startWorld = Math.floor(
+        (this.projectedGeoRectangleBbox[0] - (-HALF_SIZE)) / this.worldWidth
       )
-    }) as Rectangle
+      this.endWorld = Math.ceil(
+        (this.projectedGeoRectangleBbox[2] - HALF_SIZE) / this.worldWidth
+      ) + 1
+    } else {
+      this.worldWidth = 0
+      this.startWorld = 0
+      this.endWorld = 1
+    }
+
+    // TODO: improve this with an interpolated back-projection, resulting in a ring
+    const [a, b, c, d] = this.projectedGeoRectangle
+    this.geoRectangle = [
+      this.projectedGeoPointToGeoPoint(a),
+      this.projectedGeoPointToGeoPoint(b),
+      this.projectedGeoPointToGeoPoint(c),
+      this.projectedGeoPointToGeoPoint(d)
+    ]
     this.geoRectangleBbox = computeBbox(this.geoRectangle)
     this.geoCenter = bboxToCenter(this.geoRectangleBbox)
     this.geoSize = bboxToSize(this.geoRectangleBbox)
@@ -222,12 +250,15 @@ export class Viewport {
 
     this.projectedGeoToViewportHomogeneousTransform =
       this.composeProjectedGeoToViewportHomogeneousTransform()
+    this.viewportToProjectedGeoHomogeneousTransform =
+      invertHomogeneousTransform(this.projectedGeoToViewportHomogeneousTransform)
     this.projectedGeoToCanvasHomogeneousTransform =
       this.composeProjectedGeoToCanvasHomogeneousTransform()
     this.projectedGeoToClipHomogeneousTransform =
       this.composeProjectedGeoToClipHomogeneousTransform()
     this.viewportToClipHomogeneousTransform =
       this.composeViewportToClipHomogeneousTransform()
+
   }
 
   /**
@@ -468,25 +499,27 @@ export class Viewport {
   }
 
   getProjectedGeoBufferedRectangle(bufferFraction?: number): Rectangle {
-    const viewportBufferedBbox = bufferBboxByRatio(
-      this.viewportBbox,
-      bufferFraction
-    )
-    const viewportBufferedRectangle = bboxToRectangle(viewportBufferedBbox)
-    return viewportBufferedRectangle.map((point) =>
-      applyHomogeneousTransform(
-        invertHomogeneousTransform(
-          this.projectedGeoToViewportHomogeneousTransform
-        ),
-        point
-      )
-    ) as Rectangle
+    const bufferedBbox = bufferBboxByRatio(this.viewportBbox, bufferFraction ?? 0);
+    const [bl, br, tr, tl] = bboxToRectangle(bufferedBbox);
+
+    const transform = this.viewportToProjectedGeoHomogeneousTransform;
+
+    return [
+      this.wrapProjectedGeoPoint(applyHomogeneousTransform(transform, bl)),
+      this.wrapProjectedGeoPoint(applyHomogeneousTransform(transform, br)),
+      this.wrapProjectedGeoPoint(applyHomogeneousTransform(transform, tr)),
+      this.wrapProjectedGeoPoint(applyHomogeneousTransform(transform, tl)),
+    ];
   }
 
   getGeoBufferedRectangle(bufferFraction?: number): Rectangle {
-    return this.getProjectedGeoBufferedRectangle(bufferFraction).map((point) =>
-      proj4(this.projection.definition, lonLatProjection.definition, point)
-    ) as Rectangle
+    const [a, b, c, d] = this.getProjectedGeoBufferedRectangle(bufferFraction)
+    return [
+      this.projectedGeoPointToGeoPoint(a),
+      this.projectedGeoPointToGeoPoint(b),
+      this.projectedGeoPointToGeoPoint(c),
+      this.projectedGeoPointToGeoPoint(d)
+    ]
   }
 
   private composeProjectedGeoToViewportHomogeneousTransform(): HomogeneousTransform {
@@ -534,6 +567,38 @@ export class Viewport {
       0,
       -this.viewportCenter[0],
       -this.viewportCenter[1]
+    )
+  }
+
+  /**
+   * Wraps a projected geo point's X coordinate into the primary world [-HALF_SIZE, HALF_SIZE].
+   * This ensures proj4 inverse projection produces valid longitude values.
+   *
+   * @param point - A point in projected geospatial coordinates
+   * @returns The point with X coordinate wrapped into [-HALF_SIZE, HALF_SIZE]
+   */
+  private wrapProjectedGeoPoint([x, y]: Point): Point {
+    if (this.worldWidth === 0) {
+      return [x, y]
+    }
+    const distanceFromLeftEdge = x - (-HALF_SIZE)
+    const worldsCrossed = Math.floor(distanceFromLeftEdge / this.worldWidth)
+
+    return [x - worldsCrossed * this.worldWidth, y]
+  }
+
+  /**
+   * Converts a point in projected geospatial coordinates to longitude/latitude coordinates.
+   * The point's X coordinate is first wrapped into the primary world before inverse projection.
+   *
+   * @param point - A point in projected geospatial coordinates.
+   * @returns The point in longitude/latitude coordinates.
+   */
+  private projectedGeoPointToGeoPoint(point: Point): Point {
+    return proj4(
+      this.projection.definition,
+      lonLatProjection.definition,
+      this.wrapProjectedGeoPoint(point)
     )
   }
 

--- a/packages/render/test/viewport.test.ts
+++ b/packages/render/test/viewport.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect } from 'vitest'
+
+import { Viewport } from '../src/viewport/Viewport.js'
+
+import { expectToBeCloseToArray } from '../../stdlib/test/helper-functions.js'
+import { HALF_SIZE } from '../src/shared/web-mercator.js'
+
+const WORLD_WIDTH = 2 * HALF_SIZE
+
+const defaultViewportSize: [number, number] = [800, 600]
+
+const originCenter: [number, number] = [0, 0]
+const leftEdgeCenter: [number, number] = [-HALF_SIZE, 0]
+const rightEdgeCenter: [number, number] = [HALF_SIZE, 0]
+const pastAntiMeridianCenter: [number, number] = [HALF_SIZE + 1000000, 0]
+const utmCenter: [number, number] = [500000, 5000000]
+
+// Scale where viewport width covers exactly one world
+const singleWorldScale = WORLD_WIDTH / defaultViewportSize[0] / 2
+// Scale where viewport width covers two worlds
+const multiWorldScale = WORLD_WIDTH * 2 / defaultViewportSize[0]
+
+const utmProjection = {
+  name: 'UTM Zone 32N',
+  definition: '+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs'
+}
+
+describe('Viewport world wrapping', () => {
+  describe('Web Mercator projection', () => {
+    test('should have worldWidth equal to full Web Mercator extent', () => {
+      const viewport = new Viewport(defaultViewportSize, originCenter, singleWorldScale)
+      expect(viewport.worldWidth).to.be.approximately(WORLD_WIDTH, 1)
+    })
+
+    test('should have startWorld=0 and endWorld=1 for a viewport in the primary world', () => {
+      const viewport = new Viewport(defaultViewportSize, originCenter, singleWorldScale)
+      expect(viewport.startWorld).to.equal(0)
+      expect(viewport.endWorld).to.equal(1)
+    })
+
+    test('should have startWorld=-1 when viewport extends past the left edge of the primary world', () => {
+      const viewport = new Viewport(defaultViewportSize, leftEdgeCenter, singleWorldScale)
+      expect(viewport.startWorld).to.equal(-1)
+      expect(viewport.endWorld).to.equal(1)
+    })
+
+    test('should have endWorld=2 when viewport extends past the right edge of the primary world', () => {
+      const viewport = new Viewport(defaultViewportSize, rightEdgeCenter, singleWorldScale)
+      expect(viewport.startWorld).to.equal(0)
+      expect(viewport.endWorld).to.equal(2)
+    })
+
+    test('should still reach endWorld=2 when centered just inside the right edge', () => {
+      const justInsideRight: [number, number] = [HALF_SIZE - 1, 0]
+      const viewport = new Viewport(defaultViewportSize, justInsideRight, singleWorldScale)
+      expect(viewport.endWorld).to.equal(2)
+    })
+
+    test('should report 3 world copies when viewport width equals two full world widths', () => {
+      const viewport = new Viewport(defaultViewportSize, originCenter, multiWorldScale)
+      expect(viewport.endWorld - viewport.startWorld).to.equal(3)
+    })
+
+    test('should produce valid geoRectangle coordinates within [-180, 180] longitude', () => {
+      const viewport = new Viewport(defaultViewportSize, pastAntiMeridianCenter, singleWorldScale)
+      for (const point of viewport.geoRectangle) {
+        expect(point[0]).to.be.greaterThanOrEqual(-180)
+        expect(point[0]).to.be.lessThanOrEqual(180)
+      }
+    })
+
+    test('should produce valid geoRectangle for a viewport in the primary world', () => {
+      const viewport = new Viewport(defaultViewportSize, originCenter, singleWorldScale)
+      for (const point of viewport.geoRectangle) {
+        expect(point[0]).to.be.greaterThanOrEqual(-180)
+        expect(point[0]).to.be.lessThanOrEqual(180)
+        expect(point[1]).to.be.greaterThanOrEqual(-90)
+        expect(point[1]).to.be.lessThanOrEqual(90)
+      }
+    })
+
+    test('geoCenter should be near [0, 0] for a viewport centered at the origin', () => {
+      const viewport = new Viewport(defaultViewportSize, originCenter, singleWorldScale)
+      expectToBeCloseToArray(viewport.geoCenter, [0, 0], 1e-6)
+    })
+
+    test('geoRectangle longitudes should not span more than 360 degrees when crossing the anti-meridian', () => {
+      const viewport = new Viewport(defaultViewportSize, pastAntiMeridianCenter, singleWorldScale)
+      const lons = viewport.geoRectangle.map(p => p[0])
+      const lonRange = Math.max(...lons) - Math.min(...lons)
+      expect(lonRange).to.be.lessThan(360)
+    })
+  })
+
+  describe('Non-Mercator projection', () => {
+    test('should have worldWidth=0 for a non-wrapping projection', () => {
+      const viewport = new Viewport(defaultViewportSize, utmCenter, singleWorldScale, {
+        projection: utmProjection,
+        rotation: 0,
+        devicePixelRatio: 1
+      })
+      expect(viewport.worldWidth).to.equal(0)
+    })
+
+    test('should have startWorld=0 and endWorld=1 for a non-wrapping projection', () => {
+      const viewport = new Viewport(defaultViewportSize, utmCenter, singleWorldScale, {
+        projection: utmProjection,
+        rotation: 0,
+        devicePixelRatio: 1
+      })
+      expect(viewport.startWorld).to.equal(0)
+      expect(viewport.endWorld).to.equal(1)
+    })
+  })
+
+  describe('getProjectedGeoBufferedRectangle', () => {
+    test('should return wrapped coordinates within the primary world when past the anti-meridian', () => {
+      const viewport = new Viewport(defaultViewportSize, pastAntiMeridianCenter, singleWorldScale)
+      const rect = viewport.getProjectedGeoBufferedRectangle(0)
+      for (const point of rect) {
+        expect(point[0]).to.be.greaterThanOrEqual(-HALF_SIZE)
+        expect(point[0]).to.be.lessThanOrEqual(HALF_SIZE)
+      }
+    })
+
+    test('should return coordinates within the primary world for a centered viewport', () => {
+      const viewport = new Viewport(defaultViewportSize, originCenter, singleWorldScale)
+      const rect = viewport.getProjectedGeoBufferedRectangle(0)
+      for (const point of rect) {
+        expect(point[0]).to.be.greaterThanOrEqual(-HALF_SIZE)
+        expect(point[0]).to.be.lessThanOrEqual(HALF_SIZE)
+      }
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2139,6 +2139,9 @@ importers:
       vite-plugin-no-bundle:
         specifier: ^4.0.0
         version: 4.0.0
+      vitest:
+        specifier: ^4.0.4
+        version: 4.0.15(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/render-wasm: {}
 
@@ -15056,7 +15059,7 @@ snapshots:
 
   '@vitest/expect@4.0.15':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
       '@vitest/spy': 4.0.15
       '@vitest/utils': 4.0.15
@@ -15186,7 +15189,7 @@ snapshots:
       '@vue/shared': 3.5.25
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.8
       source-map-js: 1.2.1
     optional: true
 
@@ -21761,7 +21764,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.8
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21777,7 +21780,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.8
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
  Summary

  - When panning across the anti-meridian (±180° longitude), warped maps would disappear because the renderer only drew a single world copy
  - The WebGL2Renderer now renders multiple world copies, matching how OpenLayers handles world wrapping internally
  - The Viewport computes which world copies are visible (startWorld/endWorld) based on the viewport extent and the projection's world width
  - For each visible world, a translated projection transform is composed and passed to the shader, so the same map geometry is drawn at the correct offset
  - Coordinate wrapping ensures geoRectangle and getProjectedGeoBufferedRectangle always return values within the primary world, so tile fetching and proj4 inverse projections produce valid results
  - World wrapping is only enabled for Web Mercator (+proj=merc); non-wrapping projections default to a single world copy, keeping behavior safe for the viewport projection support in #361

  Files changed

  - packages/render/src/shared/web-mercator.ts (new) — RADIUS and HALF_SIZE constants, computed from the WGS84 sphere radius like OpenLayers
  - packages/render/src/viewport/Viewport.ts — startWorld, endWorld, worldWidth properties; wrapProjectedGeoPoint and projectedGeoPointToGeoPoint helpers
  - packages/render/src/renderers/WebGL2Renderer.ts — getWorldClipTransforms() pre-computes one transform per world copy; render methods loop over worlds
  - packages/render/test/viewport.test.ts (new) — 14 tests covering world offset calculation, coordinate wrapping, and non-Mercator safety
  - packages/render/package.json — added vitest dev dependency and test script