### PR TITLE
Introduced 4 user foles for setting API limits

### DIFF
--- a/apis/annotations/src/app.ts
+++ b/apis/annotations/src/app.ts
@@ -20,11 +20,11 @@ import {
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
-import { maps } from './routes/maps.js'
-import { images } from './routes/images.js'
-import { canvases } from './routes/canvases.js'
-import { manifests } from './routes/manifests.js'
-import { organizations } from './routes/organizations.js'
+import { createMapsRoutes } from './routes/maps.js'
+import { createImagesRoutes } from './routes/images.js'
+import { createCanvasesRoutes } from './routes/canvases.js'
+import { createManifestsRoutes } from './routes/manifests.js'
+import { createOrganizationsRoutes } from './routes/organizations.js'
 import { createListsRoutes } from './routes/lists.js'
 
 import packageJson from '../package.json' with { type: 'json' }
@@ -68,11 +68,11 @@ export function createApp(env: AnnotationsEnv, betterAuth: BetterAuthContext) {
         }
       })
     )
-    .use(maps)
-    .use(images)
-    .use(canvases)
-    .use(manifests)
-    .use(organizations)
+    .use(createMapsRoutes(env, betterAuth))
+    .use(createImagesRoutes(env, betterAuth))
+    .use(createCanvasesRoutes(env, betterAuth))
+    .use(createManifestsRoutes(env, betterAuth))
+    .use(createOrganizationsRoutes(env, betterAuth))
     .use(createListsRoutes(env, betterAuth))
     .get(
       '/',

--- a/apis/annotations/src/routes/canvases.ts
+++ b/apis/annotations/src/routes/canvases.ts
@@ -2,30 +2,41 @@ import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
 import { setCacheControl } from '@allmaps/api-shared'
+import { createAuth } from '@allmaps/db/auth'
+
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia } from '../elysia.js'
 
-export const canvases = createElysia({ name: 'canvases' }).get(
-  '/canvases/:canvasId',
-  ({ request, env, db, params, set }) => {
-    setCacheControl(set, 'public-medium')
-    return queryMaps(
-      env.PUBLIC_ANNOTATIONS_BASE_URL,
-      db,
-      { canvasId: params.canvasId },
-      {
-        id: request.url,
-        format: 'annotation',
-        expectRows: true,
-        singular: false
+export function createCanvasesRoutes(
+  env: AnnotationsEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  void betterAuth
+
+  return createElysia({ name: 'canvases' }).get(
+    '/canvases/:canvasId',
+    ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-medium')
+      return queryMaps(
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
+        db,
+        { canvasId: params.canvasId },
+        {
+          id: request.url,
+          format: 'annotation',
+          expectRows: true,
+          singular: false
+        }
+      )
+    },
+    {
+      params: t.Object({ canvasId: t.String() }),
+      detail: {
+        summary: 'Get Georeference Annotations for a single IIIF Canvas',
+        tags: ['Canvases']
       }
-    )
-  },
-  {
-    params: t.Object({ canvasId: t.String() }),
-    detail: {
-      summary: 'Get Georeference Annotations for a single IIIF Canvas',
-      tags: ['Canvases']
     }
-  }
-)
+  )
+}

--- a/apis/annotations/src/routes/images.ts
+++ b/apis/annotations/src/routes/images.ts
@@ -1,5 +1,9 @@
 import { queryMaps } from '@allmaps/api-shared/db'
 import { setCacheControl } from '@allmaps/api-shared'
+import { createAuth } from '@allmaps/db/auth'
+
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia, RegExpRoute } from '../elysia.js'
 
@@ -13,28 +17,35 @@ const imageRoute = new RegExpRoute<{
   /^(?<imageId>[0-9a-f]+)(@(?<imageChecksum>[0-9a-f]+))?(\.(?<ext>\w+))?$/
 )
 
-export const images = createElysia({ name: 'images' }).get(
-  `/images/${imageRoute.path}`,
-  ({ request, env, db, params, set }) => {
-    const { imageId, imageChecksum, ext } = imageRoute.parse(params)
-    setCacheControl(set, imageChecksum ? 'public-immutable' : 'public-medium')
-    const format = ext === 'geojson' ? 'geojson' : 'annotation'
-    return queryMaps(
-      env.PUBLIC_ANNOTATIONS_BASE_URL,
-      db,
-      {
-        imageId,
-        ...(imageChecksum ? { imageChecksum } : {})
-      },
-      { id: request.url, format, expectRows: true, singular: false }
-    )
-  },
-  {
-    params: imageRoute.params,
-    detail: {
-      summary:
-        'Get Georeference Annotations for a single IIIF Image (with optional version)',
-      tags: ['Images']
+export function createImagesRoutes(
+  env: AnnotationsEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  void betterAuth
+
+  return createElysia({ name: 'images' }).get(
+    `/images/${imageRoute.path}`,
+    ({ request, env, db, params, set }) => {
+      const { imageId, imageChecksum, ext } = imageRoute.parse(params)
+      setCacheControl(set, imageChecksum ? 'public-immutable' : 'public-medium')
+      const format = ext === 'geojson' ? 'geojson' : 'annotation'
+      return queryMaps(
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
+        db,
+        {
+          imageId,
+          ...(imageChecksum ? { imageChecksum } : {})
+        },
+        { id: request.url, format, expectRows: true, singular: false }
+      )
+    },
+    {
+      params: imageRoute.params,
+      detail: {
+        summary:
+          'Get Georeference Annotations for a single IIIF Image (with optional version)',
+        tags: ['Images']
+      }
     }
-  }
-)
+  )
+}

--- a/apis/annotations/src/routes/manifests.ts
+++ b/apis/annotations/src/routes/manifests.ts
@@ -2,30 +2,41 @@ import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
 import { setCacheControl } from '@allmaps/api-shared'
+import { createAuth } from '@allmaps/db/auth'
+
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia } from '../elysia.js'
 
-export const manifests = createElysia({ name: 'manifests' }).get(
-  '/manifests/:manifestId',
-  ({ request, env, db, params, set }) => {
-    setCacheControl(set, 'public-medium')
-    return queryMaps(
-      env.PUBLIC_ANNOTATIONS_BASE_URL,
-      db,
-      { manifestId: params.manifestId },
-      {
-        id: request.url,
-        format: 'annotation',
-        expectRows: true,
-        singular: false
+export function createManifestsRoutes(
+  env: AnnotationsEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  void betterAuth
+
+  return createElysia({ name: 'manifests' }).get(
+    '/manifests/:manifestId',
+    ({ request, env, db, params, set }) => {
+      setCacheControl(set, 'public-medium')
+      return queryMaps(
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
+        db,
+        { manifestId: params.manifestId },
+        {
+          id: request.url,
+          format: 'annotation',
+          expectRows: true,
+          singular: false
+        }
+      )
+    },
+    {
+      params: t.Object({ manifestId: t.String() }),
+      detail: {
+        summary: 'Get Georeference Annotations for a single IIIF Manifest',
+        tags: ['Manifests']
       }
-    )
-  },
-  {
-    params: t.Object({ manifestId: t.String() }),
-    detail: {
-      summary: 'Get Georeference Annotations for a single IIIF Manifest',
-      tags: ['Manifests']
     }
-  }
-)
+  )
+}

--- a/apis/annotations/src/routes/maps.ts
+++ b/apis/annotations/src/routes/maps.ts
@@ -2,9 +2,17 @@ import { t } from 'elysia'
 
 import { generateRandomId } from '@allmaps/id/sync'
 import { queryMaps } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams, setCacheControl } from '@allmaps/api-shared'
+import {
+  needsElevatedLimitRole,
+  normalizeMapsQueryParams,
+  setCacheControl
+} from '@allmaps/api-shared'
+import { createAuth } from '@allmaps/db/auth'
 
-import { createElysia, RegExpRoute } from '../elysia.js'
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import type { AnnotationsEnv } from '@allmaps/env/annotations'
+
+import { createElysia, createBetterAuthPlugin, RegExpRoute } from '../elysia.js'
 
 const mapsQuerySchema = t.Object({
   limit: t.Optional(t.Number()),
@@ -26,117 +34,138 @@ const mapRoute = new RegExpRoute<{
   ext?: string
 }>('mapId', /^(?<mapId>[0-9a-f]+)(@(?<checksum>[0-9a-f]+))?(\.(?<ext>\w+))?$/)
 
-export const maps = createElysia({ name: 'maps' })
-  .get(
-    '/maps',
-    ({ request, env, db, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        normalizeMapsQueryParams(request),
-        {
-          id: request.url,
-          format: 'annotation',
-          expectRows: false,
-          singular: false
-        }
-      )
-    },
-    {
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get Georeference Annotations',
-        tags: ['Maps']
-      }
-    }
-  )
-  .get(
-    '/maps.geojson',
-    ({ request, env, db, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        normalizeMapsQueryParams(request),
-        {
-          id: request.url,
-          format: 'geojson',
-          expectRows: false,
-          singular: false
-        }
-      )
-    },
-    {
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get Georeference Annotations as GeoJSON',
-        tags: ['Maps']
-      }
-    }
-  )
-  .get(
-    '/maps/random',
-    ({ request, env, db, set }) => {
-      setCacheControl(set, 'private-no-store')
-      const randomMapId = generateRandomId()
-
-      // Try maps with id > randomMapId first, fall back to id <= randomMapId
-      const baseQuery = {
-        ...normalizeMapsQueryParams(request),
-        limit: 1
-      }
-      const responseOptions = {
-        format: 'annotation' as const,
-        expectRows: true,
-        singular: true
-      }
-
-      try {
+export function createMapsRoutes(
+  env: AnnotationsEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  return createElysia({ name: 'maps' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      '/maps',
+      async ({ request, env, db, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          { ...baseQuery, randomMapId, randomMapIdOp: 'gt' },
-          responseOptions
+          { ...queryParams, userRole },
+          {
+            id: request.url,
+            format: 'annotation',
+            expectRows: false,
+            singular: false
+          }
         )
-      } catch {
+      },
+      {
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get Georeference Annotations',
+          tags: ['Maps']
+        }
+      }
+    )
+    .get(
+      '/maps.geojson',
+      async ({ request, env, db, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          { ...baseQuery, randomMapId, randomMapIdOp: 'lte' },
-          responseOptions
+          { ...queryParams, userRole },
+          {
+            id: request.url,
+            format: 'geojson',
+            expectRows: false,
+            singular: false
+          }
         )
+      },
+      {
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get Georeference Annotations as GeoJSON',
+          tags: ['Maps']
+        }
       }
-    },
-    {
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get random Georeference Annotations',
-        tags: ['Maps']
+    )
+    .get(
+      '/maps/random',
+      ({ request, env, db, set }) => {
+        setCacheControl(set, 'private-no-store')
+        const randomMapId = generateRandomId()
+
+        // Try maps with id > randomMapId first, fall back to id <= randomMapId
+        const baseQuery = {
+          ...normalizeMapsQueryParams(request),
+          limit: 1
+        }
+        const responseOptions = {
+          format: 'annotation' as const,
+          expectRows: true,
+          singular: true
+        }
+
+        try {
+          return queryMaps(
+            env.PUBLIC_ANNOTATIONS_BASE_URL,
+            db,
+            { ...baseQuery, randomMapId, randomMapIdOp: 'gt' },
+            responseOptions
+          )
+        } catch {
+          return queryMaps(
+            env.PUBLIC_ANNOTATIONS_BASE_URL,
+            db,
+            { ...baseQuery, randomMapId, randomMapIdOp: 'lte' },
+            responseOptions
+          )
+        }
+      },
+      {
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get random Georeference Annotations',
+          tags: ['Maps']
+        }
       }
-    }
-  )
-  .get(
-    `/maps/${mapRoute.path}`,
-    ({ env, db, params, set }) => {
-      const { mapId, checksum, ext } = mapRoute.parse(params)
-      setCacheControl(set, checksum ? 'public-immutable' : 'public-medium')
-      const format = ext === 'geojson' ? 'geojson' : 'annotation'
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          mapId,
-          ...(checksum ? { checksum } : {})
-        },
-        { format, expectRows: true, singular: true }
-      )
-    },
-    {
-      params: mapRoute.params,
-      detail: {
-        summary: 'Get a single Georeference Annotation (with optional version)',
-        tags: ['Maps']
+    )
+    .get(
+      `/maps/${mapRoute.path}`,
+      ({ env, db, params, set }) => {
+        const { mapId, checksum, ext } = mapRoute.parse(params)
+        setCacheControl(set, checksum ? 'public-immutable' : 'public-medium')
+        const format = ext === 'geojson' ? 'geojson' : 'annotation'
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            mapId,
+            ...(checksum ? { checksum } : {})
+          },
+          { format, expectRows: true, singular: true }
+        )
+      },
+      {
+        params: mapRoute.params,
+        detail: {
+          summary:
+            'Get a single Georeference Annotation (with optional version)',
+          tags: ['Maps']
+        }
       }
-    }
-  )
+    )
+}

--- a/apis/annotations/src/routes/organizations.ts
+++ b/apis/annotations/src/routes/organizations.ts
@@ -1,5 +1,9 @@
 import { ResponseError, setCacheControl } from '@allmaps/api-shared'
 import { queryMaps, queryOrganizationBySlug } from '@allmaps/api-shared/db'
+import { createAuth } from '@allmaps/db/auth'
+
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia, RegExpRoute } from '../elysia.js'
 
@@ -11,36 +15,44 @@ const organizationRoute = new RegExpRoute<{
   /^(?<organizationSlug>[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.(?<ext>\w+))?$/
 )
 
-export const organizations = createElysia({ name: 'organizations' }).get(
-  `/organizations/${organizationRoute.path}`,
-  async ({ request, env, db, params, set }) => {
-    setCacheControl(set, 'public-medium')
-    const { organizationSlug, ext } = organizationRoute.parse(params)
-    const organization = await queryOrganizationBySlug(
-      db,
-      env.PUBLIC_ANNOTATIONS_BASE_URL,
-      organizationSlug
-    )
+export function createOrganizationsRoutes(
+  env: AnnotationsEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  void betterAuth
 
-    if (!organization || !organization.plan) {
-      throw new ResponseError('Organization not found', 404)
-    }
-
-    const format = ext === 'geojson' ? 'geojson' : 'annotation'
-    return queryMaps(
-      env.PUBLIC_ANNOTATIONS_BASE_URL,
-      db,
-      {
+  return createElysia({ name: 'organizations' }).get(
+    `/organizations/${organizationRoute.path}`,
+    async ({ request, env, db, params, set }) => {
+      const { organizationSlug, ext } = organizationRoute.parse(params)
+      const organization = await queryOrganizationBySlug(
+        db,
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
         organizationSlug
-      },
-      { id: request.url, format, expectRows: true, singular: false }
-    )
-  },
-  {
-    params: organizationRoute.params,
-    detail: {
-      summary: 'Get Georeference Annotations for a single organization',
-      tags: ['Organizations']
+      )
+
+      if (!organization || !organization.plan) {
+        throw new ResponseError('Organization not found', 404)
+      }
+
+      setCacheControl(set, 'public-medium')
+
+      const format = ext === 'geojson' ? 'geojson' : 'annotation'
+      return queryMaps(
+        env.PUBLIC_ANNOTATIONS_BASE_URL,
+        db,
+        {
+          organizationSlug
+        },
+        { id: request.url, format, expectRows: true, singular: false }
+      )
+    },
+    {
+      params: organizationRoute.params,
+      detail: {
+        summary: 'Get Georeference Annotations for a single organization',
+        tags: ['Organizations']
+      }
     }
-  }
-)
+  )
+}

--- a/apis/rest/src/app.ts
+++ b/apis/rest/src/app.ts
@@ -17,9 +17,9 @@ import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { RestEnv } from '@allmaps/env/rest'
 
 import { createAuthRoutes } from './routes/auth.js'
-import { manifests } from './routes/manifests.js'
-import { canvases } from './routes/canvases.js'
-import { images } from './routes/images.js'
+import { createManifestsRoutes } from './routes/manifests.js'
+import { createCanvasesRoutes } from './routes/canvases.js'
+import { createImagesRoutes } from './routes/images.js'
 import { createMapsRoutes } from './routes/maps.js'
 import { createListsRoutes } from './routes/lists.js'
 import { createOrganizationsRoutes } from './routes/organizations.js'
@@ -92,9 +92,9 @@ export function createApp(env: RestEnv, betterAuth: BetterAuthContext) {
     .use(createMapsRoutes(betterAuth))
     .use(createListsRoutes(betterAuth))
     .use(createOrganizationsRoutes(env, betterAuth))
-    .use(manifests)
-    .use(canvases)
-    .use(images)
+    .use(createManifestsRoutes(env, betterAuth))
+    .use(createCanvasesRoutes(env, betterAuth))
+    .use(createImagesRoutes(env, betterAuth))
     .use(projections)
     .get(
       '/',

--- a/apis/rest/src/routes/auth.ts
+++ b/apis/rest/src/routes/auth.ts
@@ -32,7 +32,13 @@ export function createAuthRoutes(
       '/users',
       ({ db, env, query, set }) => {
         setCacheControl(set, 'private-no-store')
-        return queryUsers(db, env.PUBLIC_REST_BASE_URL, query.limit, true)
+        return queryUsers(
+          db,
+          env.PUBLIC_REST_BASE_URL,
+          query.limit,
+          true,
+          'admin'
+        )
       },
       {
         admin: true,

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -1,8 +1,13 @@
 import { t } from 'elysia'
 
-import { createElysia } from '../elysia.js'
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import { createAuth } from '@allmaps/db/auth'
+import type { RestEnv } from '@allmaps/env/rest'
+
+import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { queryCanvases, queryMaps } from '@allmaps/api-shared/db'
 import {
+  needsElevatedLimitRole,
   normalizeMapsQueryParams,
   queryRandom,
   setCacheControl
@@ -27,106 +32,138 @@ const mapsQuerySchema = t.Object({
   modifiedBefore: t.Optional(t.String())
 })
 
-export const canvases = createElysia({ name: 'canvases' })
-  .get(
-    '/canvases',
-    async ({ db, env, query, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryCanvases(
-        env.PUBLIC_REST_BASE_URL,
-        db,
-        { georeferenced: query.georeferenced, limit: query.limit },
-        { expectRows: false, singular: false }
-      )
-    },
-    {
-      query: canvasesQuerySchema,
-      detail: { summary: 'Get IIIF Canvases', tags: ['Canvases'] }
-    }
-  )
-  .get(
-    '/canvases/random',
-    async ({ db, env, query, set }) => {
-      setCacheControl(set, 'private-no-store')
-      return queryRandom((op, randomId) =>
-        queryCanvases(
+export function createCanvasesRoutes(
+  env: RestEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  return createElysia({ name: 'canvases' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      '/canvases',
+      async ({ db, env, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryCanvases(
           env.PUBLIC_REST_BASE_URL,
           db,
-          {
-            georeferenced: query.georeferenced,
-            limit: query.limit,
-            randomCanvasId: randomId,
-            randomCanvasIdOp: op
-          },
-          { expectRows: true, singular: false }
+          { georeferenced: query.georeferenced, limit: query.limit, userRole },
+          { expectRows: false, singular: false }
         )
-      )
-    },
-    {
-      query: canvasesQuerySchema,
-      detail: { summary: 'Get a random IIIF Canvas', tags: ['Canvases'] }
-    }
-  )
-  .get(
-    '/canvases/:canvasId',
-    async ({ db, env, params, query, set }) => {
-      setCacheControl(set, 'public-medium')
-      return queryCanvases(
-        env.PUBLIC_REST_BASE_URL,
-        db,
-        { canvasId: params.canvasId, georeferenced: query.georeferenced },
-        { expectRows: true, singular: true }
-      )
-    },
-    {
-      params: t.Object({ canvasId: t.String() }),
-      query: t.Object({ georeferenced: t.Optional(t.Boolean()) }),
-      detail: { summary: 'Get a single IIIF Canvas', tags: ['Canvases'] }
-    }
-  )
-  .get(
-    '/canvases/:canvasId/maps',
-    ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          ...normalizeMapsQueryParams(request),
-          canvasId: params.canvasId
-        },
-        { format: 'map', expectRows: true, singular: false }
-      )
-    },
-    {
-      params: t.Object({ canvasId: t.String() }),
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get maps for a single IIIF Canvas',
-        tags: ['Canvases']
+      },
+      {
+        query: canvasesQuerySchema,
+        detail: { summary: 'Get IIIF Canvases', tags: ['Canvases'] }
       }
-    }
-  )
-  .get(
-    '/canvases/:canvasId/maps.geojson',
-    ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          ...normalizeMapsQueryParams(request),
-          canvasId: params.canvasId
-        },
-        { format: 'geojson', expectRows: true, singular: false }
-      )
-    },
-    {
-      params: t.Object({ canvasId: t.String() }),
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get maps for a single IIIF Canvas as GeoJSON',
-        tags: ['Canvases']
+    )
+    .get(
+      '/canvases/random',
+      async ({ db, env, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(set, 'private-no-store')
+        return queryRandom((op, randomId) =>
+          queryCanvases(
+            env.PUBLIC_REST_BASE_URL,
+            db,
+            {
+              georeferenced: query.georeferenced,
+              limit: query.limit,
+              randomCanvasId: randomId,
+              randomCanvasIdOp: op,
+              userRole
+            },
+            { expectRows: true, singular: false }
+          )
+        )
+      },
+      {
+        query: canvasesQuerySchema,
+        detail: { summary: 'Get a random IIIF Canvas', tags: ['Canvases'] }
       }
-    }
-  )
+    )
+    .get(
+      '/canvases/:canvasId',
+      async ({ db, env, params, query, set }) => {
+        setCacheControl(set, 'public-medium')
+        return queryCanvases(
+          env.PUBLIC_REST_BASE_URL,
+          db,
+          { canvasId: params.canvasId, georeferenced: query.georeferenced },
+          { expectRows: true, singular: true }
+        )
+      },
+      {
+        params: t.Object({ canvasId: t.String() }),
+        query: t.Object({ georeferenced: t.Optional(t.Boolean()) }),
+        detail: { summary: 'Get a single IIIF Canvas', tags: ['Canvases'] }
+      }
+    )
+    .get(
+      '/canvases/:canvasId/maps',
+      async ({ request, env, db, params, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            ...queryParams,
+            canvasId: params.canvasId,
+            userRole
+          },
+          { format: 'map', expectRows: true, singular: false }
+        )
+      },
+      {
+        params: t.Object({ canvasId: t.String() }),
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get maps for a single IIIF Canvas',
+          tags: ['Canvases']
+        }
+      }
+    )
+    .get(
+      '/canvases/:canvasId/maps.geojson',
+      async ({ request, env, db, params, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            ...queryParams,
+            canvasId: params.canvasId,
+            userRole
+          },
+          { format: 'geojson', expectRows: true, singular: false }
+        )
+      },
+      {
+        params: t.Object({ canvasId: t.String() }),
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get maps for a single IIIF Canvas as GeoJSON',
+          tags: ['Canvases']
+        }
+      }
+    )
+}

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -1,6 +1,10 @@
 import { t } from 'elysia'
 
-import { createElysia } from '../elysia.js'
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import { createAuth } from '@allmaps/db/auth'
+import type { RestEnv } from '@allmaps/env/rest'
+
+import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import {
   queryImage,
   queryImages,
@@ -9,6 +13,7 @@ import {
   queryImageChecksums
 } from '@allmaps/api-shared/db'
 import {
+  needsElevatedLimitRole,
   normalizeMapsQueryParams,
   queryRandom,
   setCacheControl
@@ -33,131 +38,166 @@ const mapsQuerySchema = t.Object({
   modifiedBefore: t.Optional(t.String())
 })
 
-export const images = createElysia({ name: 'images' })
-  .get(
-    '/images',
-    ({ env, db, query, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryImages(
-        env.PUBLIC_REST_BASE_URL,
-        db,
-        { georeferenced: query.georeferenced, limit: query.limit },
-        { expectRows: false, singular: false }
-      )
-    },
-    {
-      query: imagesQuerySchema,
-      detail: { summary: 'Get IIIF Images', tags: ['Images'] }
-    }
-  )
-  .get(
-    '/images/random',
-    async ({ env, db, query, set }) => {
-      setCacheControl(set, 'private-no-store')
-      return queryRandom((op, randomId) =>
-        queryImages(
+export function createImagesRoutes(
+  env: RestEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  return createElysia({ name: 'images' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      '/images',
+      async ({ env, db, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryImages(
           env.PUBLIC_REST_BASE_URL,
           db,
-          {
-            georeferenced: query.georeferenced,
-            limit: query.limit,
-            randomImageId: randomId,
-            randomImageIdOp: op
-          },
-          { expectRows: true, singular: false }
+          { georeferenced: query.georeferenced, limit: query.limit, userRole },
+          { expectRows: false, singular: false }
         )
-      )
-    },
-    {
-      query: imagesQuerySchema,
-      detail: { summary: 'Get a random IIIF Image', tags: ['Images'] }
-    }
-  )
-  .get(
-    '/images/:imageId',
-    ({ env, db, params, set }) => {
-      setCacheControl(set, 'public-medium')
-      return queryImage(env.PUBLIC_REST_BASE_URL, db, params.imageId)
-    },
-    {
-      params: t.Object({ imageId: t.String() }),
-      detail: { summary: 'Get a single IIIF Image', tags: ['Images'] }
-    }
-  )
-  .get(
-    '/images/:imageId/versions',
-    ({ env, db, params, set }) => {
-      setCacheControl(set, 'public-medium')
-      return queryImageChecksums(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        params.imageId
-      )
-    },
-    {
-      params: t.Object({ imageId: t.String() }),
-      detail: {
-        summary: 'Get all versions for a single IIIF Image',
-        tags: ['Images']
+      },
+      {
+        query: imagesQuerySchema,
+        detail: { summary: 'Get IIIF Images', tags: ['Images'] }
       }
-    }
-  )
-  .get(
-    '/images/:imageId/maps',
-    ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          ...normalizeMapsQueryParams(request),
-          imageId: params.imageId
-        },
-        { format: 'map', expectRows: true, singular: false }
-      )
-    },
-    {
-      params: t.Object({ imageId: t.String() }),
-      query: mapsQuerySchema,
-      detail: { summary: 'Get maps for a single IIIF Image', tags: ['Images'] }
-    }
-  )
-  .get(
-    '/images/:imageId/maps.geojson',
-    ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          ...normalizeMapsQueryParams(request),
-          imageId: params.imageId
-        },
-        { format: 'geojson', expectRows: true, singular: false }
-      )
-    },
-    {
-      params: t.Object({ imageId: t.String() }),
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get maps for a single IIIF Image as GeoJSON',
-        tags: ['Images']
+    )
+    .get(
+      '/images/random',
+      async ({ env, db, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(set, 'private-no-store')
+        return queryRandom((op, randomId) =>
+          queryImages(
+            env.PUBLIC_REST_BASE_URL,
+            db,
+            {
+              georeferenced: query.georeferenced,
+              limit: query.limit,
+              randomImageId: randomId,
+              randomImageIdOp: op,
+              userRole
+            },
+            { expectRows: true, singular: false }
+          )
+        )
+      },
+      {
+        query: imagesQuerySchema,
+        detail: { summary: 'Get a random IIIF Image', tags: ['Images'] }
       }
-    }
-  )
-  .put(
-    '/images/:imageId',
-    ({ db, params, body, set }) => {
-      setCacheControl(set, 'private-no-store')
-      return createImage(db, params.imageId, body.url)
-    },
-    {
-      params: t.Object({ imageId: t.String() }),
-      body: t.Object({ url: t.String() }),
-      detail: {
-        hide: true,
-        summary: 'Create or update a single IIIF Image from a IIIF URL',
-        tags: ['Images']
+    )
+    .get(
+      '/images/:imageId',
+      ({ env, db, params, set }) => {
+        setCacheControl(set, 'public-medium')
+        return queryImage(env.PUBLIC_REST_BASE_URL, db, params.imageId)
+      },
+      {
+        params: t.Object({ imageId: t.String() }),
+        detail: { summary: 'Get a single IIIF Image', tags: ['Images'] }
       }
-    }
-  )
+    )
+    .get(
+      '/images/:imageId/versions',
+      ({ env, db, params, set }) => {
+        setCacheControl(set, 'public-medium')
+        return queryImageChecksums(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          params.imageId
+        )
+      },
+      {
+        params: t.Object({ imageId: t.String() }),
+        detail: {
+          summary: 'Get all versions for a single IIIF Image',
+          tags: ['Images']
+        }
+      }
+    )
+    .get(
+      '/images/:imageId/maps',
+      async ({ request, env, db, params, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            ...queryParams,
+            imageId: params.imageId,
+            userRole
+          },
+          { format: 'map', expectRows: true, singular: false }
+        )
+      },
+      {
+        params: t.Object({ imageId: t.String() }),
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get maps for a single IIIF Image',
+          tags: ['Images']
+        }
+      }
+    )
+    .get(
+      '/images/:imageId/maps.geojson',
+      async ({ request, env, db, params, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            ...queryParams,
+            imageId: params.imageId,
+            userRole
+          },
+          { format: 'geojson', expectRows: true, singular: false }
+        )
+      },
+      {
+        params: t.Object({ imageId: t.String() }),
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get maps for a single IIIF Image as GeoJSON',
+          tags: ['Images']
+        }
+      }
+    )
+    .put(
+      '/images/:imageId',
+      ({ db, params, body, set }) => {
+        setCacheControl(set, 'private-no-store')
+        return createImage(db, params.imageId, body.url)
+      },
+      {
+        params: t.Object({ imageId: t.String() }),
+        body: t.Object({ url: t.String() }),
+        detail: {
+          hide: true,
+          summary: 'Create or update a single IIIF Image from a IIIF URL',
+          tags: ['Images']
+        }
+      }
+    )
+}

--- a/apis/rest/src/routes/manifests.ts
+++ b/apis/rest/src/routes/manifests.ts
@@ -1,12 +1,17 @@
 import { t } from 'elysia'
 
-import { createElysia } from '../elysia.js'
+import type { BetterAuthContext } from '@allmaps/db/auth'
+import { createAuth } from '@allmaps/db/auth'
+import type { RestEnv } from '@allmaps/env/rest'
+
+import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import {
   queryManifests,
   createManifest,
   queryMaps
 } from '@allmaps/api-shared/db'
 import {
+  needsElevatedLimitRole,
   normalizeMapsQueryParams,
   queryRandom,
   setCacheControl
@@ -26,129 +31,161 @@ const mapsQuerySchema = t.Object({
   modifiedBefore: t.Optional(t.String())
 })
 
-export const manifests = createElysia({ name: 'manifests' })
-  .get(
-    '/manifests',
-    async ({ db, env, query, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryManifests(
-        env.PUBLIC_REST_BASE_URL,
-        db,
-        { georeferenced: query.georeferenced, limit: query.limit },
-        { expectRows: false, singular: false }
-      )
-    },
-    {
-      query: t.Object({
-        georeferenced: t.Optional(t.Boolean()),
-        limit: t.Optional(t.Number())
-      }),
-      detail: { summary: 'Get IIIF Manifests', tags: ['Manifests'] }
-    }
-  )
-  .get(
-    '/manifests/random',
-    async ({ db, env, query, set }) => {
-      setCacheControl(set, 'private-no-store')
-      return queryRandom((op, randomId) =>
-        queryManifests(
+export function createManifestsRoutes(
+  env: RestEnv,
+  betterAuth: BetterAuthContext = createAuth(env)
+) {
+  return createElysia({ name: 'manifests' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      '/manifests',
+      async ({ db, env, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryManifests(
           env.PUBLIC_REST_BASE_URL,
           db,
-          {
-            georeferenced: query.georeferenced,
-            limit: query.limit,
-            randomManifestId: randomId,
-            randomManifestIdOp: op
-          },
-          { expectRows: true, singular: false }
+          { georeferenced: query.georeferenced, limit: query.limit, userRole },
+          { expectRows: false, singular: false }
         )
-      )
-    },
-    {
-      query: t.Object({
-        georeferenced: t.Optional(t.Boolean()),
-        limit: t.Optional(t.Number())
-      }),
-      detail: { summary: 'Get a random IIIF Manifest', tags: ['Manifests'] }
-    }
-  )
-  .get(
-    '/manifests/:manifestId',
-    async ({ db, params, env, query, set }) => {
-      setCacheControl(set, 'public-medium')
-      return queryManifests(
-        env.PUBLIC_REST_BASE_URL,
-        db,
-        { manifestId: params.manifestId, georeferenced: query.georeferenced },
-        { expectRows: true, singular: true }
-      )
-    },
-    {
-      params: t.Object({ manifestId: t.String() }),
-      query: t.Object({ georeferenced: t.Optional(t.Boolean()) }),
-      detail: { summary: 'Get a single IIIF Manifest', tags: ['Manifests'] }
-    }
-  )
-  .get(
-    '/manifests/:manifestId/maps',
-    async ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          ...normalizeMapsQueryParams(request),
-          manifestId: params.manifestId
-        },
-        { format: 'map', expectRows: true, singular: false }
-      )
-    },
-    {
-      params: t.Object({ manifestId: t.String() }),
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get maps for a single IIIF Manifest',
-        tags: ['Manifests']
+      },
+      {
+        query: t.Object({
+          georeferenced: t.Optional(t.Boolean()),
+          limit: t.Optional(t.Number())
+        }),
+        detail: { summary: 'Get IIIF Manifests', tags: ['Manifests'] }
       }
-    }
-  )
-  .get(
-    '/manifests/:manifestId/maps.geojson',
-    async ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-short')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          ...normalizeMapsQueryParams(request),
-          manifestId: params.manifestId
-        },
-        { format: 'geojson', expectRows: true, singular: false }
-      )
-    },
-    {
-      params: t.Object({ manifestId: t.String() }),
-      query: mapsQuerySchema,
-      detail: {
-        summary: 'Get maps for a single IIIF Manifest as GeoJSON',
-        tags: ['Manifests']
+    )
+    .get(
+      '/manifests/random',
+      async ({ db, env, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(set, 'private-no-store')
+        return queryRandom((op, randomId) =>
+          queryManifests(
+            env.PUBLIC_REST_BASE_URL,
+            db,
+            {
+              georeferenced: query.georeferenced,
+              limit: query.limit,
+              randomManifestId: randomId,
+              randomManifestIdOp: op,
+              userRole
+            },
+            { expectRows: true, singular: false }
+          )
+        )
+      },
+      {
+        query: t.Object({
+          georeferenced: t.Optional(t.Boolean()),
+          limit: t.Optional(t.Number())
+        }),
+        detail: { summary: 'Get a random IIIF Manifest', tags: ['Manifests'] }
       }
-    }
-  )
-  .put(
-    '/manifests/:manifestId',
-    async ({ db, params, body, set }) => {
-      setCacheControl(set, 'private-no-store')
-      // TODO: add checkseum and check checksum matches manifest at URL before creating/updating
-      return createManifest(db, params.manifestId, body.url)
-    },
-    {
-      params: t.Object({ manifestId: t.String() }),
-      body: t.Object({ url: t.String(), checksum: t.String() }),
-      detail: {
-        hide: true,
-        summary: 'Create or update a IIIF Manifest from a IIIF URL',
-        tags: ['Manifests']
+    )
+    .get(
+      '/manifests/:manifestId',
+      async ({ db, params, env, query, set }) => {
+        setCacheControl(set, 'public-medium')
+        return queryManifests(
+          env.PUBLIC_REST_BASE_URL,
+          db,
+          { manifestId: params.manifestId, georeferenced: query.georeferenced },
+          { expectRows: true, singular: true }
+        )
+      },
+      {
+        params: t.Object({ manifestId: t.String() }),
+        query: t.Object({ georeferenced: t.Optional(t.Boolean()) }),
+        detail: { summary: 'Get a single IIIF Manifest', tags: ['Manifests'] }
       }
-    }
-  )
+    )
+    .get(
+      '/manifests/:manifestId/maps',
+      async ({ request, env, db, params, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            ...queryParams,
+            manifestId: params.manifestId,
+            userRole
+          },
+          { format: 'map', expectRows: true, singular: false }
+        )
+      },
+      {
+        params: t.Object({ manifestId: t.String() }),
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get maps for a single IIIF Manifest',
+          tags: ['Manifests']
+        }
+      }
+    )
+    .get(
+      '/manifests/:manifestId/maps.geojson',
+      async ({ request, env, db, params, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            ...queryParams,
+            manifestId: params.manifestId,
+            userRole
+          },
+          { format: 'geojson', expectRows: true, singular: false }
+        )
+      },
+      {
+        params: t.Object({ manifestId: t.String() }),
+        query: mapsQuerySchema,
+        detail: {
+          summary: 'Get maps for a single IIIF Manifest as GeoJSON',
+          tags: ['Manifests']
+        }
+      }
+    )
+    .put(
+      '/manifests/:manifestId',
+      async ({ db, params, body, set }) => {
+        setCacheControl(set, 'private-no-store')
+        // TODO: add checkseum and check checksum matches manifest at URL before creating/updating
+        return createManifest(db, params.manifestId, body.url)
+      },
+      {
+        params: t.Object({ manifestId: t.String() }),
+        body: t.Object({ url: t.String(), checksum: t.String() }),
+        detail: {
+          hide: true,
+          summary: 'Create or update a IIIF Manifest from a IIIF URL',
+          tags: ['Manifests']
+        }
+      }
+    )
+}

--- a/apis/rest/src/routes/maps.ts
+++ b/apis/rest/src/routes/maps.ts
@@ -1,7 +1,11 @@
 import { t } from 'elysia'
 
 import { queryMaps, queryChecksums } from '@allmaps/api-shared/db'
-import { normalizeMapsQueryParams, setCacheControl } from '@allmaps/api-shared'
+import {
+  needsElevatedLimitRole,
+  normalizeMapsQueryParams,
+  setCacheControl
+} from '@allmaps/api-shared'
 
 import { RegExpRoute, createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { adminDetail } from '../openapi.js'
@@ -53,12 +57,19 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/maps',
-      ({ request, env, db, set }) => {
-        setCacheControl(set, 'public-short')
+      async ({ request, env, db, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          normalizeMapsQueryParams(request),
+          { ...queryParams, userRole },
           { format: 'map', expectRows: false, singular: false }
         )
       },
@@ -69,12 +80,19 @@ export function createMapsRoutes(betterAuth: BetterAuthContext) {
     )
     .get(
       '/maps.geojson',
-      ({ request, env, db, set }) => {
-        setCacheControl(set, 'public-short')
+      async ({ request, env, db, set, getLimitRole }) => {
+        const queryParams = normalizeMapsQueryParams(request)
+        const userRole = needsElevatedLimitRole(queryParams.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          normalizeMapsQueryParams(request),
+          { ...queryParams, userRole },
           { format: 'geojson', expectRows: false, singular: false }
         )
       },

--- a/apis/rest/src/routes/organizations.ts
+++ b/apis/rest/src/routes/organizations.ts
@@ -18,7 +18,7 @@ import {
   queryCanvases,
   queryManifests
 } from '@allmaps/api-shared/db'
-import { setCacheControl } from '@allmaps/api-shared'
+import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
 
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { adminDetail } from '../openapi.js'
@@ -56,7 +56,8 @@ export function createOrganizationsRoutes(
           return listOrganizationsWithUsers(
             db,
             env.PUBLIC_REST_BASE_URL,
-            query.limit
+            query.limit,
+            'admin'
           )
         }
 
@@ -103,15 +104,25 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId/manifests',
-      ({ env, db, params, query, set }) => {
-        setCacheControl(set, 'public-short')
+      async ({ env, db, params, query, set, getOrganizationLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getOrganizationLimitRole({
+              id: params.organizationId
+            })
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+
         return queryManifests(
           env.PUBLIC_REST_BASE_URL,
           db,
           {
             organizationId: params.organizationId,
             georeferenced: query.georeferenced,
-            limit: query.limit
+            limit: query.limit,
+            userRole
           },
           { expectRows: false, singular: false }
         )
@@ -126,15 +137,25 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId/canvases',
-      ({ env, db, params, query, set }) => {
-        setCacheControl(set, 'public-short')
+      async ({ env, db, params, query, set, getOrganizationLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getOrganizationLimitRole({
+              id: params.organizationId
+            })
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+
         return queryCanvases(
           env.PUBLIC_REST_BASE_URL,
           db,
           {
             organizationId: params.organizationId,
             georeferenced: query.georeferenced,
-            limit: query.limit
+            limit: query.limit,
+            userRole
           },
           { expectRows: false, singular: false }
         )
@@ -149,15 +170,25 @@ export function createOrganizationsRoutes(
     )
     .get(
       '/organizations/:organizationId/images',
-      ({ env, db, params, query, set }) => {
-        setCacheControl(set, 'public-short')
+      async ({ env, db, params, query, set, getOrganizationLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getOrganizationLimitRole({
+              id: params.organizationId
+            })
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-short' : 'private-no-store'
+        )
+
         return queryImages(
           env.PUBLIC_REST_BASE_URL,
           db,
           {
             organizationId: params.organizationId,
             georeferenced: query.georeferenced,
-            limit: query.limit
+            limit: query.limit,
+            userRole
           },
           { expectRows: false, singular: false }
         )

--- a/packages/api-shared/src/elysia/auth.ts
+++ b/packages/api-shared/src/elysia/auth.ts
@@ -1,11 +1,17 @@
 import { t } from 'elysia'
+import { and, eq } from 'drizzle-orm'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
+import * as authSchema from '@allmaps/db/schema/auth'
 
 import { ResponseError } from '../shared/errors.js'
 import { createElysia } from './app.js'
 import { setCacheControl } from './cache.js'
 import { redirect } from './response.js'
+
+import type { UserRole } from '../shared/limits.js'
+
+const PAID_ORGANIZATION_PLANS = new Set(['supporter', 'innovator'])
 
 function copySetCookieHeader(
   response: Response,
@@ -47,20 +53,74 @@ export function createBetterAuthPlugin<TEnv = Record<string, unknown>>(
         }
       }
     })
-    .derive(({ request: { headers } }) => {
+    .derive(({ db, request: { headers } }) => {
+      const getOptionalSession = async () => auth.api.getSession({ headers })
+
       return {
-        getOptionalSession: async () => auth.api.getSession({ headers }),
+        getOptionalSession,
+        getLimitRole: async (): Promise<UserRole> => {
+          const session = await getOptionalSession()
+
+          return session?.user.role === 'admin'
+            ? 'admin'
+            : session?.user.id
+              ? 'user'
+              : 'public'
+        },
         getSession: async () => {
-          const session = await auth.api.getSession({ headers })
+          const session = await getOptionalSession()
 
           if (!session) {
             throw new ResponseError('Unauthorized', 401)
           }
 
           return session
+        },
+        getOrganizationLimitRole: async (organization: {
+          id?: string
+          slug?: string
+        }): Promise<UserRole> => {
+          const session = await getOptionalSession()
+
+          if (session?.user.role === 'admin') {
+            return 'admin'
+          }
+
+          if (!session?.user.id || (!organization.id && !organization.slug)) {
+            return 'public'
+          }
+
+          const [membership] = await db
+            .select({
+              plan: authSchema.organizations.plan
+            })
+            .from(authSchema.members)
+            .innerJoin(
+              authSchema.organizations,
+              eq(authSchema.members.organizationId, authSchema.organizations.id)
+            )
+            .where(
+              and(
+                eq(authSchema.members.userId, session.user.id),
+                organization.id
+                  ? eq(authSchema.organizations.id, organization.id)
+                  : eq(authSchema.organizations.slug, organization.slug!)
+              )
+            )
+            .limit(1)
+
+          if (
+            membership?.plan &&
+            PAID_ORGANIZATION_PLANS.has(membership.plan)
+          ) {
+            return 'member'
+          }
+
+          return 'user'
         }
       }
     })
+    .as('global')
 }
 
 export function createBetterAuthRoutes<TEnv = Record<string, unknown>>(

--- a/packages/api-shared/src/index.ts
+++ b/packages/api-shared/src/index.ts
@@ -8,7 +8,16 @@ export {
 } from './shared/maps.js'
 
 export { ResponseError } from './shared/errors.js'
-export { DEFAULT_LIMIT, MAX_LIMIT, clampLimit } from './shared/limits.js'
+export {
+  DEFAULT_LIMIT,
+  PUBLIC_MAX_LIMIT,
+  USER_MAX_LIMIT,
+  MEMBER_MAX_LIMIT,
+  ADMIN_MAX_LIMIT,
+  clampLimit,
+  needsElevatedLimitRole
+} from './shared/limits.js'
+export type { UserRole } from './shared/limits.js'
 export { normalizeMapsQueryParams } from './shared/query-params.js'
 export { queryRandom } from './shared/random.js'
 export { setCacheControl } from './elysia/cache.js'

--- a/packages/api-shared/src/queries/auth.ts
+++ b/packages/api-shared/src/queries/auth.ts
@@ -5,6 +5,7 @@ import * as authSchema from '@allmaps/db/schema/auth'
 import { clampLimit } from '../shared/limits.js'
 
 import type { Db } from '@allmaps/db'
+import type { UserRole } from '../shared/limits.js'
 
 type DbUser = typeof authSchema.users.$inferSelect & {
   members?: {
@@ -296,7 +297,8 @@ export async function queryUsers(
   db: Db,
   restBaseUrl: string,
   limit?: number,
-  includeOrganizations = false
+  includeOrganizations = false,
+  userRole?: UserRole
 ) {
   if (includeOrganizations) {
     const users = await db.query.users.findMany({
@@ -325,7 +327,7 @@ export async function queryUsers(
         }
       },
       orderBy: (users, { asc }) => asc(users.createdAt),
-      limit: clampLimit(limit)
+      limit: clampLimit(limit, userRole)
     })
 
     return users.map((user) => fromDbUser(restBaseUrl, user))
@@ -336,7 +338,7 @@ export async function queryUsers(
     .from(authSchema.users)
     .where(eq(authSchema.users.isAnonymous, false))
     .orderBy(authSchema.users.createdAt)
-    .limit(clampLimit(limit))
+    .limit(clampLimit(limit, userRole))
 
   return users.map((user) => fromDbUser(restBaseUrl, user))
 }

--- a/packages/api-shared/src/queries/iiif.ts
+++ b/packages/api-shared/src/queries/iiif.ts
@@ -10,6 +10,7 @@ import { ResponseError, clampLimit } from '@allmaps/api-shared'
 
 import type { LanguageString } from '@allmaps/iiif-parser'
 import type { Db } from '@allmaps/db'
+import type { UserRole } from '../shared/limits.js'
 
 type DbManifest = {
   id: string
@@ -236,6 +237,7 @@ export async function queryImages(
     limit?: number
     randomImageId?: string
     randomImageIdOp?: 'gt' | 'lte'
+    userRole?: UserRole
   },
   responseOptions: {
     expectRows: boolean
@@ -328,7 +330,9 @@ export async function queryImages(
       ? (images, { asc, desc }) =>
           params.randomImageIdOp === 'gt' ? asc(images.id) : desc(images.id)
       : undefined,
-    limit: responseOptions.singular ? 1 : clampLimit(params.limit ?? 100)
+    limit: responseOptions.singular
+      ? 1
+      : clampLimit(params.limit ?? 100, params.userRole)
   })
 
   if (responseOptions.expectRows && rows.length === 0) {
@@ -352,6 +356,7 @@ export async function queryCanvases(
     limit?: number
     randomCanvasId?: string
     randomCanvasIdOp?: 'gt' | 'lte'
+    userRole?: UserRole
   },
   responseOptions: {
     expectRows: boolean
@@ -447,7 +452,9 @@ export async function queryCanvases(
             ? asc(canvases.id)
             : desc(canvases.id)
       : undefined,
-    limit: responseOptions.singular ? 1 : clampLimit(params.limit ?? 100)
+    limit: responseOptions.singular
+      ? 1
+      : clampLimit(params.limit ?? 100, params.userRole)
   })
 
   if (responseOptions.expectRows && rows.length === 0) {
@@ -471,6 +478,7 @@ export async function queryManifests(
     limit?: number
     randomManifestId?: string
     randomManifestIdOp?: 'gt' | 'lte'
+    userRole?: UserRole
   },
   responseOptions: {
     expectRows: boolean
@@ -571,7 +579,9 @@ export async function queryManifests(
             ? asc(manifests.id)
             : desc(manifests.id)
       : undefined,
-    limit: responseOptions.singular ? 1 : clampLimit(params.limit ?? 100)
+    limit: responseOptions.singular
+      ? 1
+      : clampLimit(params.limit ?? 100, params.userRole)
   })
 
   if (responseOptions.expectRows && rows.length === 0) {

--- a/packages/api-shared/src/queries/maps.ts
+++ b/packages/api-shared/src/queries/maps.ts
@@ -250,7 +250,9 @@ export async function queryMaps(
         return desc(maps.updatedAt)
       }
     },
-    limit: responseOptions.singular ? 1 : clampLimit(params.limit)
+    limit: responseOptions.singular
+      ? 1
+      : clampLimit(params.limit, params.userRole)
   })
 
   if (responseOptions.expectRows && rows.length === 0) {

--- a/packages/api-shared/src/queries/organizations.ts
+++ b/packages/api-shared/src/queries/organizations.ts
@@ -12,6 +12,7 @@ import {
 import { clampLimit } from '../shared/limits.js'
 
 import type { Db, DbOrTx } from '@allmaps/db'
+import type { UserRole } from '../shared/limits.js'
 
 type DbOrganization = {
   id: string
@@ -206,14 +207,15 @@ export async function replaceOrganizationUrls(
 export async function listOrganizations(
   db: Db,
   restBaseUrl: string,
-  limit?: number
+  limit?: number,
+  userRole?: UserRole
 ) {
   const dbOrganizations = await db.query.organizations.findMany({
     with: {
       urls: true
     },
     orderBy: (organizations, { asc }) => asc(organizations.name),
-    limit: clampLimit(limit)
+    limit: clampLimit(limit, userRole)
   })
 
   return dbOrganizations.map((dbOrganization) =>
@@ -224,7 +226,8 @@ export async function listOrganizations(
 export async function listOrganizationsWithUsers(
   db: Db,
   restBaseUrl: string,
-  limit?: number
+  limit?: number,
+  userRole?: UserRole
 ) {
   const [dbOrganizations, usersByOrganizationId] = await Promise.all([
     db.query.organizations.findMany({
@@ -232,7 +235,7 @@ export async function listOrganizationsWithUsers(
         urls: true
       },
       orderBy: (organizations, { asc }) => asc(organizations.name),
-      limit: clampLimit(limit)
+      limit: clampLimit(limit, userRole)
     }),
     queryAllOrganizationUsers(db, restBaseUrl)
   ])

--- a/packages/api-shared/src/shared/limits.ts
+++ b/packages/api-shared/src/shared/limits.ts
@@ -1,6 +1,31 @@
-export const DEFAULT_LIMIT = 250
-export const MAX_LIMIT = 750
+export const DEFAULT_LIMIT = 100
 
-export function clampLimit(limit: number | undefined): number {
-  return Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+export const PUBLIC_MAX_LIMIT = 100
+export const USER_MAX_LIMIT = 250
+export const MEMBER_MAX_LIMIT = 500
+export const ADMIN_MAX_LIMIT = 500
+
+export type UserRole = 'public' | 'user' | 'member' | 'admin'
+
+const MAX_LIMITS: Record<UserRole, number> = {
+  public: PUBLIC_MAX_LIMIT,
+  user: USER_MAX_LIMIT,
+  admin: ADMIN_MAX_LIMIT,
+  member: MEMBER_MAX_LIMIT
+}
+
+function getMaxLimitForRole(role: UserRole): number {
+  return MAX_LIMITS[role]
+}
+
+export function clampLimit(
+  limit: number | undefined,
+  userRole: UserRole = 'public'
+): number {
+  const maxLimit = getMaxLimitForRole(userRole)
+  return Math.min(limit ?? DEFAULT_LIMIT, maxLimit)
+}
+
+export function needsElevatedLimitRole(limit: number | undefined): boolean {
+  return limit !== undefined && limit > PUBLIC_MAX_LIMIT
 }

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -4,6 +4,7 @@ import type { GeoreferencedMap } from '@allmaps/annotation'
 import type { LanguageString } from '@allmaps/iiif-parser'
 
 import type { DbMap } from '@allmaps/db'
+import type { UserRole } from './shared/limits.js'
 
 export type IntersectsWith = [number, number] | [number, number, number, number]
 export type ContainedBy = [number, number, number, number]
@@ -31,6 +32,7 @@ export type MapsQueryParams = {
   maxArea: number
   modifiedAfter: Date
   modifiedBefore: Date
+  userRole: UserRole
 }
 
 export type MapsQueryUrlParams = {


### PR DESCRIPTION
This pull request refactors how route modules are defined and used in both the `annotations` and `rest` APIs. It transitions from exporting static route objects to exporting factory functions that accept environment and authentication context parameters. Additionally, it introduces improved handling of user roles and cache control for endpoints with query limits, enhancing security and flexibility.

The most important changes are:

### Route Module Refactoring

* All route modules (`maps`, `images`, `canvases`, `manifests`, `organizations`) now export factory functions (e.g., `createMapsRoutes`) instead of static objects, allowing routes to be instantiated with specific environment and authentication context. App initializers (`app.ts`) are updated to use these factories. [[1]](diffhunk://#diff-bc0a48fd934b3a8fd154b0a00d1618b41204b50597ebcdf6300f3796864057b6L23-R27) [[2]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84R5-R18) [[3]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84R42) [[4]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215R3-R6) [[5]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215L16-R26) [[6]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215R51) [[7]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69R5-R18) [[8]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69R42) [[9]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL5-R15) [[10]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL29-R57) [[11]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL138-R171) [[12]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462R3-R6) [[13]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L14-L17) [[14]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462R38-R39) [[15]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462R58) [[16]](diffhunk://#diff-1dcc728aea3f23b0f0c211d094dd07d6245513dc92b56285780e268fbc827cf0L20-R22) [[17]](diffhunk://#diff-1dcc728aea3f23b0f0c211d094dd07d6245513dc92b56285780e268fbc827cf0L95-R97) [[18]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L3-R10) [[19]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L30-R54) [[20]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L49-R68) [[21]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L59-R79) [[22]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L89-R124) [[23]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L112-R155) [[24]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91R169) [[25]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L3-R7) [[26]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359R16)

### Authentication and Role-based Access

* Route factories accept an optional `BetterAuthContext` and, where appropriate, apply authentication plugins (e.g., `createBetterAuthPlugin`). This enables more flexible and explicit authentication handling per route group. [[1]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL5-R15) [[2]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L3-R10) [[3]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L30-R54) [[4]](diffhunk://#diff-2ccc1c25d61013d58fe242b187962b6c75ae9f7f06fd7f156ac7c94a16f66359L3-R7)

### User Role and Cache Control Logic

* Endpoints that accept a `limit` parameter now determine if an elevated user role is required (using `needsElevatedLimitRole`). If so, the user's role is fetched and passed to query functions, and cache control headers are set accordingly (`public-short` for public users, `private-no-store` for elevated users). This applies to both `maps` and `canvases` routes, including subroutes for random selection and geojson formats. [[1]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL29-R57) [[2]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL56-R88) [[3]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L30-R54) [[4]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L49-R68) [[5]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L59-R79) [[6]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L89-R124) [[7]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L112-R155)

### Query Parameter Handling

* Query functions such as `queryMaps` and `queryCanvases` now receive the computed `userRole` as part of their parameters, ensuring that backend logic can enforce role-based restrictions. [[1]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL29-R57) [[2]](diffhunk://#diff-4252523d8f30a37b1874254ff637c6b6f3fa8bf23715dd2bed6b344eac6a19aaL56-R88) [[3]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L30-R54) [[4]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L49-R68) [[5]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L59-R79) [[6]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L89-R124) [[7]](diffhunk://#diff-0e00b84a88a40c791331e02d447f0f4dda353fe1173093575e57e727b6e67c91L112-R155)

### Minor Improvements

* The `/users` route in the REST API now explicitly passes `'admin'` as the user role to the `queryUsers` function for clarity and security.

These changes collectively improve the modularity, security, and maintainability of the API route definitions.