### PR TITLE
Align OpenAPI implementation

### DIFF
--- a/apis/annotations/src/app.ts
+++ b/apis/annotations/src/app.ts
@@ -50,7 +50,7 @@ export function createApp(env: AnnotationsEnv, betterAuth: BetterAuthContext) {
     .use(cors())
     .use(
       openapi({
-        provider: null,
+        path: 'docs',
         specPath: 'openapi.json',
         documentation: {
           info: {
@@ -58,7 +58,21 @@ export function createApp(env: AnnotationsEnv, betterAuth: BetterAuthContext) {
             description: 'API documentation for the Allmaps Annotations API',
             version: packageJson.version
           },
+          components: {
+            securitySchemes: {
+              sessionCookie: {
+                type: 'apiKey',
+                in: 'cookie',
+                name: 'better-auth.session_token',
+                description:
+                  'Better Auth session cookie. Some routes additionally require the authenticated user to be an admin.'
+              }
+            }
+          },
           tags: openApiTags
+        },
+        exclude: {
+          staticFile: false
         },
         scalar: {
           tagsSorter,

--- a/apis/rest/src/app.ts
+++ b/apis/rest/src/app.ts
@@ -57,6 +57,7 @@ export function createApp(env: RestEnv, betterAuth: BetterAuthContext) {
     .use(
       openapi({
         path: 'docs',
+        specPath: 'openapi.json',
         documentation: {
           info: {
             title: 'Allmaps API Documentation',


### PR DESCRIPTION
Align OpenAPI implementation for both APIs. In the future, we might set
`provider: null` and run a stand-alone ScalarUI instance that loads 2
`openapi.json` URLs from both APIs