### PR TITLE
Started using multiple tile layers, for maps of different scale

### DIFF
--- a/apps/explore/src/lib/shared/mask-bands.ts
+++ b/apps/explore/src/lib/shared/mask-bands.ts
@@ -1,0 +1,79 @@
+import type { FilterSpecification } from 'maplibre-gl'
+
+export type MaskBand = {
+  id: string
+  layerId: string
+  sourceLayer: string
+  minzoom: number
+  maxzoom: number
+  lineWidth: number
+  lineOpacity: number
+}
+
+export const maskBands = [
+  {
+    id: 'global',
+    layerId: 'masks-global',
+    sourceLayer: 'masks_global',
+    minzoom: 0,
+    maxzoom: 6,
+    lineWidth: 1.25,
+    lineOpacity: 0.4
+  },
+  {
+    id: 'continent',
+    layerId: 'masks-continent',
+    sourceLayer: 'masks_continent',
+    minzoom: 2,
+    maxzoom: 8,
+    lineWidth: 1.5,
+    lineOpacity: 0.5
+  },
+  {
+    id: 'country',
+    layerId: 'masks-country',
+    sourceLayer: 'masks_country',
+    minzoom: 4,
+    maxzoom: 10,
+    lineWidth: 1.75,
+    lineOpacity: 0.6
+  },
+  {
+    id: 'region',
+    layerId: 'masks-region',
+    sourceLayer: 'masks_region',
+    minzoom: 6,
+    maxzoom: 12,
+    lineWidth: 2,
+    lineOpacity: 0.7
+  },
+  {
+    id: 'city',
+    layerId: 'masks-city',
+    sourceLayer: 'masks_city',
+    minzoom: 8,
+    maxzoom: 14,
+    lineWidth: 2.5,
+    lineOpacity: 0.8
+  },
+  {
+    id: 'local',
+    layerId: 'masks-local',
+    sourceLayer: 'masks_local',
+    minzoom: 10,
+    maxzoom: 15,
+    lineWidth: 3,
+    lineOpacity: 0.9
+  }
+] as const satisfies readonly MaskBand[]
+
+export const maskLayerIds = maskBands.map((maskBand) => maskBand.layerId)
+
+export function getMaskFilter(maxArea: number): FilterSpecification {
+  return [
+    'all',
+    ['>=', 'area', 0],
+    ['<=', 'area', maxArea],
+    ['!=', 'imageServiceDomain', 'iiif.nypl.org']
+  ]
+}

--- a/apps/explore/src/routes/+page.svelte
+++ b/apps/explore/src/routes/+page.svelte
@@ -17,11 +17,12 @@
   import { fetchImageInfo } from '@allmaps/stdlib'
   import { WarpedMapLayer } from '@allmaps/maplibre'
 
-  import type { MapGeoJSONFeature, FilterSpecification } from 'maplibre-gl'
+  import type { MapGeoJSONFeature } from 'maplibre-gl'
 
   import { PUBLIC_GEOCODE_EARTH_API_KEY } from '$env/static/public'
 
   import { formatTimeAgo } from '$lib/shared/format.js'
+  import { getMaskFilter, maskBands, maskLayerIds } from '$lib/shared/mask-bands.js'
 
   import type { Bbox } from '@allmaps/types'
   import type { GeocoderGeoJsonFeature } from '@allmaps/components/geocoder'
@@ -42,22 +43,13 @@
   let lastModifiedAgo: string | undefined = $state('')
 
   const minMaxArea = 100_000
-  const maxMaxAea = 500_000_000_000
+  const maxMaxAea = 300_000_000_000_000
 
-  let maxAreaSqrt = $state(Math.sqrt(5_000_000_000))
-
-  function getFilters(maxAea: number): FilterSpecification {
-    return [
-      'all',
-      ['>=', 'area', 0],
-      ['<=', 'area', maxAea],
-      ['!=', 'imageServiceDomain', 'iiif.nypl.org']
-    ]
-  }
+  let maxAreaSqrt = $state(Math.sqrt(maxMaxAea))
 
   function updateFeatures() {
     const newFeatures = map.queryRenderedFeatures({
-      layers: ['masks']
+      layers: maskLayerIds
     })
 
     features = uniqWith(
@@ -138,7 +130,6 @@
       hash: true
     })
 
-    // @ts-expect-error incorrect MapLibre types
     addTerrain(map, maplibregl)
 
     map.on('load', () => {
@@ -147,24 +138,29 @@
         url: `pmtiles://${pmtilesUrl}`
       })
 
-      map.addLayer({
-        id: 'masks',
-        type: 'line',
-        source: 'masks',
-        'source-layer': 'masks',
-        layout: {
-          'line-join': 'round',
-          'line-cap': 'round'
-        },
-        paint: {
-          'line-color': '#ff56ba',
-          'line-width': 3
-        }
-      })
+      for (const maskBand of maskBands) {
+        map.addLayer({
+          id: maskBand.layerId,
+          type: 'line',
+          source: 'masks',
+          'source-layer': maskBand.sourceLayer,
+          minzoom: maskBand.minzoom,
+          maxzoom: maskBand.maxzoom,
+          layout: {
+            'line-join': 'round',
+            'line-cap': 'round'
+          },
+          paint: {
+            'line-color': '#ff56ba',
+            'line-width': maskBand.lineWidth,
+            'line-opacity': maskBand.lineOpacity
+          },
+          filter: getMaskFilter(maxAreaSqrt ** 2)
+        })
+      }
 
       warpedMapLayer = new WarpedMapLayer()
 
-      // @ts-expect-error incorrect MapLibre types
       map.addLayer(warpedMapLayer)
 
       layersAdded = true
@@ -197,7 +193,9 @@
 
   $effect(() => {
     if (layersAdded) {
-      map.setFilter('masks', getFilters(maxAreaSqrt ** 2))
+      for (const maskLayerId of maskLayerIds) {
+        map.setFilter(maskLayerId, getMaskFilter(maxAreaSqrt ** 2))
+      }
       updateFeatures()
     }
   })
@@ -244,7 +242,7 @@
                   mode="contain"
                 />
               </a>
-              <div class="flex-shrink-0 flex gap-2 flex-wrap">
+              <div class="shrink-0 flex gap-2 flex-wrap">
                 <button
                   onclick={() => showOnMap(feature.properties.id)}
                   class="py-2.5 px-5 text-sm focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-100"

--- a/tools/data-export/README.md
+++ b/tools/data-export/README.md
@@ -65,6 +65,19 @@ The PMTiles command reads `maps-flattened.geojson` and writes:
 
 - `maps.pmtiles`
 
+`maps.pmtiles` contains one vector source layer per map area band. Area is in
+square meters and the bands overlap in zoom so Explore can render adjacent
+scales together:
+
+| Source layer      |                                   Area | Tile zooms |
+| ----------------- | -------------------------------------: | ---------: |
+| `masks_global`    |                `>= 10,000,000,000,000` |        0-5 |
+| `masks_continent` | `1,000,000,000,000-10,000,000,000,000` |        2-7 |
+| `masks_country`   |     `10,000,000,000-1,000,000,000,000` |        4-9 |
+| `masks_region`    |           `100,000,000-10,000,000,000` |       6-11 |
+| `masks_city`      |                `1,000,000-100,000,000` |       8-13 |
+| `masks_local`     |                          `< 1,000,000` |      10-14 |
+
 Next implementation steps:
 
 - upload completed files to R2

--- a/tools/data-export/scripts/pmtiles.sh
+++ b/tools/data-export/scripts/pmtiles.sh
@@ -19,13 +19,14 @@ fi
 
 tippecanoe \
   -f \
-  -z8 \
+  -z14 \
   --simplify-only-low-zooms \
-  --full-detail=24 \
+  --full-detail=18 \
   --visvalingam \
   --drop-densest-as-needed \
   --projection=EPSG:4326 \
   -y id \
+  -y tileBand \
   -y scale \
   -y area \
   -y modified \
@@ -35,5 +36,4 @@ tippecanoe \
   -y resourceHeight \
   -y imageServiceDomain \
   -o "$OUTPUT_PATH" \
-  -l masks \
   "$INPUT_PATH"

--- a/tools/data-export/scripts/upload.sh
+++ b/tools/data-export/scripts/upload.sh
@@ -5,4 +5,10 @@ set -euo pipefail
 OUTPUT_DIR="${DATA_EXPORT_OUTPUT_DIR:-./data}"
 R2_DESTINATION="${DATA_EXPORT_R2_DESTINATION:-r2:allmaps-files}"
 
+if [[ "$R2_DESTINATION" == http://* || "$R2_DESTINATION" == https://* ]]; then
+  echo "DATA_EXPORT_R2_DESTINATION must be an rclone destination like r2:allmaps-files, not an endpoint URL." >&2
+  echo "Put the Cloudflare R2 endpoint URL in RCLONE_CONFIG_R2_ENDPOINT instead." >&2
+  exit 1
+fi
+
 rclone --config="./config/rclone.conf" copy "$OUTPUT_DIR" "$R2_DESTINATION"

--- a/tools/data-export/src/tile-bands.ts
+++ b/tools/data-export/src/tile-bands.ts
@@ -1,0 +1,75 @@
+export type TileBand = {
+  id: string
+  layer: string
+  minArea: number
+  maxArea: number
+  minzoom: number
+  maxzoom: number
+}
+
+export const tileBands = [
+  {
+    id: 'global',
+    layer: 'masks_global',
+    minArea: 10_000_000_000_000,
+    maxArea: Infinity,
+    minzoom: 0,
+    maxzoom: 5
+  },
+  {
+    id: 'continent',
+    layer: 'masks_continent',
+    minArea: 1_000_000_000_000,
+    maxArea: 10_000_000_000_000,
+    minzoom: 2,
+    maxzoom: 7
+  },
+  {
+    id: 'country',
+    layer: 'masks_country',
+    minArea: 10_000_000_000,
+    maxArea: 1_000_000_000_000,
+    minzoom: 4,
+    maxzoom: 9
+  },
+  {
+    id: 'region',
+    layer: 'masks_region',
+    minArea: 100_000_000,
+    maxArea: 10_000_000_000,
+    minzoom: 6,
+    maxzoom: 11
+  },
+  {
+    id: 'city',
+    layer: 'masks_city',
+    minArea: 1_000_000,
+    maxArea: 100_000_000,
+    minzoom: 8,
+    maxzoom: 13
+  },
+  {
+    id: 'local',
+    layer: 'masks_local',
+    minArea: 0,
+    maxArea: 1_000_000,
+    minzoom: 10,
+    maxzoom: 14
+  }
+] as const satisfies readonly TileBand[]
+
+export function getTileBand(area: number | undefined): TileBand {
+  if (typeof area !== 'number' || !Number.isFinite(area)) {
+    return tileBands.at(-1) as TileBand
+  }
+
+  const tileBand = tileBands.find(
+    (tileBand) => area >= tileBand.minArea && area < tileBand.maxArea
+  )
+
+  if (!tileBand) {
+    throw new Error(`No tile band found for area ${area}`)
+  }
+
+  return tileBand
+}

--- a/tools/data-export/src/writers.ts
+++ b/tools/data-export/src/writers.ts
@@ -12,6 +12,7 @@ import {
   serializeDomainCounts,
   type DomainCounts
 } from './domains.ts'
+import { getTileBand } from './tile-bands.ts'
 
 import type { ApiMap } from '@allmaps/api-shared/types'
 import type { Writable } from 'node:stream'
@@ -112,11 +113,18 @@ function generateFlattenedFeature(map: ApiMap) {
   const feature = generateFeature(map)
   const mapUrl = getRequiredString(map._allmaps?.id ?? map.id, 'map id')
   const modified = getRequiredString(map.modified, 'map modified date')
+  const tileBand = getTileBand(map._allmaps?.area)
 
   return {
     type: 'Feature',
+    tippecanoe: {
+      layer: tileBand.layer,
+      minzoom: tileBand.minzoom,
+      maxzoom: tileBand.maxzoom
+    },
     properties: {
       mapId: getLastPathPart(mapUrl),
+      tileBand: tileBand.id,
       modified: Math.floor(Date.parse(modified) / 1000),
       id: mapUrl,
       scale: map._allmaps?.scale,


### PR DESCRIPTION
This pull request introduces a new system for organizing and rendering map mask layers by area bands, improving both the data export pipeline and the Explore app's map rendering logic. The main changes include splitting masks into multiple vector layers based on area, updating the frontend to handle these layers, and adjusting data export scripts and documentation accordingly.

**Map rendering and logic improvements:**

* Added `maskBands` and related utilities in `mask-bands.ts` to define mask layers by area band, including their IDs, zoom ranges, and style properties. Also provides a shared filter function for consistent layer filtering.
* Updated `+page.svelte` to use the new `maskBands` and `maskLayerIds` for adding multiple mask layers, setting their filters, and querying features, instead of a single `masks` layer. This includes dynamic layer creation and filtering logic based on the area band configuration. [[1]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L20-R25) [[2]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L45-R52) [[3]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6R141-L167) [[4]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L200-R198)
* Minor UI fix: changed `flex-shrink-0` to `shrink-0` for a button container.

**Data export pipeline changes:**

* Added `tile-bands.ts` to define area bands and a utility to determine the correct band for a given area.
* Updated `writers.ts` to assign each feature a `tileBand` and tippecanoe layer/zoom properties based on area, ensuring features are exported to the correct vector layer. [[1]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5R15) [[2]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5R116-R127)
* Adjusted `pmtiles.sh` to export all relevant properties, remove the single `masks` layer, and increase the maximum zoom to 14 for finer granularity. [[1]](diffhunk://#diff-db02b062709e15dd5a45c41a02d7c55b71b04b18ebedc1983a5b8306f1405b13L22-R29) [[2]](diffhunk://#diff-db02b062709e15dd5a45c41a02d7c55b71b04b18ebedc1983a5b8306f1405b13L38)
* Improved validation in `upload.sh` to ensure correct R2 destination configuration.

**Documentation:**

* Updated `README.md` to document the new area bands, their corresponding source layers, and zoom ranges for `maps.pmtiles`.

These changes together enable more flexible and performant rendering of mask layers by area, and ensure the data export pipeline and frontend are in sync regarding mask layer structure.