### PR TITLE
remove duplicate annotation fetch in preview worker

### DIFF
--- a/workers/preview/src/shared/warped-map-wasm.ts
+++ b/workers/preview/src/shared/warped-map-wasm.ts
@@ -37,9 +37,6 @@ export async function generateWarpedMapImage(
   }
 
   const annotation = await annotationResponse.json()
-  const annotation = await cachedFetch(annotationUrl).then((response) =>
-    response.json()
-  )
 
   // Parse transformation type
   let transformationType


### PR DESCRIPTION
Fixes a "Cannot redeclare block-scoped variable 'annotation'" error