### PR TITLE
Develop into main

### DIFF
--- a/apis/annotations/src/routes/maps.ts
+++ b/apis/annotations/src/routes/maps.ts
@@ -2,7 +2,7 @@ import { t } from 'elysia'
 
 import { generateRandomId } from '@allmaps/id/sync'
 import { queryMaps } from '@allmaps/api-shared/db'
-import type { ContainedBy, IntersectsWith } from '@allmaps/api-shared/types'
+import { normalizeMapsQueryParams } from '@allmaps/api-shared'
 
 import { createElysia, RegExpRoute } from '../elysia.js'
 
@@ -18,18 +18,6 @@ const mapsQuerySchema = t.Object({
   maxArea: t.Optional(t.Number())
 })
 
-function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
-  if (intersects && (intersects.length === 2 || intersects.length === 4)) {
-    return intersects as IntersectsWith
-  }
-}
-
-function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
-  if (containedBy && containedBy.length === 4) {
-    return containedBy as ContainedBy
-  }
-}
-
 const mapRoute = new RegExpRoute<{
   mapId: string
   checksum?: string
@@ -39,21 +27,11 @@ const mapRoute = new RegExpRoute<{
 export const maps = createElysia({ name: 'maps' })
   .get(
     '/maps',
-    ({ request, env, db, query }) =>
+    ({ request, env, db }) =>
       queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
-        {
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
-        },
+        normalizeMapsQueryParams(request),
         {
           id: request.url,
           format: 'annotation',
@@ -71,21 +49,11 @@ export const maps = createElysia({ name: 'maps' })
   )
   .get(
     '/maps.geojson',
-    ({ request, env, db, query }) =>
+    ({ request, env, db }) =>
       queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
-        {
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
-        },
+        normalizeMapsQueryParams(request),
         {
           id: request.url,
           format: 'geojson',
@@ -103,19 +71,12 @@ export const maps = createElysia({ name: 'maps' })
   )
   .get(
     '/maps/random',
-    ({ env, db, query }) => {
+    ({ request, env, db }) => {
       const randomMapId = generateRandomId()
 
       // Try maps with id > randomMapId first, fall back to id <= randomMapId
       const baseQuery = {
-        intersectsWith: parseIntersects(query.intersects),
-        containedBy: parseContainedBy(query.containedBy),
-        imageServiceDomain: query.imageServiceDomain,
-        manifestDomain: query.manifestDomain,
-        minScale: query.minScale,
-        maxScale: query.maxScale,
-        minArea: query.minArea,
-        maxArea: query.maxArea,
+        ...normalizeMapsQueryParams(request),
         limit: 1
       }
       const responseOptions = {

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -2,9 +2,7 @@ import { t } from 'elysia'
 
 import { createElysia } from '../elysia.js'
 import { queryCanvases, queryMaps } from '@allmaps/api-shared/db'
-import { queryRandom } from '@allmaps/api-shared'
-
-import type { ContainedBy, IntersectsWith } from '@allmaps/api-shared/types'
+import { normalizeMapsQueryParams, queryRandom } from '@allmaps/api-shared'
 
 const canvasesQuerySchema = t.Object({
   georeferenced: t.Optional(t.Boolean()),
@@ -22,18 +20,6 @@ const mapsQuerySchema = t.Object({
   minArea: t.Optional(t.Number()),
   maxArea: t.Optional(t.Number())
 })
-
-function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
-  if (intersects && (intersects.length === 2 || intersects.length === 4)) {
-    return intersects as IntersectsWith
-  }
-}
-
-function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
-  if (containedBy && containedBy.length === 4) {
-    return containedBy as ContainedBy
-  }
-}
 
 export const canvases = createElysia({ name: 'canvases' })
   .get(
@@ -88,21 +74,13 @@ export const canvases = createElysia({ name: 'canvases' })
   )
   .get(
     '/canvases/:canvasId/maps',
-    ({ env, db, params, query }) =>
+    ({ request, env, db, params }) =>
       queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
-          canvasId: params.canvasId,
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
+          ...normalizeMapsQueryParams(request),
+          canvasId: params.canvasId
         },
         { format: 'map', expectRows: true, singular: false }
       ),

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -8,8 +8,7 @@ import {
   queryMaps,
   queryImageChecksums
 } from '@allmaps/api-shared/db'
-import { queryRandom } from '@allmaps/api-shared'
-import type { ContainedBy, IntersectsWith } from '@allmaps/api-shared/types'
+import { normalizeMapsQueryParams, queryRandom } from '@allmaps/api-shared'
 
 const imagesQuerySchema = t.Object({
   georeferenced: t.Optional(t.Boolean()),
@@ -27,18 +26,6 @@ const mapsQuerySchema = t.Object({
   minArea: t.Optional(t.Number()),
   maxArea: t.Optional(t.Number())
 })
-
-function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
-  if (intersects && (intersects.length === 2 || intersects.length === 4)) {
-    return intersects as IntersectsWith
-  }
-}
-
-function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
-  if (containedBy && containedBy.length === 4) {
-    return containedBy as ContainedBy
-  }
-}
 
 export const images = createElysia({ name: 'images' })
   .get(
@@ -99,21 +86,13 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/:imageId/maps',
-    ({ env, db, params, query }) =>
+    ({ request, env, db, params }) =>
       queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
-          imageId: params.imageId,
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
+          ...normalizeMapsQueryParams(request),
+          imageId: params.imageId
         },
         { format: 'map', expectRows: true, singular: false }
       ),
@@ -125,21 +104,13 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/:imageId/maps.geojson',
-    ({ env, db, params, query }) =>
+    ({ request, env, db, params }) =>
       queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
-          imageId: params.imageId,
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
+          ...normalizeMapsQueryParams(request),
+          imageId: params.imageId
         },
         { format: 'geojson', expectRows: true, singular: false }
       ),

--- a/apis/rest/src/routes/manifests.ts
+++ b/apis/rest/src/routes/manifests.ts
@@ -6,8 +6,7 @@ import {
   createManifest,
   queryMaps
 } from '@allmaps/api-shared/db'
-import { queryRandom } from '@allmaps/api-shared'
-import type { ContainedBy, IntersectsWith } from '@allmaps/api-shared/types'
+import { normalizeMapsQueryParams, queryRandom } from '@allmaps/api-shared'
 
 const mapsQuerySchema = t.Object({
   limit: t.Optional(t.Number()),
@@ -20,18 +19,6 @@ const mapsQuerySchema = t.Object({
   minArea: t.Optional(t.Number()),
   maxArea: t.Optional(t.Number())
 })
-
-function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
-  if (intersects && (intersects.length === 2 || intersects.length === 4)) {
-    return intersects as IntersectsWith
-  }
-}
-
-function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
-  if (containedBy && containedBy.length === 4) {
-    return containedBy as ContainedBy
-  }
-}
 
 export const manifests = createElysia({ name: 'manifests' })
   .get(
@@ -92,21 +79,13 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .get(
     '/manifests/:manifestId/maps',
-    async ({ env, db, params, query }) => {
+    async ({ request, env, db, params }) => {
       return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
-          manifestId: params.manifestId,
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
+          ...normalizeMapsQueryParams(request),
+          manifestId: params.manifestId
         },
         { format: 'map', expectRows: true, singular: false }
       )
@@ -122,21 +101,13 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .get(
     '/manifests/:manifestId/maps.geojson',
-    async ({ env, db, params, query }) => {
+    async ({ request, env, db, params }) => {
       return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
-          manifestId: params.manifestId,
-          intersectsWith: parseIntersects(query.intersects),
-          containedBy: parseContainedBy(query.containedBy),
-          limit: query.limit,
-          imageServiceDomain: query.imageServiceDomain,
-          manifestDomain: query.manifestDomain,
-          minScale: query.minScale,
-          maxScale: query.maxScale,
-          minArea: query.minArea,
-          maxArea: query.maxArea
+          ...normalizeMapsQueryParams(request),
+          manifestId: params.manifestId
         },
         { format: 'geojson', expectRows: true, singular: false }
       )

--- a/apis/rest/src/routes/maps.ts
+++ b/apis/rest/src/routes/maps.ts
@@ -1,12 +1,11 @@
 import { t } from 'elysia'
 
 import { queryMaps, queryChecksums } from '@allmaps/api-shared/db'
+import { normalizeMapsQueryParams } from '@allmaps/api-shared'
 
 import { RegExpRoute, createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { adminDetail } from '../openapi.js'
 import type { BetterAuthContext } from '@allmaps/db/auth'
-
-import type { ContainedBy, IntersectsWith } from '@allmaps/api-shared/types'
 
 const mapsQuerySchema = t.Object({
   limit: t.Optional(t.Number()),
@@ -20,25 +19,13 @@ const mapsQuerySchema = t.Object({
   maxArea: t.Optional(t.Number())
 })
 
-function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
-  if (intersects && (intersects.length === 2 || intersects.length === 4)) {
-    return intersects as IntersectsWith
-  }
-}
-
-function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
-  if (containedBy && containedBy.length === 4) {
-    return containedBy as ContainedBy
-  }
-}
-
 const mapRoute = new RegExpRoute<{
   mapId: string
   version?: string
   ext?: string
 }>(
   'mapId',
-  /^(?<mapId>[0-9a-f]{16})(\@(?<version>[0-9a-f]{16}))?(\.(?<ext>geojson))?$/
+  /^(?<mapId>[0-9a-f]{16})(@(?<version>[0-9a-f]{16}))?(\.(?<ext>geojson))?$/
 )
 
 async function callLive(liveBaseUrl: string, path: string, body: unknown) {
@@ -64,21 +51,11 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/maps',
-      ({ env, db, query }) =>
+      ({ request, env, db }) =>
         queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          {
-            intersectsWith: parseIntersects(query.intersects),
-            containedBy: parseContainedBy(query.containedBy),
-            limit: query.limit,
-            imageServiceDomain: query.imageServiceDomain,
-            manifestDomain: query.manifestDomain,
-            minScale: query.minScale,
-            maxScale: query.maxScale,
-            minArea: query.minArea,
-            maxArea: query.maxArea
-          },
+          normalizeMapsQueryParams(request),
           { format: 'map', expectRows: false, singular: false }
         ),
       {
@@ -88,21 +65,11 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     )
     .get(
       '/maps.geojson',
-      ({ env, db, query }) =>
+      ({ request, env, db }) =>
         queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          {
-            intersectsWith: parseIntersects(query.intersects),
-            containedBy: parseContainedBy(query.containedBy),
-            limit: query.limit,
-            imageServiceDomain: query.imageServiceDomain,
-            manifestDomain: query.manifestDomain,
-            minScale: query.minScale,
-            maxScale: query.maxScale,
-            minArea: query.minArea,
-            maxArea: query.maxArea
-          },
+          normalizeMapsQueryParams(request),
           { format: 'geojson', expectRows: false, singular: false }
         ),
       {

--- a/packages/annotation/src/generator.ts
+++ b/packages/annotation/src/generator.ts
@@ -159,16 +159,17 @@ function generateGeoreferenceAnnotation(
     resourceCrs = georeferencedMap.resourceCrs
   }
 
+  let _allmaps: unknown
+  if ('_allmaps' in georeferencedMap) {
+    _allmaps = georeferencedMap._allmaps
+  }
+
   const body = {
     type: 'FeatureCollection' as const,
     transformation: georeferencedMap.transformation,
     resourceCrs,
-    features: georeferencedMap.gcps.map((gcp) => generateFeature(gcp))
-  }
-
-  let _allmaps: unknown
-  if ('_allmaps' in georeferencedMap) {
-    _allmaps = georeferencedMap._allmaps
+    features: georeferencedMap.gcps.map((gcp) => generateFeature(gcp)),
+    _allmaps
   }
 
   return {
@@ -178,8 +179,7 @@ function generateGeoreferenceAnnotation(
     ...generateDates(georeferencedMap),
     motivation: 'georeferencing' as const,
     target,
-    body,
-    _allmaps
+    body
   }
 }
 

--- a/packages/annotation/src/parser.ts
+++ b/packages/annotation/src/parser.ts
@@ -168,8 +168,8 @@ function getGeoreferencedMap(
   }
 
   let _allmaps: unknown
-  if ('_allmaps' in annotation) {
-    _allmaps = annotation._allmaps
+  if ('_allmaps' in annotation.body) {
+    _allmaps = annotation.body._allmaps
   }
 
   return {

--- a/packages/annotation/src/schemas/annotation/annotation.1.ts
+++ b/packages/annotation/src/schemas/annotation/annotation.1.ts
@@ -97,7 +97,10 @@ export const BodySchema = z.object({
       properties: FeaturePropertiesSchema,
       geometry: PointGeometrySchema
     })
-  )
+  ),
+  // TODO: accept all keys that start with underscore and pass them?
+  // TODO: define proper schema for _allmaps
+  _allmaps: z.unknown().optional()
 })
 
 export const AnnotationSchema = z.object({
@@ -108,10 +111,7 @@ export const AnnotationSchema = z.object({
   created: z.string().datetime().optional(),
   modified: z.string().datetime().optional(),
   target: TargetSchema,
-  body: BodySchema,
-  // TODO: accept all keys that start with underscore and pass them?
-  // TODO: define proper schema for _allmaps
-  _allmaps: z.unknown().optional()
+  body: BodySchema
 })
 
 export const AnnotationPageSchema = z.object({

--- a/packages/annotation/test/format-zod-error.ts
+++ b/packages/annotation/test/format-zod-error.ts
@@ -21,7 +21,7 @@ function formatPath(path: readonly PropertyKey[]) {
     return ''
   }
 
-  return path.reduce((result, segment, index) => {
+  return path.reduce((result: string, segment, index) => {
     if (typeof segment === 'number') {
       return `${result}[${segment}]`
     }
@@ -60,7 +60,7 @@ function getValueAtPath(input: unknown, path: readonly PropertyKey[]) {
       return undefined
     }
 
-    current = (current as Record<string, unknown>)[segment]
+    current = (current as Record<PropertyKey, unknown>)[segment]
   }
 
   return current

--- a/packages/api-shared/src/index.ts
+++ b/packages/api-shared/src/index.ts
@@ -9,4 +9,5 @@ export {
 
 export { ResponseError } from './shared/errors.js'
 export { DEFAULT_LIMIT, MAX_LIMIT, clampLimit } from './shared/limits.js'
+export { normalizeMapsQueryParams } from './shared/query-params.js'
 export { queryRandom } from './shared/random.js'

--- a/packages/api-shared/src/shared/query-params.ts
+++ b/packages/api-shared/src/shared/query-params.ts
@@ -1,0 +1,116 @@
+import { ResponseError } from './errors.js'
+
+import type { ContainedBy, IntersectsWith, MapsQueryParams } from '../types.js'
+
+type MapsQueryParamName =
+  | 'limit'
+  | 'imageServiceDomain'
+  | 'manifestDomain'
+  | 'intersectsWith'
+  | 'containedBy'
+  | 'minScale'
+  | 'maxScale'
+  | 'minArea'
+  | 'maxArea'
+
+const mapsQueryParamNames: Record<string, MapsQueryParamName> = {
+  limit: 'limit',
+  imageservicedomain: 'imageServiceDomain',
+  manifestdomain: 'manifestDomain',
+  intersects: 'intersectsWith',
+  containedby: 'containedBy',
+  minscale: 'minScale',
+  maxscale: 'maxScale',
+  minarea: 'minArea',
+  maxarea: 'maxArea'
+}
+
+function parseNumberParam(name: string, value: string) {
+  const number = Number(value)
+
+  if (!Number.isFinite(number)) {
+    throw new ResponseError(`Invalid query parameter ${name}: ${value}`, 400)
+  }
+
+  return number
+}
+
+function parseNumberArrayParam(name: string, values: string[]) {
+  return values
+    .flatMap((value) => value.split(','))
+    .filter((value) => value !== '')
+    .map((value) => parseNumberParam(name, value))
+}
+
+function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
+  if (intersects && (intersects.length === 2 || intersects.length === 4)) {
+    return intersects as IntersectsWith
+  }
+}
+
+function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
+  if (containedBy && containedBy.length === 4) {
+    return containedBy as ContainedBy
+  }
+}
+
+export function normalizeMapsQueryParams(
+  request: Request
+): Partial<MapsQueryParams> {
+  const searchParams = new URL(request.url).searchParams
+  const valuesByName = new Map<MapsQueryParamName, string[]>()
+
+  for (const [key, value] of searchParams) {
+    const name = mapsQueryParamNames[key.toLowerCase()]
+
+    if (name) {
+      valuesByName.set(name, [...(valuesByName.get(name) ?? []), value])
+    }
+  }
+
+  const params: Partial<MapsQueryParams> = {}
+
+  for (const [name, values] of valuesByName) {
+    const lastValue = values.at(-1)
+
+    if (lastValue === undefined) {
+      continue
+    }
+
+    switch (name) {
+      case 'limit':
+        params.limit = parseNumberParam(name, lastValue)
+        break
+      case 'imageServiceDomain':
+        params.imageServiceDomain = lastValue
+        break
+      case 'manifestDomain':
+        params.manifestDomain = lastValue
+        break
+      case 'intersectsWith':
+        params.intersectsWith = parseIntersects(
+          parseNumberArrayParam('intersects', values)
+        )
+        break
+      case 'containedBy':
+        params.containedBy = parseContainedBy(
+          parseNumberArrayParam('containedBy', values)
+        )
+        break
+      case 'minScale':
+        params.minScale = parseNumberParam(name, lastValue)
+        break
+      case 'maxScale':
+        params.maxScale = parseNumberParam(name, lastValue)
+        break
+      case 'minArea':
+        params.minArea = parseNumberParam(name, lastValue)
+        break
+      case 'maxArea':
+        params.maxArea = parseNumberParam(name, lastValue)
+        break
+    }
+  }
+
+  return params
+}


### PR DESCRIPTION
This pull request refactors how query parameters are handled in API route handlers and improves support for the `_allmaps` property in annotation schemas and serialization. The main changes are the removal of custom parsing functions for map query parameters in favor of a centralized normalization function, and the adjustment of annotation handling to include and validate the optional `_allmaps` field in annotation bodies.

**API Query Parameter Refactoring:**

* Replaced custom `parseIntersects` and `parseContainedBy` functions with a unified `normalizeMapsQueryParams` utility in all relevant API route handlers (`maps`, `canvases`, `images`, `manifests`), simplifying and centralizing query parameter processing. [[1]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL5-R5) [[2]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL21-L32) [[3]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL42-R34) [[4]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL74-R56) [[5]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL106-R79) [[6]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L5-R5) [[7]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L26-L37) [[8]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L91-R83) [[9]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L11-R11) [[10]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L31-L42) [[11]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L102-R95) [[12]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L128-R113) [[13]](diffhunk://#diff-197fb975c4aa4d550ec214e856837e3acd6d8f5df29030230f186e93b9eb4c7eL9-R9) [[14]](diffhunk://#diff-197fb975c4aa4d550ec214e856837e3acd6d8f5df29030230f186e93b9eb4c7eL24-L35) [[15]](diffhunk://#diff-197fb975c4aa4d550ec214e856837e3acd6d8f5df29030230f186e93b9eb4c7eL95-R88) [[16]](diffhunk://#diff-197fb975c4aa4d550ec214e856837e3acd6d8f5df29030230f186e93b9eb4c7eL125-R110) [[17]](diffhunk://#diff-85849544d7284cdf03c57a8c56f6267290b660b7930704242af61a20437afb23R4-L10) [[18]](diffhunk://#diff-85849544d7284cdf03c57a8c56f6267290b660b7930704242af61a20437afb23L23-R28) [[19]](diffhunk://#diff-85849544d7284cdf03c57a8c56f6267290b660b7930704242af61a20437afb23L67-R58) [[20]](diffhunk://#diff-85849544d7284cdf03c57a8c56f6267290b660b7930704242af61a20437afb23L91-R72)

**Annotation Schema and Serialization Improvements:**

* Updated the annotation body schema to accept an optional `_allmaps` field, and removed support for `_allmaps` at the top annotation level. [[1]](diffhunk://#diff-ee3f966d359bed9da51d67ffc8df3e8542b3fd386ce93d5afbd7346ea44b351cL100-R103) [[2]](diffhunk://#diff-ee3f966d359bed9da51d67ffc8df3e8542b3fd386ce93d5afbd7346ea44b351cL111-R114)
* Modified the annotation generator and parser to consistently include and extract the `_allmaps` field from the body of annotations, ensuring round-trip support. [[1]](diffhunk://#diff-47d7fe9381ab21464e3bc6a52af786967b8206e18fa829a71ea06311ab68aae6R162-R172) [[2]](diffhunk://#diff-47d7fe9381ab21464e3bc6a52af786967b8206e18fa829a71ea06311ab68aae6L181-R182) [[3]](diffhunk://#diff-14d89715925abf4d3cc353a11fada61809aed9406ff471b8f23faf0dcb463db4L171-R172)

**TypeScript Type Improvements:**

* Fixed type assertions in test utilities for better compatibility with property keys and path traversal. [[1]](diffhunk://#diff-b0cc9e50a79dbc9e4d2ce36963de2c3532207efa63eabdeb71c20175b51f673cL24-R24) [[2]](diffhunk://#diff-b0cc9e50a79dbc9e4d2ce36963de2c3532207efa63eabdeb71c20175b51f673cL63-R63)