### PR TITLE
Added GeoJSON route for canvases, and added missing imports/functions for cache headers

### DIFF
--- a/apis/annotations/src/app.ts
+++ b/apis/annotations/src/app.ts
@@ -6,6 +6,7 @@ import { openapi } from '@elysiajs/openapi'
 import { IIIF } from '@allmaps/iiif-parser'
 import { fetchJson } from '@allmaps/stdlib'
 import { generateId } from '@allmaps/id'
+import { setCacheControl } from '@allmaps/api-shared'
 
 import {
   createElysia,

--- a/apis/annotations/src/routes/lists.ts
+++ b/apis/annotations/src/routes/lists.ts
@@ -1,6 +1,6 @@
 import { t } from 'elysia'
 
-import { ResponseError } from '@allmaps/api-shared'
+import { ResponseError, setCacheControl } from '@allmaps/api-shared'
 import {
   queryLists,
   queryList,

--- a/apis/rest/src/app.ts
+++ b/apis/rest/src/app.ts
@@ -1,6 +1,8 @@
 import { cors } from '@elysiajs/cors'
 import { openapi } from '@elysiajs/openapi'
 
+import { setCacheControl } from '@allmaps/api-shared'
+
 import {
   createElysia,
   error,

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -105,3 +105,26 @@ export const canvases = createElysia({ name: 'canvases' })
       }
     }
   )
+  .get(
+    '/canvases/:canvasId/maps.geojson',
+    ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-short')
+      return queryMaps(
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
+        db,
+        {
+          ...normalizeMapsQueryParams(request),
+          canvasId: params.canvasId
+        },
+        { format: 'geojson', expectRows: true, singular: false }
+      )
+    },
+    {
+      params: t.Object({ canvasId: t.String() }),
+      query: mapsQuerySchema,
+      detail: {
+        summary: 'Get maps for a single IIIF Canvas as GeoJSON',
+        tags: ['Canvases']
+      }
+    }
+  )

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -8,7 +8,11 @@ import {
   queryMaps,
   queryImageChecksums
 } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams, queryRandom } from '@allmaps/api-shared'
+import {
+  normalizeMapsQueryParams,
+  queryRandom,
+  setCacheControl
+} from '@allmaps/api-shared'
 
 const imagesQuerySchema = t.Object({
   georeferenced: t.Optional(t.Boolean()),


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve maps for a single IIIF Canvas as GeoJSON and standardizes cache control across the API by importing and using the `setCacheControl` utility in multiple files. The changes improve API consistency and performance by ensuring proper caching headers.

### New Feature

* Added a new GET endpoint `/canvases/:canvasId/maps.geojson` in `canvases.ts` to fetch maps for a specific IIIF Canvas in GeoJSON format, with appropriate cache control headers.

### Caching Improvements

* Imported and prepared to use the `setCacheControl` utility from `@allmaps/api-shared` in `app.ts` files for both the annotations and rest APIs, as well as in relevant route files (`lists.ts`, `images.ts`). This ensures consistent and configurable cache headers throughout the API. [[1]](diffhunk://#diff-bc0a48fd934b3a8fd154b0a00d1618b41204b50597ebcdf6300f3796864057b6R9) [[2]](diffhunk://#diff-1dcc728aea3f23b0f0c211d094dd07d6245513dc92b56285780e268fbc827cf0R4-R5) [[3]](diffhunk://#diff-6970b7677ac617016dd1af880307df6389aa7fa926bea54e20cb097096139dc8L3-R3) [[4]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L11-R15)