### PR TITLE
Filter maps by date modified

### DIFF
--- a/apis/annotations/src/routes/maps.ts
+++ b/apis/annotations/src/routes/maps.ts
@@ -15,7 +15,9 @@ const mapsQuerySchema = t.Object({
   minScale: t.Optional(t.Number()),
   maxScale: t.Optional(t.Number()),
   minArea: t.Optional(t.Number()),
-  maxArea: t.Optional(t.Number())
+  maxArea: t.Optional(t.Number()),
+  modifiedAfter: t.Optional(t.String()),
+  modifiedBefore: t.Optional(t.String())
 })
 
 const mapRoute = new RegExpRoute<{

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -22,7 +22,9 @@ const mapsQuerySchema = t.Object({
   minScale: t.Optional(t.Number()),
   maxScale: t.Optional(t.Number()),
   minArea: t.Optional(t.Number()),
-  maxArea: t.Optional(t.Number())
+  maxArea: t.Optional(t.Number()),
+  modifiedAfter: t.Optional(t.String()),
+  modifiedBefore: t.Optional(t.String())
 })
 
 export const canvases = createElysia({ name: 'canvases' })

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -28,7 +28,9 @@ const mapsQuerySchema = t.Object({
   minScale: t.Optional(t.Number()),
   maxScale: t.Optional(t.Number()),
   minArea: t.Optional(t.Number()),
-  maxArea: t.Optional(t.Number())
+  maxArea: t.Optional(t.Number()),
+  modifiedAfter: t.Optional(t.String()),
+  modifiedBefore: t.Optional(t.String())
 })
 
 export const images = createElysia({ name: 'images' })

--- a/apis/rest/src/routes/manifests.ts
+++ b/apis/rest/src/routes/manifests.ts
@@ -21,7 +21,9 @@ const mapsQuerySchema = t.Object({
   minScale: t.Optional(t.Number()),
   maxScale: t.Optional(t.Number()),
   minArea: t.Optional(t.Number()),
-  maxArea: t.Optional(t.Number())
+  maxArea: t.Optional(t.Number()),
+  modifiedAfter: t.Optional(t.String()),
+  modifiedBefore: t.Optional(t.String())
 })
 
 export const manifests = createElysia({ name: 'manifests' })

--- a/apis/rest/src/routes/maps.ts
+++ b/apis/rest/src/routes/maps.ts
@@ -16,7 +16,9 @@ const mapsQuerySchema = t.Object({
   minScale: t.Optional(t.Number()),
   maxScale: t.Optional(t.Number()),
   minArea: t.Optional(t.Number()),
-  maxArea: t.Optional(t.Number())
+  maxArea: t.Optional(t.Number()),
+  modifiedAfter: t.Optional(t.String()),
+  modifiedBefore: t.Optional(t.String())
 })
 
 const mapRoute = new RegExpRoute<{

--- a/packages/api-shared/src/queries/maps.ts
+++ b/packages/api-shared/src/queries/maps.ts
@@ -199,6 +199,12 @@ export async function queryMaps(
           checksum: {
             eq: params.checksum
           }
+        },
+        {
+          updatedAt: {
+            gte: params.modifiedAfter,
+            lte: params.modifiedBefore
+          }
         }
       ],
       image: {

--- a/packages/api-shared/src/shared/query-params.ts
+++ b/packages/api-shared/src/shared/query-params.ts
@@ -12,6 +12,8 @@ type MapsQueryParamName =
   | 'maxScale'
   | 'minArea'
   | 'maxArea'
+  | 'modifiedAfter'
+  | 'modifiedBefore'
 
 const mapsQueryParamNames: Record<string, MapsQueryParamName> = {
   limit: 'limit',
@@ -22,8 +24,14 @@ const mapsQueryParamNames: Record<string, MapsQueryParamName> = {
   minscale: 'minScale',
   maxscale: 'maxScale',
   minarea: 'minArea',
-  maxarea: 'maxArea'
+  maxarea: 'maxArea',
+  modifiedafter: 'modifiedAfter',
+  modifiedbefore: 'modifiedBefore'
 }
+
+const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/
+const utcDateTimePattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
 
 function parseNumberParam(name: string, value: string) {
   const number = Number(value)
@@ -40,6 +48,34 @@ function parseNumberArrayParam(name: string, values: string[]) {
     .flatMap((value) => value.split(','))
     .filter((value) => value !== '')
     .map((value) => parseNumberParam(name, value))
+}
+
+function parseDateParam(
+  name: 'modifiedAfter' | 'modifiedBefore',
+  value: string
+) {
+  const isDateOnly = dateOnlyPattern.test(value)
+  const isUtcDateTime = utcDateTimePattern.test(value)
+
+  if (!isDateOnly && !isUtcDateTime) {
+    throw new ResponseError(`Invalid query parameter ${name}: ${value}`, 400)
+  }
+
+  const normalizedValue = isDateOnly
+    ? `${value}T${name === 'modifiedAfter' ? '00:00:00.000' : '23:59:59.999'}Z`
+    : value
+
+  const date = new Date(normalizedValue)
+
+  if (
+    Number.isNaN(date.getTime()) ||
+    (isDateOnly && date.toISOString().slice(0, 10) !== value) ||
+    (isUtcDateTime && date.toISOString().slice(0, 19) !== value.slice(0, 19))
+  ) {
+    throw new ResponseError(`Invalid query parameter ${name}: ${value}`, 400)
+  }
+
+  return date
 }
 
 function parseIntersects(intersects?: number[]): IntersectsWith | undefined {
@@ -109,7 +145,24 @@ export function normalizeMapsQueryParams(
       case 'maxArea':
         params.maxArea = parseNumberParam(name, lastValue)
         break
+      case 'modifiedAfter':
+        params.modifiedAfter = parseDateParam(name, lastValue)
+        break
+      case 'modifiedBefore':
+        params.modifiedBefore = parseDateParam(name, lastValue)
+        break
     }
+  }
+
+  if (
+    params.modifiedAfter &&
+    params.modifiedBefore &&
+    params.modifiedAfter > params.modifiedBefore
+  ) {
+    throw new ResponseError(
+      'Invalid query parameters: modifiedAfter is later than modifiedBefore',
+      400
+    )
   }
 
   return params

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -29,6 +29,8 @@ export type MapsQueryParams = {
   maxScale: number
   minArea: number
   maxArea: number
+  modifiedAfter: Date
+  modifiedBefore: Date
 }
 
 export type MapsQueryUrlParams = {
@@ -42,6 +44,8 @@ export type MapsQueryUrlParams = {
   maxscale: string
   minarea: string
   maxarea: string
+  modifiedafter: string
+  modifiedbefore: string
 }
 
 export type ExtParams = {


### PR DESCRIPTION
This pull request adds support for filtering map-related API queries by modification date, allowing users to specify `modifiedAfter` and `modifiedBefore` parameters. It introduces these parameters to the relevant query schemas, updates type definitions, and ensures validation and normalization of date inputs.

**API Query Enhancements:**

* Added optional `modifiedAfter` and `modifiedBefore` parameters to the query schemas in `maps`, `canvases`, `images`, and `manifests` routes, enabling date-based filtering. [[1]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL18-R20) [[2]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L25-R27) [[3]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L31-R33) [[4]](diffhunk://#diff-197fb975c4aa4d550ec214e856837e3acd6d8f5df29030230f186e93b9eb4c7eL24-R26) [[5]](diffhunk://#diff-85849544d7284cdf03c57a8c56f6267290b660b7930704242af61a20437afb23L19-R21)

**Type and Parameter Handling:**

* Updated `MapsQueryParams` and `MapsQueryUrlParams` types to include `modifiedAfter` and `modifiedBefore` as `Date` and `string` fields, respectively. [[1]](diffhunk://#diff-2f6e9e903fda249111970b037eb48da4e210d6d3a463dcaca6b8d2a8615bc75bR32-R33) [[2]](diffhunk://#diff-2f6e9e903fda249111970b037eb48da4e210d6d3a463dcaca6b8d2a8615bc75bR47-R48)
* Added `modifiedAfter` and `modifiedBefore` to the list of recognized query parameter names and their normalized forms. [[1]](diffhunk://#diff-7512d61abc482d4b1e08689fb5616b6f9bd50ad405a29e02182fca36d5d1e51dR15-R16) [[2]](diffhunk://#diff-7512d61abc482d4b1e08689fb5616b6f9bd50ad405a29e02182fca36d5d1e51dL25-R35)

**Validation and Normalization:**

* Implemented `parseDateParam` to validate and normalize date and datetime strings for the new parameters, ensuring correct formats and ranges.
* Updated `normalizeMapsQueryParams` to handle the new parameters and added a check to ensure `modifiedAfter` is not later than `modifiedBefore`.

**Query Logic:**

* Modified the `queryMaps` function to filter results based on the `updatedAt` field using the new date parameters.