### PR TITLE
editor-fixes

### DIFF
--- a/apps/editor/src/lib/components/views/Georeference.svelte
+++ b/apps/editor/src/lib/components/views/Georeference.svelte
@@ -387,7 +387,7 @@
           coordinates: resourceTransformer.transformToGeo(resourcePoint)
         })
       } else {
-        addGeoGcpFeature(
+        addResourceGcpFeature(
           {
             id: gcpId,
             index: gcpIndexFromGcpId(gcpId),

--- a/apps/editor/src/lib/components/views/Georeference.svelte
+++ b/apps/editor/src/lib/components/views/Georeference.svelte
@@ -201,11 +201,6 @@
 
     if (geoMap) {
       navPlaceGeoViewport = getNavPlaceViewport(sourceState.navPlace)
-      console.log(
-        'navPlaceGeoViewport',
-        sourceState.navPlace,
-        navPlaceGeoViewport
-      )
       urlGeoViewport = getBboxViewport(urlState.params.bbox)
 
       if (mapsState.activeMap?.gcps) {


### PR DESCRIPTION
This pull request makes minor improvements to the `Georeference.svelte` component by cleaning up debug logging and clarifying a function name.

- Debugging/logging cleanup:
  * Removed a `console.log` statement that printed `navPlaceGeoViewport` for debugging purposes.

- Code clarity:
  * Renamed the function call from `addGeoGcpFeature` to `addResourceGcpFeature` to better reflect its purpose.