### PR TITLE
moved the _allmaps object back to the annotation body

### DIFF
--- a/packages/annotation/src/generator.ts
+++ b/packages/annotation/src/generator.ts
@@ -159,16 +159,17 @@ function generateGeoreferenceAnnotation(
     resourceCrs = georeferencedMap.resourceCrs
   }
 
+  let _allmaps: unknown
+  if ('_allmaps' in georeferencedMap) {
+    _allmaps = georeferencedMap._allmaps
+  }
+
   const body = {
     type: 'FeatureCollection' as const,
     transformation: georeferencedMap.transformation,
     resourceCrs,
-    features: georeferencedMap.gcps.map((gcp) => generateFeature(gcp))
-  }
-
-  let _allmaps: unknown
-  if ('_allmaps' in georeferencedMap) {
-    _allmaps = georeferencedMap._allmaps
+    features: georeferencedMap.gcps.map((gcp) => generateFeature(gcp)),
+    _allmaps
   }
 
   return {
@@ -178,8 +179,7 @@ function generateGeoreferenceAnnotation(
     ...generateDates(georeferencedMap),
     motivation: 'georeferencing' as const,
     target,
-    body,
-    _allmaps
+    body
   }
 }
 

--- a/packages/annotation/src/parser.ts
+++ b/packages/annotation/src/parser.ts
@@ -168,8 +168,8 @@ function getGeoreferencedMap(
   }
 
   let _allmaps: unknown
-  if ('_allmaps' in annotation) {
-    _allmaps = annotation._allmaps
+  if ('_allmaps' in annotation.body) {
+    _allmaps = annotation.body._allmaps
   }
 
   return {

--- a/packages/annotation/src/schemas/annotation/annotation.1.ts
+++ b/packages/annotation/src/schemas/annotation/annotation.1.ts
@@ -97,7 +97,10 @@ export const BodySchema = z.object({
       properties: FeaturePropertiesSchema,
       geometry: PointGeometrySchema
     })
-  )
+  ),
+  // TODO: accept all keys that start with underscore and pass them?
+  // TODO: define proper schema for _allmaps
+  _allmaps: z.unknown().optional()
 })
 
 export const AnnotationSchema = z.object({
@@ -108,10 +111,7 @@ export const AnnotationSchema = z.object({
   created: z.string().datetime().optional(),
   modified: z.string().datetime().optional(),
   target: TargetSchema,
-  body: BodySchema,
-  // TODO: accept all keys that start with underscore and pass them?
-  // TODO: define proper schema for _allmaps
-  _allmaps: z.unknown().optional()
+  body: BodySchema
 })
 
 export const AnnotationPageSchema = z.object({

--- a/packages/annotation/test/format-zod-error.ts
+++ b/packages/annotation/test/format-zod-error.ts
@@ -21,7 +21,7 @@ function formatPath(path: readonly PropertyKey[]) {
     return ''
   }
 
-  return path.reduce((result, segment, index) => {
+  return path.reduce((result: string, segment, index) => {
     if (typeof segment === 'number') {
       return `${result}[${segment}]`
     }
@@ -60,7 +60,7 @@ function getValueAtPath(input: unknown, path: readonly PropertyKey[]) {
       return undefined
     }
 
-    current = (current as Record<string, unknown>)[segment]
+    current = (current as Record<PropertyKey, unknown>)[segment]
   }
 
   return current


### PR DESCRIPTION
This pull request refactors how the `_allmaps` metadata field is handled in georeference annotation objects. The main change is to move `_allmaps` from the top level of the annotation object into the `body` property, aligning with a more consistent schema. The validation schemas and parsing logic are updated to reflect this change, and minor type improvements are made in test utilities.

**Georeference annotation structure changes:**

* Moved the `_allmaps` field from the top level of the annotation object into the `body` property in both the generator and schema definitions, ensuring consistent placement and validation. [[1]](diffhunk://#diff-47d7fe9381ab21464e3bc6a52af786967b8206e18fa829a71ea06311ab68aae6R162-R172) [[2]](diffhunk://#diff-47d7fe9381ab21464e3bc6a52af786967b8206e18fa829a71ea06311ab68aae6L181-R182) [[3]](diffhunk://#diff-ee3f966d359bed9da51d67ffc8df3e8542b3fd386ce93d5afbd7346ea44b351cL100-R103) [[4]](diffhunk://#diff-ee3f966d359bed9da51d67ffc8df3e8542b3fd386ce93d5afbd7346ea44b351cL111-R114)
* Updated the parser logic in `getGeoreferencedMap` to extract `_allmaps` from `annotation.body` instead of the top level, matching the new structure.

**Validation and type improvements:**

* Updated the Zod schema for the annotation body to optionally accept an unknown `_allmaps` field, and removed the top-level `_allmaps` from the annotation schema. [[1]](diffhunk://#diff-ee3f966d359bed9da51d67ffc8df3e8542b3fd386ce93d5afbd7346ea44b351cL100-R103) [[2]](diffhunk://#diff-ee3f966d359bed9da51d67ffc8df3e8542b3fd386ce93d5afbd7346ea44b351cL111-R114)
* Improved type safety in test utility functions by specifying types in `formatPath` and `getValueAtPath`. [[1]](diffhunk://#diff-b0cc9e50a79dbc9e4d2ce36963de2c3532207efa63eabdeb71c20175b51f673cL24-R24) [[2]](diffhunk://#diff-b0cc9e50a79dbc9e4d2ce36963de2c3532207efa63eabdeb71c20175b51f673cL63-R63)