### PR TITLE
api-fixes

### DIFF
--- a/apis/annotations/src/app.ts
+++ b/apis/annotations/src/app.ts
@@ -77,6 +77,7 @@ export function createApp(env: AnnotationsEnv, betterAuth: BetterAuthContext) {
       '/',
       async ({ env, query, set }) => {
         if (query.url) {
+          setCacheControl(set, 'public-medium')
           const iiifData = await fetchJson(query.url)
           const parsedIiif = IIIF.parse(iiifData)
           const id = await generateId(parsedIiif.uri)
@@ -96,6 +97,7 @@ export function createApp(env: AnnotationsEnv, betterAuth: BetterAuthContext) {
           return
         }
 
+        setCacheControl(set, 'public-short')
         return {
           name: 'Allmaps Annotations API',
           version: packageJson.version,

--- a/apis/annotations/src/routes/canvases.ts
+++ b/apis/annotations/src/routes/canvases.ts
@@ -1,13 +1,15 @@
 import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia } from '../elysia.js'
 
 export const canvases = createElysia({ name: 'canvases' }).get(
   '/canvases/:canvasId',
-  ({ request, env, db, params }) =>
-    queryMaps(
+  ({ request, env, db, params, set }) => {
+    setCacheControl(set, 'public-medium')
+    return queryMaps(
       env.PUBLIC_ANNOTATIONS_BASE_URL,
       db,
       { canvasId: params.canvasId },
@@ -17,7 +19,8 @@ export const canvases = createElysia({ name: 'canvases' }).get(
         expectRows: true,
         singular: false
       }
-    ),
+    )
+  },
   {
     params: t.Object({ canvasId: t.String() }),
     detail: {

--- a/apis/annotations/src/routes/images.ts
+++ b/apis/annotations/src/routes/images.ts
@@ -1,4 +1,5 @@
 import { queryMaps } from '@allmaps/api-shared/db'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia, RegExpRoute } from '../elysia.js'
 
@@ -14,8 +15,9 @@ const imageRoute = new RegExpRoute<{
 
 export const images = createElysia({ name: 'images' }).get(
   `/images/${imageRoute.path}`,
-  ({ request, env, db, params }) => {
+  ({ request, env, db, params, set }) => {
     const { imageId, imageChecksum, ext } = imageRoute.parse(params)
+    setCacheControl(set, imageChecksum ? 'public-immutable' : 'public-medium')
     const format = ext === 'geojson' ? 'geojson' : 'annotation'
     return queryMaps(
       env.PUBLIC_ANNOTATIONS_BASE_URL,

--- a/apis/annotations/src/routes/lists.ts
+++ b/apis/annotations/src/routes/lists.ts
@@ -50,7 +50,8 @@ export function createListsRoutes(
   })
     .get(
       '/@:username/lists',
-      async ({ db, env, params, request }) => {
+      async ({ db, env, params, request, set }) => {
+        setCacheControl(set, 'private-no-store')
         await assertCanAccessUserLists(
           betterAuth,
           request.headers,
@@ -75,7 +76,8 @@ export function createListsRoutes(
     )
     .get(
       '/@:username/lists/:listId',
-      async ({ db, env, params, request }) => {
+      async ({ db, env, params, request, set }) => {
+        setCacheControl(set, 'private-no-store')
         await assertCanAccessUserLists(
           betterAuth,
           request.headers,
@@ -102,7 +104,8 @@ export function createListsRoutes(
     )
     .get(
       '/@:username/lists/:listId/georeference-annotations',
-      async ({ db, env, params, request }) => {
+      async ({ db, env, params, request, set }) => {
+        setCacheControl(set, 'private-no-store')
         await assertCanAccessUserLists(
           betterAuth,
           request.headers,

--- a/apis/annotations/src/routes/manifests.ts
+++ b/apis/annotations/src/routes/manifests.ts
@@ -1,13 +1,15 @@
 import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia } from '../elysia.js'
 
 export const manifests = createElysia({ name: 'manifests' }).get(
   '/manifests/:manifestId',
-  ({ request, env, db, params }) =>
-    queryMaps(
+  ({ request, env, db, params, set }) => {
+    setCacheControl(set, 'public-medium')
+    return queryMaps(
       env.PUBLIC_ANNOTATIONS_BASE_URL,
       db,
       { manifestId: params.manifestId },
@@ -17,7 +19,8 @@ export const manifests = createElysia({ name: 'manifests' }).get(
         expectRows: true,
         singular: false
       }
-    ),
+    )
+  },
   {
     params: t.Object({ manifestId: t.String() }),
     detail: {

--- a/apis/annotations/src/routes/maps.ts
+++ b/apis/annotations/src/routes/maps.ts
@@ -2,7 +2,7 @@ import { t } from 'elysia'
 
 import { generateRandomId } from '@allmaps/id/sync'
 import { queryMaps } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams } from '@allmaps/api-shared'
+import { normalizeMapsQueryParams, setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia, RegExpRoute } from '../elysia.js'
 
@@ -27,8 +27,9 @@ const mapRoute = new RegExpRoute<{
 export const maps = createElysia({ name: 'maps' })
   .get(
     '/maps',
-    ({ request, env, db }) =>
-      queryMaps(
+    ({ request, env, db, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         normalizeMapsQueryParams(request),
@@ -38,7 +39,8 @@ export const maps = createElysia({ name: 'maps' })
           expectRows: false,
           singular: false
         }
-      ),
+      )
+    },
     {
       query: mapsQuerySchema,
       detail: {
@@ -49,8 +51,9 @@ export const maps = createElysia({ name: 'maps' })
   )
   .get(
     '/maps.geojson',
-    ({ request, env, db }) =>
-      queryMaps(
+    ({ request, env, db, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         normalizeMapsQueryParams(request),
@@ -60,7 +63,8 @@ export const maps = createElysia({ name: 'maps' })
           expectRows: false,
           singular: false
         }
-      ),
+      )
+    },
     {
       query: mapsQuerySchema,
       detail: {
@@ -71,7 +75,8 @@ export const maps = createElysia({ name: 'maps' })
   )
   .get(
     '/maps/random',
-    ({ request, env, db }) => {
+    ({ request, env, db, set }) => {
+      setCacheControl(set, 'private-no-store')
       const randomMapId = generateRandomId()
 
       // Try maps with id > randomMapId first, fall back to id <= randomMapId
@@ -111,8 +116,9 @@ export const maps = createElysia({ name: 'maps' })
   )
   .get(
     `/maps/${mapRoute.path}`,
-    ({ env, db, params }) => {
+    ({ env, db, params, set }) => {
       const { mapId, checksum, ext } = mapRoute.parse(params)
+      setCacheControl(set, checksum ? 'public-immutable' : 'public-medium')
       const format = ext === 'geojson' ? 'geojson' : 'annotation'
       return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,

--- a/apis/annotations/src/routes/organizations.ts
+++ b/apis/annotations/src/routes/organizations.ts
@@ -1,4 +1,4 @@
-import { ResponseError } from '@allmaps/api-shared'
+import { ResponseError, setCacheControl } from '@allmaps/api-shared'
 import { queryMaps, queryOrganizationBySlug } from '@allmaps/api-shared/db'
 
 import { createElysia, RegExpRoute } from '../elysia.js'
@@ -13,7 +13,8 @@ const organizationRoute = new RegExpRoute<{
 
 export const organizations = createElysia({ name: 'organizations' }).get(
   `/organizations/${organizationRoute.path}`,
-  async ({ request, env, db, params }) => {
+  async ({ request, env, db, params, set }) => {
+    setCacheControl(set, 'public-medium')
     const { organizationSlug, ext } = organizationRoute.parse(params)
     const organization = await queryOrganizationBySlug(
       db,

--- a/apis/rest/src/app.ts
+++ b/apis/rest/src/app.ts
@@ -96,8 +96,9 @@ export function createApp(env: RestEnv, betterAuth: BetterAuthContext) {
     .use(projections)
     .get(
       '/',
-      async ({ env, getOptionalSession }) => {
+      async ({ env, getOptionalSession, set }) => {
         const session = await getOptionalSession()
+        setCacheControl(set, session ? 'private-no-store' : 'public-short')
 
         let user
 

--- a/apis/rest/src/routes/auth.ts
+++ b/apis/rest/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { t } from 'elysia'
 
+import { setCacheControl } from '@allmaps/api-shared'
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import { createAuth } from '@allmaps/db/auth'
 import { createElysia, createBetterAuthPlugin, error } from '../elysia.js'
@@ -29,8 +30,10 @@ export function createAuthRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/users',
-      ({ db, env, query }) =>
-        queryUsers(db, env.PUBLIC_REST_BASE_URL, query.limit, true),
+      ({ db, env, query, set }) => {
+        setCacheControl(set, 'private-no-store')
+        return queryUsers(db, env.PUBLIC_REST_BASE_URL, query.limit, true)
+      },
       {
         admin: true,
         query: t.Object({ limit: t.Optional(t.Number()) }),
@@ -43,7 +46,8 @@ export function createAuthRoutes(
     )
     .get(
       '/users/:userId',
-      async ({ db, env, params }) => {
+      async ({ db, env, params, set }) => {
+        setCacheControl(set, 'private-no-store')
         const user = await queryUserWithOrganizationsById(
           db,
           env.PUBLIC_REST_BASE_URL,
@@ -68,12 +72,14 @@ export function createAuthRoutes(
     )
     .get(
       '/organizations/:organizationId/users',
-      ({ db, env, params }) =>
-        queryOrganizationMembersById(
+      ({ db, env, params, set }) => {
+        setCacheControl(set, 'private-no-store')
+        return queryOrganizationMembersById(
           db,
           env.PUBLIC_REST_BASE_URL,
           params.organizationId
-        ),
+        )
+      },
       {
         admin: true,
         params: t.Object({ organizationId: t.String() }),
@@ -86,7 +92,8 @@ export function createAuthRoutes(
     )
     .post(
       '/organizations/:organizationId/users',
-      async ({ db, body, params }) => {
+      async ({ db, body, params, set }) => {
+        setCacheControl(set, 'private-no-store')
         const { email, role } = body
 
         const organization = await queryAdminOrganizationById(
@@ -126,7 +133,8 @@ export function createAuthRoutes(
     )
     .delete(
       '/organizations/:organizationId/users/:userId',
-      async ({ db, env, params, request }) => {
+      async ({ db, env, params, request, set }) => {
+        setCacheControl(set, 'private-no-store')
         const { organizationId, userId } = params
 
         const organization = await queryAdminOrganizationById(
@@ -162,7 +170,8 @@ export function createAuthRoutes(
     )
     .patch(
       '/organizations/:organizationId/users/:userId',
-      async ({ db, body, params, request }) => {
+      async ({ db, body, params, request, set }) => {
+        setCacheControl(set, 'private-no-store')
         const { organizationId, userId } = params
         const { role } = body
 

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -2,7 +2,11 @@ import { t } from 'elysia'
 
 import { createElysia } from '../elysia.js'
 import { queryCanvases, queryMaps } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams, queryRandom } from '@allmaps/api-shared'
+import {
+  normalizeMapsQueryParams,
+  queryRandom,
+  setCacheControl
+} from '@allmaps/api-shared'
 
 const canvasesQuerySchema = t.Object({
   georeferenced: t.Optional(t.Boolean()),
@@ -24,13 +28,15 @@ const mapsQuerySchema = t.Object({
 export const canvases = createElysia({ name: 'canvases' })
   .get(
     '/canvases',
-    async ({ db, env, query }) =>
-      queryCanvases(
+    async ({ db, env, query, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryCanvases(
         env.PUBLIC_REST_BASE_URL,
         db,
         { georeferenced: query.georeferenced, limit: query.limit },
         { expectRows: false, singular: false }
-      ),
+      )
+    },
     {
       query: canvasesQuerySchema,
       detail: { summary: 'Get IIIF Canvases', tags: ['Canvases'] }
@@ -38,8 +44,9 @@ export const canvases = createElysia({ name: 'canvases' })
   )
   .get(
     '/canvases/random',
-    async ({ db, env, query }) =>
-      queryRandom((op, randomId) =>
+    async ({ db, env, query, set }) => {
+      setCacheControl(set, 'private-no-store')
+      return queryRandom((op, randomId) =>
         queryCanvases(
           env.PUBLIC_REST_BASE_URL,
           db,
@@ -51,7 +58,8 @@ export const canvases = createElysia({ name: 'canvases' })
           },
           { expectRows: true, singular: false }
         )
-      ),
+      )
+    },
     {
       query: canvasesQuerySchema,
       detail: { summary: 'Get a random IIIF Canvas', tags: ['Canvases'] }
@@ -59,13 +67,15 @@ export const canvases = createElysia({ name: 'canvases' })
   )
   .get(
     '/canvases/:canvasId',
-    async ({ db, env, params, query }) =>
-      queryCanvases(
+    async ({ db, env, params, query, set }) => {
+      setCacheControl(set, 'public-medium')
+      return queryCanvases(
         env.PUBLIC_REST_BASE_URL,
         db,
         { canvasId: params.canvasId, georeferenced: query.georeferenced },
         { expectRows: true, singular: true }
-      ),
+      )
+    },
     {
       params: t.Object({ canvasId: t.String() }),
       query: t.Object({ georeferenced: t.Optional(t.Boolean()) }),
@@ -74,8 +84,9 @@ export const canvases = createElysia({ name: 'canvases' })
   )
   .get(
     '/canvases/:canvasId/maps',
-    ({ request, env, db, params }) =>
-      queryMaps(
+    ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
@@ -83,7 +94,8 @@ export const canvases = createElysia({ name: 'canvases' })
           canvasId: params.canvasId
         },
         { format: 'map', expectRows: true, singular: false }
-      ),
+      )
+    },
     {
       params: t.Object({ canvasId: t.String() }),
       query: mapsQuerySchema,

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -30,13 +30,15 @@ const mapsQuerySchema = t.Object({
 export const images = createElysia({ name: 'images' })
   .get(
     '/images',
-    ({ env, db, query }) =>
-      queryImages(
+    ({ env, db, query, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryImages(
         env.PUBLIC_REST_BASE_URL,
         db,
         { georeferenced: query.georeferenced, limit: query.limit },
         { expectRows: false, singular: false }
-      ),
+      )
+    },
     {
       query: imagesQuerySchema,
       detail: { summary: 'Get IIIF Images', tags: ['Images'] }
@@ -44,8 +46,9 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/random',
-    async ({ env, db, query }) =>
-      queryRandom((op, randomId) =>
+    async ({ env, db, query, set }) => {
+      setCacheControl(set, 'private-no-store')
+      return queryRandom((op, randomId) =>
         queryImages(
           env.PUBLIC_REST_BASE_URL,
           db,
@@ -57,7 +60,8 @@ export const images = createElysia({ name: 'images' })
           },
           { expectRows: true, singular: false }
         )
-      ),
+      )
+    },
     {
       query: imagesQuerySchema,
       detail: { summary: 'Get a random IIIF Image', tags: ['Images'] }
@@ -65,8 +69,10 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/:imageId',
-    ({ env, db, params }) =>
-      queryImage(env.PUBLIC_REST_BASE_URL, db, params.imageId),
+    ({ env, db, params, set }) => {
+      setCacheControl(set, 'public-medium')
+      return queryImage(env.PUBLIC_REST_BASE_URL, db, params.imageId)
+    },
     {
       params: t.Object({ imageId: t.String() }),
       detail: { summary: 'Get a single IIIF Image', tags: ['Images'] }
@@ -74,8 +80,14 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/:imageId/versions',
-    ({ env, db, params }) =>
-      queryImageChecksums(env.PUBLIC_ANNOTATIONS_BASE_URL, db, params.imageId),
+    ({ env, db, params, set }) => {
+      setCacheControl(set, 'public-medium')
+      return queryImageChecksums(
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
+        db,
+        params.imageId
+      )
+    },
     {
       params: t.Object({ imageId: t.String() }),
       detail: {
@@ -86,8 +98,9 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/:imageId/maps',
-    ({ request, env, db, params }) =>
-      queryMaps(
+    ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
@@ -95,7 +108,8 @@ export const images = createElysia({ name: 'images' })
           imageId: params.imageId
         },
         { format: 'map', expectRows: true, singular: false }
-      ),
+      )
+    },
     {
       params: t.Object({ imageId: t.String() }),
       query: mapsQuerySchema,
@@ -104,8 +118,9 @@ export const images = createElysia({ name: 'images' })
   )
   .get(
     '/images/:imageId/maps.geojson',
-    ({ request, env, db, params }) =>
-      queryMaps(
+    ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
         {
@@ -113,7 +128,8 @@ export const images = createElysia({ name: 'images' })
           imageId: params.imageId
         },
         { format: 'geojson', expectRows: true, singular: false }
-      ),
+      )
+    },
     {
       params: t.Object({ imageId: t.String() }),
       query: mapsQuerySchema,
@@ -125,7 +141,10 @@ export const images = createElysia({ name: 'images' })
   )
   .put(
     '/images/:imageId',
-    ({ db, params, body }) => createImage(db, params.imageId, body.url),
+    ({ db, params, body, set }) => {
+      setCacheControl(set, 'private-no-store')
+      return createImage(db, params.imageId, body.url)
+    },
     {
       params: t.Object({ imageId: t.String() }),
       body: t.Object({ url: t.String() }),

--- a/apis/rest/src/routes/lists.ts
+++ b/apis/rest/src/routes/lists.ts
@@ -10,6 +10,7 @@ import {
   deleteListItem,
   deleteUserList
 } from '@allmaps/api-shared/db'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { authenticatedDetail } from '../openapi.js'
@@ -33,17 +34,27 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     name: 'lists-routes'
   })
     .use(createBetterAuthPlugin(betterAuth))
-    .get('/lists', ({ db, user }) => queryUserLists(db, getUserId(user)), {
-      auth: true,
-      detail: {
-        summary: 'Get current user lists',
-        tags: ['Lists'],
-        ...authenticatedDetail
+    .get(
+      '/lists',
+      ({ db, user, set }) => {
+        setCacheControl(set, 'private-no-store')
+        return queryUserLists(db, getUserId(user))
+      },
+      {
+        auth: true,
+        detail: {
+          summary: 'Get current user lists',
+          tags: ['Lists'],
+          ...authenticatedDetail
+        }
       }
-    })
+    )
     .post(
       '/lists',
-      ({ db, user, body }) => createUserList(db, getUserId(user), body.name),
+      ({ db, user, body, set }) => {
+        setCacheControl(set, 'private-no-store')
+        return createUserList(db, getUserId(user), body.name)
+      },
       {
         auth: true,
         body: t.Object({
@@ -58,7 +69,8 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     )
     .get(
       '/lists/:listId',
-      async ({ db, user, params, status }) => {
+      async ({ db, user, params, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const result = await queryListWithItems(
           db,
           getUserId(user),
@@ -83,7 +95,8 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     )
     .patch(
       '/lists/:listId',
-      async ({ db, user, params, body, status }) => {
+      async ({ db, user, params, body, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const name = body.name.trim()
         if (!name) {
           return status(400, { error: 'Name is required' })
@@ -114,7 +127,8 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     )
     .post(
       '/lists/:listId/items',
-      async ({ db, user, params, body, status }) => {
+      async ({ db, user, params, body, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const userId = getUserId(user)
         const list = await queryListWithItems(db, userId, params.listId)
 
@@ -147,7 +161,8 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     )
     .post(
       '/lists/:listId/items/url',
-      async ({ db, user, params, body, status }) => {
+      async ({ db, user, params, body, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const userId = getUserId(user)
         const list = await queryListWithItems(db, userId, params.listId)
 
@@ -179,7 +194,8 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     )
     .delete(
       '/lists/:listId/items',
-      async ({ db, user, params, query, status }) => {
+      async ({ db, user, params, query, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const userId = getUserId(user)
         const list = await queryListWithItems(db, userId, params.listId)
 
@@ -215,7 +231,8 @@ export function createListsRoutes(betterAuth: BetterAuthContext) {
     )
     .delete(
       '/lists/:listId',
-      async ({ db, user, params, status }) => {
+      async ({ db, user, params, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const result = await deleteUserList(db, getUserId(user), params.listId)
         if (!result.success) {
           return status(result.status, { error: result.error })

--- a/apis/rest/src/routes/manifests.ts
+++ b/apis/rest/src/routes/manifests.ts
@@ -6,7 +6,11 @@ import {
   createManifest,
   queryMaps
 } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams, queryRandom } from '@allmaps/api-shared'
+import {
+  normalizeMapsQueryParams,
+  queryRandom,
+  setCacheControl
+} from '@allmaps/api-shared'
 
 const mapsQuerySchema = t.Object({
   limit: t.Optional(t.Number()),
@@ -23,13 +27,15 @@ const mapsQuerySchema = t.Object({
 export const manifests = createElysia({ name: 'manifests' })
   .get(
     '/manifests',
-    async ({ db, env, query }) =>
-      queryManifests(
+    async ({ db, env, query, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryManifests(
         env.PUBLIC_REST_BASE_URL,
         db,
         { georeferenced: query.georeferenced, limit: query.limit },
         { expectRows: false, singular: false }
-      ),
+      )
+    },
     {
       query: t.Object({
         georeferenced: t.Optional(t.Boolean()),
@@ -40,8 +46,9 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .get(
     '/manifests/random',
-    async ({ db, env, query }) =>
-      queryRandom((op, randomId) =>
+    async ({ db, env, query, set }) => {
+      setCacheControl(set, 'private-no-store')
+      return queryRandom((op, randomId) =>
         queryManifests(
           env.PUBLIC_REST_BASE_URL,
           db,
@@ -53,7 +60,8 @@ export const manifests = createElysia({ name: 'manifests' })
           },
           { expectRows: true, singular: false }
         )
-      ),
+      )
+    },
     {
       query: t.Object({
         georeferenced: t.Optional(t.Boolean()),
@@ -64,13 +72,15 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .get(
     '/manifests/:manifestId',
-    async ({ db, params, env, query }) =>
-      queryManifests(
+    async ({ db, params, env, query, set }) => {
+      setCacheControl(set, 'public-medium')
+      return queryManifests(
         env.PUBLIC_REST_BASE_URL,
         db,
         { manifestId: params.manifestId, georeferenced: query.georeferenced },
         { expectRows: true, singular: true }
-      ),
+      )
+    },
     {
       params: t.Object({ manifestId: t.String() }),
       query: t.Object({ georeferenced: t.Optional(t.Boolean()) }),
@@ -79,7 +89,8 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .get(
     '/manifests/:manifestId/maps',
-    async ({ request, env, db, params }) => {
+    async ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-short')
       return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
@@ -101,7 +112,8 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .get(
     '/manifests/:manifestId/maps.geojson',
-    async ({ request, env, db, params }) => {
+    async ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-short')
       return queryMaps(
         env.PUBLIC_ANNOTATIONS_BASE_URL,
         db,
@@ -123,7 +135,8 @@ export const manifests = createElysia({ name: 'manifests' })
   )
   .put(
     '/manifests/:manifestId',
-    async ({ db, params, body }) => {
+    async ({ db, params, body, set }) => {
+      setCacheControl(set, 'private-no-store')
       // TODO: add checkseum and check checksum matches manifest at URL before creating/updating
       return createManifest(db, params.manifestId, body.url)
     },

--- a/apis/rest/src/routes/maps.ts
+++ b/apis/rest/src/routes/maps.ts
@@ -1,7 +1,7 @@
 import { t } from 'elysia'
 
 import { queryMaps, queryChecksums } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams } from '@allmaps/api-shared'
+import { normalizeMapsQueryParams, setCacheControl } from '@allmaps/api-shared'
 
 import { RegExpRoute, createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { adminDetail } from '../openapi.js'
@@ -51,13 +51,15 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/maps',
-      ({ request, env, db }) =>
-        queryMaps(
+      ({ request, env, db, set }) => {
+        setCacheControl(set, 'public-short')
+        return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           normalizeMapsQueryParams(request),
           { format: 'map', expectRows: false, singular: false }
-        ),
+        )
+      },
       {
         query: mapsQuerySchema,
         detail: { summary: 'Get maps', tags: ['Maps'] }
@@ -65,13 +67,15 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     )
     .get(
       '/maps.geojson',
-      ({ request, env, db }) =>
-        queryMaps(
+      ({ request, env, db, set }) => {
+        setCacheControl(set, 'public-short')
+        return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           normalizeMapsQueryParams(request),
           { format: 'geojson', expectRows: false, singular: false }
-        ),
+        )
+      },
       {
         query: mapsQuerySchema,
         detail: { summary: 'Get maps as GeoJSON', tags: ['Maps'] }
@@ -79,7 +83,8 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     )
     .post(
       '/maps',
-      async ({ env, body }) => {
+      async ({ env, body, set }) => {
+        setCacheControl(set, 'private-no-store')
         return callLive(env.PUBLIC_LIVE_BASE_URL, '/maps', body)
       },
       {
@@ -93,8 +98,10 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     )
     .get(
       '/maps/:mapId/versions',
-      ({ env, db, params }) =>
-        queryChecksums(env.PUBLIC_ANNOTATIONS_BASE_URL, db, params.mapId),
+      ({ env, db, params, set }) => {
+        setCacheControl(set, 'public-medium')
+        return queryChecksums(env.PUBLIC_ANNOTATIONS_BASE_URL, db, params.mapId)
+      },
       {
         params: t.Object({ mapId: t.String() }),
         detail: {
@@ -106,13 +113,14 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
 
     .get(
       `/maps/${mapRoute.path}`,
-      ({ env, db, params }) => {
-        const { mapId, ext } = mapRoute.parse(params)
+      ({ env, db, params, set }) => {
+        const { mapId, version, ext } = mapRoute.parse(params)
+        setCacheControl(set, version ? 'public-immutable' : 'public-medium')
         const format = ext === 'geojson' ? 'geojson' : 'map'
         return queryMaps(
           env.PUBLIC_REST_BASE_URL,
           db,
-          { mapId },
+          { mapId, ...(version ? { checksum: version } : {}) },
           { format, expectRows: true, singular: true }
         )
       },
@@ -127,7 +135,8 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     )
     .patch(
       '/maps/:mapId',
-      async ({ env, params, body }) => {
+      async ({ env, params, body, set }) => {
+        setCacheControl(set, 'private-no-store')
         return callLive(env.PUBLIC_LIVE_BASE_URL, `/maps/${params.mapId}`, body)
       },
       {

--- a/apis/rest/src/routes/organizations.ts
+++ b/apis/rest/src/routes/organizations.ts
@@ -5,6 +5,7 @@ import { createAuth } from '@allmaps/db/auth'
 import type { RestEnv } from '@allmaps/env/rest'
 import {
   normalizeOrganizationSlug,
+  normalizeHomepageUrl,
   normalizeDomains,
   listOrganizations,
   listOrganizationsWithUsers,
@@ -177,11 +178,27 @@ export function createOrganizationsRoutes(
           })
         }
 
+        const validHomepage =
+          body.homepage === undefined || body.homepage === null
+            ? body.homepage
+            : normalizeHomepageUrl(body.homepage)
+
+        if (
+          body.homepage !== undefined &&
+          body.homepage !== null &&
+          !validHomepage
+        ) {
+          return status(400, {
+            error: 'Invalid homepage. Use an absolute http(s) URL.'
+          })
+        }
+
         const organization = await createOrganization(
           db,
           env.PUBLIC_REST_BASE_URL,
           {
             ...body,
+            homepage: validHomepage,
             slug: validSlug,
             domains: validDomains
           }
@@ -226,6 +243,21 @@ export function createOrganizationsRoutes(
           })
         }
 
+        const validHomepage =
+          body.homepage === undefined || body.homepage === null
+            ? body.homepage
+            : normalizeHomepageUrl(body.homepage)
+
+        if (
+          body.homepage !== undefined &&
+          body.homepage !== null &&
+          !validHomepage
+        ) {
+          return status(400, {
+            error: 'Invalid homepage. Use an absolute http(s) URL.'
+          })
+        }
+
         const { domains, ...patch } = body
         const organization = await updateOrganization(
           db,
@@ -233,6 +265,7 @@ export function createOrganizationsRoutes(
           params.organizationId,
           {
             ...patch,
+            ...(body.homepage !== undefined ? { homepage: validHomepage } : {}),
             ...(validSlug !== undefined ? { slug: validSlug } : {})
           },
           domains !== undefined ? validDomains : undefined

--- a/apis/rest/src/routes/organizations.ts
+++ b/apis/rest/src/routes/organizations.ts
@@ -18,6 +18,7 @@ import {
   queryCanvases,
   queryManifests
 } from '@allmaps/api-shared/db'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { adminDetail } from '../openapi.js'
@@ -48,9 +49,10 @@ export function createOrganizationsRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/organizations',
-      async ({ db, env, query, request }) => {
+      async ({ db, env, query, request, set }) => {
         const session = await auth.api.getSession({ headers: request.headers })
         if (session?.user.role === 'admin') {
+          setCacheControl(set, 'private-no-store')
           return listOrganizationsWithUsers(
             db,
             env.PUBLIC_REST_BASE_URL,
@@ -58,6 +60,7 @@ export function createOrganizationsRoutes(
           )
         }
 
+        setCacheControl(set, 'public-medium')
         return listOrganizations(db, env.PUBLIC_REST_BASE_URL, query.limit)
       },
       {
@@ -67,17 +70,19 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId',
-      async ({ db, env, params, status, request }) => {
+      async ({ db, env, params, status, request, set }) => {
         const session = await auth.api.getSession({ headers: request.headers })
         let organization
 
         if (session?.user.role === 'admin') {
+          setCacheControl(set, 'private-no-store')
           organization = await queryOrganizationByIdWithUsers(
             db,
             env.PUBLIC_REST_BASE_URL,
             params.organizationId
           )
         } else {
+          setCacheControl(set, 'public-medium')
           organization = await queryOrganizationById(
             db,
             env.PUBLIC_REST_BASE_URL,
@@ -98,8 +103,9 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId/manifests',
-      ({ env, db, params, query }) =>
-        queryManifests(
+      ({ env, db, params, query, set }) => {
+        setCacheControl(set, 'public-short')
+        return queryManifests(
           env.PUBLIC_REST_BASE_URL,
           db,
           {
@@ -108,7 +114,8 @@ export function createOrganizationsRoutes(
             limit: query.limit
           },
           { expectRows: false, singular: false }
-        ),
+        )
+      },
       {
         query: querySchema,
         detail: {
@@ -119,8 +126,9 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId/canvases',
-      ({ env, db, params, query }) =>
-        queryCanvases(
+      ({ env, db, params, query, set }) => {
+        setCacheControl(set, 'public-short')
+        return queryCanvases(
           env.PUBLIC_REST_BASE_URL,
           db,
           {
@@ -129,7 +137,8 @@ export function createOrganizationsRoutes(
             limit: query.limit
           },
           { expectRows: false, singular: false }
-        ),
+        )
+      },
       {
         query: querySchema,
         detail: {
@@ -140,8 +149,9 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId/images',
-      ({ env, db, params, query }) =>
-        queryImages(
+      ({ env, db, params, query, set }) => {
+        setCacheControl(set, 'public-short')
+        return queryImages(
           env.PUBLIC_REST_BASE_URL,
           db,
           {
@@ -150,7 +160,8 @@ export function createOrganizationsRoutes(
             limit: query.limit
           },
           { expectRows: false, singular: false }
-        ),
+        )
+      },
       {
         query: querySchema,
         detail: {
@@ -161,7 +172,8 @@ export function createOrganizationsRoutes(
     )
     .post(
       '/organizations',
-      async ({ db, env, body, status }) => {
+      async ({ db, env, body, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const validSlug = normalizeOrganizationSlug(body.slug)
         if (!validSlug) {
           return status(400, {
@@ -222,7 +234,8 @@ export function createOrganizationsRoutes(
     )
     .patch(
       '/organizations/:organizationId',
-      async ({ db, env, params, body, status }) => {
+      async ({ db, env, params, body, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const validSlug =
           body.slug === undefined
             ? undefined
@@ -289,7 +302,8 @@ export function createOrganizationsRoutes(
     )
     .delete(
       '/organizations/:organizationId',
-      async ({ db, params, status }) => {
+      async ({ db, params, status, set }) => {
+        setCacheControl(set, 'private-no-store')
         const deleted = await deleteOrganization(db, params.organizationId)
 
         if (!deleted) {

--- a/apis/rest/src/routes/projections.ts
+++ b/apis/rest/src/routes/projections.ts
@@ -3,6 +3,7 @@ import {
   getProjectionsByDbId,
   getProjectionWithFullId
 } from '@allmaps/api-shared/projections'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia, error } from '../elysia.js'
 
@@ -10,11 +11,15 @@ export const projections = createElysia({ name: 'projections' })
   .decorate('projectionsById', getProjectionsByDbId())
   .get(
     '/projections',
-    ({ env, projectionsById }) =>
-      // TODO: can't we cache this instead of recomputing it on every request?
-      Object.values(projectionsById).map((projection) =>
-        getProjectionWithFullId(projection, env.PUBLIC_REST_BASE_URL)
-      ),
+    ({ env, projectionsById, set }) => {
+      setCacheControl(set, 'public-long')
+      return (
+        // TODO: can't we cache this instead of recomputing it on every request?
+        Object.values(projectionsById).map((projection) =>
+          getProjectionWithFullId(projection, env.PUBLIC_REST_BASE_URL)
+        )
+      )
+    },
     {
       detail: {
         summary: 'Get all projections',
@@ -24,7 +29,8 @@ export const projections = createElysia({ name: 'projections' })
   )
   .get(
     '/projections/:projectionId',
-    ({ env, params, projectionsById }) => {
+    ({ env, params, projectionsById, set }) => {
+      setCacheControl(set, 'public-long')
       const projection = getProjectionByDbId(
         projectionsById,
         params.projectionId

--- a/packages/api-shared/src/db.ts
+++ b/packages/api-shared/src/db.ts
@@ -43,6 +43,7 @@ export {
 
 export {
   normalizeOrganizationSlug,
+  normalizeHomepageUrl,
   normalizeDomain,
   normalizeDomains,
   fromDbOrganization,

--- a/packages/api-shared/src/elysia.ts
+++ b/packages/api-shared/src/elysia.ts
@@ -15,8 +15,10 @@ export {
 export { error, redirect } from './elysia/response.js'
 export { handleApiError } from './elysia/errors.js'
 export { RegExpRoute } from './elysia/routes.js'
+export { setCacheControl } from './elysia/cache.js'
 
 export type { DecoratedElysia } from './elysia/app.js'
+export type { CacheControlPreset } from './elysia/cache.js'
 
 export function createTagsSorter(
   tags: Array<{ name: string }>,

--- a/packages/api-shared/src/elysia/auth.ts
+++ b/packages/api-shared/src/elysia/auth.ts
@@ -4,6 +4,7 @@ import type { BetterAuthContext } from '@allmaps/db/auth'
 
 import { ResponseError } from '../shared/errors.js'
 import { createElysia } from './app.js'
+import { setCacheControl } from './cache.js'
 import { redirect } from './response.js'
 
 function copySetCookieHeader(
@@ -72,6 +73,7 @@ export function createBetterAuthRoutes<TEnv = Record<string, unknown>>(
     .get(
       '/login/github',
       async ({ set, query }) => {
+        setCacheControl(set, 'private-no-store')
         const callbackURL = query.returnTo ?? '/'
 
         const result = await auth.handler(
@@ -109,6 +111,7 @@ export function createBetterAuthRoutes<TEnv = Record<string, unknown>>(
     .get(
       '/logout',
       async ({ request, set, query }) => {
+        setCacheControl(set, 'private-no-store')
         const callbackURL = query.returnTo ?? '/'
 
         const signOutResult = await auth.handler(

--- a/packages/api-shared/src/elysia/cache.ts
+++ b/packages/api-shared/src/elysia/cache.ts
@@ -1,0 +1,26 @@
+type HeaderValue = string | number
+
+export type CacheControlPreset =
+  | 'private-no-store'
+  | 'public-short'
+  | 'public-medium'
+  | 'public-long'
+  | 'public-immutable'
+
+const cacheControlByPreset: Record<CacheControlPreset, string> = {
+  'private-no-store': 'private, no-store',
+  'public-short':
+    'public, max-age=30, s-maxage=120, stale-while-revalidate=600',
+  'public-medium':
+    'public, max-age=60, s-maxage=300, stale-while-revalidate=3600',
+  'public-long':
+    'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
+  'public-immutable': 'public, immutable, max-age=31536000, s-maxage=31536000'
+}
+
+export function setCacheControl(
+  set: { headers: Record<string, HeaderValue> },
+  preset: CacheControlPreset
+) {
+  set.headers['Cache-Control'] = cacheControlByPreset[preset]
+}

--- a/packages/api-shared/src/elysia/index.ts
+++ b/packages/api-shared/src/elysia/index.ts
@@ -2,5 +2,7 @@ export { createElysia } from './app.js'
 export { error, redirect } from './response.js'
 export { handleApiError } from './errors.js'
 export { RegExpRoute } from './routes.js'
+export { setCacheControl } from './cache.js'
 
 export type { DecoratedElysia } from './app.js'
+export type { CacheControlPreset } from './cache.js'

--- a/packages/api-shared/src/index.ts
+++ b/packages/api-shared/src/index.ts
@@ -11,3 +11,6 @@ export { ResponseError } from './shared/errors.js'
 export { DEFAULT_LIMIT, MAX_LIMIT, clampLimit } from './shared/limits.js'
 export { normalizeMapsQueryParams } from './shared/query-params.js'
 export { queryRandom } from './shared/random.js'
+export { setCacheControl } from './elysia/cache.js'
+
+export type { CacheControlPreset } from './elysia/cache.js'

--- a/packages/api-shared/src/queries/auth.ts
+++ b/packages/api-shared/src/queries/auth.ts
@@ -45,10 +45,7 @@ function fromDbOrganizationMembership(
   }
 }
 
-export function fromDbUser(
-  restBaseUrl: string,
-  user: DbUser
-) {
+export function fromDbUser(restBaseUrl: string, user: DbUser) {
   return {
     id: `${restBaseUrl}/users/${user.id}`,
     name: user.fullName,
@@ -151,7 +148,11 @@ export async function queryAllOrganizationUsers(db: Db, restBaseUrl: string) {
 
   const usersByOrganizationId: Record<
     string,
-    { role: string; createdAt: Date; user: { id: string; name: string; email: string } }[]
+    {
+      role: string
+      createdAt: Date
+      user: { id: string; name: string; email: string }
+    }[]
   > = {}
 
   for (const row of rows) {

--- a/packages/api-shared/src/queries/organizations.ts
+++ b/packages/api-shared/src/queries/organizations.ts
@@ -83,6 +83,24 @@ export function normalizeOrganizationSlug(value: string): string | undefined {
   return /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/.test(slug) ? slug : undefined
 }
 
+export function normalizeHomepageUrl(value: string): string | undefined {
+  const homepage = value.trim()
+
+  if (!homepage) {
+    return
+  }
+
+  try {
+    const url = new URL(homepage)
+
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.toString()
+    }
+  } catch {
+    return
+  }
+}
+
 export function normalizeDomains(domains: string[] | undefined) {
   if (domains === undefined) {
     return {


### PR DESCRIPTION
This pull request introduces consistent HTTP caching strategies across all API endpoints in both the `annotations` and `rest` services. By adding the `setCacheControl` function to each route, the code now explicitly sets cache-control headers based on the type of resource and access pattern, improving client and CDN caching behavior and overall API performance.

**Caching Policy Integration**

* Added `setCacheControl` calls to all major API routes in `apis/annotations` and `apis/rest`, specifying appropriate policies such as `'public-short'`, `'public-medium'`, `'public-immutable'`, and `'private-no-store'` depending on the endpoint and resource sensitivity. [[1]](diffhunk://#diff-bc0a48fd934b3a8fd154b0a00d1618b41204b50597ebcdf6300f3796864057b6R80) [[2]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84R4-R12) [[3]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215R2) [[4]](diffhunk://#diff-6970b7677ac617016dd1af880307df6389aa7fa926bea54e20cb097096139dc8L53-R54) [[5]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69R4-R12) [[6]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL5-R5) [[7]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L1-R1) [[8]](diffhunk://#diff-1dcc728aea3f23b0f0c211d094dd07d6245513dc92b56285780e268fbc827cf0L99-R101) [[9]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281R3) [[10]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L5-R9)

**Annotations API Route Updates**

* Updated all `canvases`, `images`, `lists`, `manifests`, `maps`, and `organizations` endpoints to include cache-control headers, with more restrictive policies for user-specific or random endpoints and more permissive policies for static or public resources. [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84R4-R12) [[2]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215L17-R20) [[3]](diffhunk://#diff-6970b7677ac617016dd1af880307df6389aa7fa926bea54e20cb097096139dc8L53-R54) [[4]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69L20-R23) [[5]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL30-R32) [[6]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL52-R56) [[7]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL74-R79) [[8]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL114-R121) [[9]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L16-R17)

**Rest API Route Updates**

* Applied similar cache-control strategies to all `canvases`, `auth`, and root endpoints, ensuring private data is never cached and public data is cached appropriately. [[1]](diffhunk://#diff-1dcc728aea3f23b0f0c211d094dd07d6245513dc92b56285780e268fbc827cf0L99-R101) [[2]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281L32-R36) [[3]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281L46-R50) [[4]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281L71-R82) [[5]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281L89-R96) [[6]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281L129-R137) [[7]](diffhunk://#diff-294b56271d7c55525dcefb4e98ccaa50c80a282aed12991a29a84945a332f281L165-R174) [[8]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L27-R49) [[9]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L54-R78) [[10]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L77-R98)

**Code Consistency and Maintainability**

* Standardized the route handler signatures to accept the `set` parameter, and ensured `setCacheControl` is always called before returning a response. [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84L20-R23) [[2]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69L20-R23) [[3]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL41-R43) [[4]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL63-R67) [[5]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L54-R78) [[6]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L77-R98)

These changes make caching behavior explicit and predictable, which will help with debugging, testing, and future maintenance.