### PR TITLE
Fixed broken tileserver by making rendering work when `createRTree: false`

### DIFF
--- a/packages/render/src/maps/WarpedMapList.ts
+++ b/packages/render/src/maps/WarpedMapList.ts
@@ -1,4 +1,5 @@
 import proj4 from 'proj4'
+import inside from 'point-in-polygon-hao'
 
 import { generateChecksum } from '@allmaps/id/sync'
 import {
@@ -16,12 +17,15 @@ import { WebGL2WarpedMap } from './WebGL2WarpedMap.js'
 import {
   bboxToCenter,
   bboxToLine,
+  closePolygon,
   computeBbox,
   convexHull,
+  doBboxesIntersect,
   mergeOptions,
   mergePartialOptions,
   optionKeysByMapIdToUndefinedOptionsByMapId,
-  optionKeysToUndefinedOptions
+  optionKeysToUndefinedOptions,
+  pointInBbox
 } from '@allmaps/stdlib'
 import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
 
@@ -366,27 +370,46 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
       if (selectionAndProjectionOptions.geoPoint) {
         // Select by geoPoint
         if (selectionAndProjectionOptions.applyMask) {
-          mapIds = this.geoMaskRTree?.searchFromPoint(
-            selectionAndProjectionOptions.geoPoint
-          )
+          mapIds =
+            this.geoMaskRTree?.searchFromPoint(
+              selectionAndProjectionOptions.geoPoint
+            ) ??
+            this.#getMapIdsFromPoint(
+              selectionAndProjectionOptions.geoPoint,
+              (warpedMap) => warpedMap.geoMaskBbox,
+              (warpedMap) => warpedMap.geoMask
+            )
         } else {
-          mapIds = this.geoFullMaskRTree?.searchFromPoint(
-            selectionAndProjectionOptions.geoPoint
-          )
+          mapIds =
+            this.geoFullMaskRTree?.searchFromPoint(
+              selectionAndProjectionOptions.geoPoint
+            ) ??
+            this.#getMapIdsFromPoint(
+              selectionAndProjectionOptions.geoPoint,
+              (warpedMap) => warpedMap.geoFullMaskBbox,
+              (warpedMap) => warpedMap.geoFullMask
+            )
         }
       } else if (selectionAndProjectionOptions.geoBbox) {
         // Select by geoBbox
-        mapIds = this.geoMaskRTree?.searchFromBbox(
-          selectionAndProjectionOptions.geoBbox
-        )
         if (selectionAndProjectionOptions.applyMask) {
-          mapIds = this.geoMaskRTree?.searchFromBbox(
-            selectionAndProjectionOptions.geoBbox
-          )
+          mapIds =
+            this.geoMaskRTree?.searchFromBbox(
+              selectionAndProjectionOptions.geoBbox
+            ) ??
+            this.#getMapIdsFromBbox(
+              selectionAndProjectionOptions.geoBbox,
+              (warpedMap) => warpedMap.geoMaskBbox
+            )
         } else {
-          mapIds = this.geoFullMaskRTree?.searchFromBbox(
-            selectionAndProjectionOptions.geoBbox
-          )
+          mapIds =
+            this.geoFullMaskRTree?.searchFromBbox(
+              selectionAndProjectionOptions.geoBbox
+            ) ??
+            this.#getMapIdsFromBbox(
+              selectionAndProjectionOptions.geoBbox,
+              (warpedMap) => warpedMap.geoFullMaskBbox
+            )
         }
       } else if (selectionAndProjectionOptions.projectedGeoPoint) {
         // Select by projectedGeoPoint
@@ -397,10 +420,22 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
         )
         if (selectionAndProjectionOptions.applyMask) {
           mapIds =
-            this.projectedGeoMaskRTree?.searchFromPoint(projectedGeoPoint)
+            this.projectedGeoMaskRTree?.searchFromPoint(projectedGeoPoint) ??
+            this.#getMapIdsFromPoint(
+              projectedGeoPoint,
+              (warpedMap) => warpedMap.projectedGeoMaskBbox,
+              (warpedMap) => warpedMap.projectedGeoMask
+            )
         } else {
           mapIds =
-            this.projectedGeoFullMaskRTree?.searchFromPoint(projectedGeoPoint)
+            this.projectedGeoFullMaskRTree?.searchFromPoint(
+              projectedGeoPoint
+            ) ??
+            this.#getMapIdsFromPoint(
+              projectedGeoPoint,
+              (warpedMap) => warpedMap.projectedGeoFullMaskBbox,
+              (warpedMap) => warpedMap.projectedGeoFullMask
+            )
         }
       } else if (selectionAndProjectionOptions.projectedGeoBbox) {
         // Select by projectedGeoBbox
@@ -410,10 +445,19 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
           selectionAndProjectionOptions.projectedGeoBbox
         )
         if (selectionAndProjectionOptions.applyMask) {
-          mapIds = this.projectedGeoMaskRTree?.searchFromBbox(projectedGeoBbox)
+          mapIds =
+            this.projectedGeoMaskRTree?.searchFromBbox(projectedGeoBbox) ??
+            this.#getMapIdsFromBbox(
+              projectedGeoBbox,
+              (warpedMap) => warpedMap.projectedGeoMaskBbox
+            )
         } else {
-          mapIds = mapIds =
-            this.projectedGeoFullMaskRTree?.searchFromBbox(projectedGeoBbox)
+          mapIds =
+            this.projectedGeoFullMaskRTree?.searchFromBbox(projectedGeoBbox) ??
+            this.#getMapIdsFromBbox(
+              projectedGeoBbox,
+              (warpedMap) => warpedMap.projectedGeoFullMaskBbox
+            )
         }
       } else {
         // Select all
@@ -1160,6 +1204,26 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
         warpedMap.projectedGeoFullMask
       ])
     }
+  }
+
+  #getMapIdsFromBbox(bbox: Bbox, getBbox: (warpedMap: W) => Bbox): string[] {
+    return Array.from(this.warpedMapsById.values())
+      .filter((warpedMap) => doBboxesIntersect(bbox, getBbox(warpedMap)))
+      .map((warpedMap) => warpedMap.mapId)
+  }
+
+  #getMapIdsFromPoint(
+    point: Point,
+    getBbox: (warpedMap: W) => Bbox,
+    getMask: (warpedMap: W) => Ring
+  ): string[] {
+    return Array.from(this.warpedMapsById.values())
+      .filter(
+        (warpedMap) =>
+          pointInBbox(point, getBbox(warpedMap)) &&
+          inside(point, closePolygon([getMask(warpedMap)]))
+      )
+      .map((warpedMap) => warpedMap.mapId)
   }
 
   #removeFromRtree(warpedMap: W): void {

--- a/workers/tileserver/src/index.ts
+++ b/workers/tileserver/src/index.ts
@@ -44,6 +44,8 @@ function xyzFromParams(params: unknown): XYZTile {
 // Direct template URL requests - redirect to tiles.allmaps.org
 // -------------------------------------------------------------------------------------------
 
+// First, PNG tiles:
+
 router.get('/%7Bz%7D/%7Bx%7D/%7By%7D@2x.png', (req, env) => {
   const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
   return generateTilesHtml(req, tileViewerBaseUrl, 'retina')
@@ -87,6 +89,54 @@ router.get('/manifests/:manifestId/%7Bz%7D/%7Bx%7D/%7By%7D.png', (req, env) => {
   return generateTilesHtml(req, tileViewerBaseUrl)
 })
 
+// And WebP tiles:
+
+router.get('/%7Bz%7D/%7Bx%7D/%7By%7D@2x.webp', (req, env) => {
+  const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+  return generateTilesHtml(req, tileViewerBaseUrl, 'retina')
+})
+
+router.get('/%7Bz%7D/%7Bx%7D/%7By%7D.webp', (req, env) => {
+  const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+  return generateTilesHtml(req, tileViewerBaseUrl)
+})
+
+router.get('/maps/:mapId/%7Bz%7D/%7Bx%7D/%7By%7D@2x.webp', (req, env) => {
+  const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+  return generateTilesHtml(req, tileViewerBaseUrl, 'retina')
+})
+
+router.get('/maps/:mapId/%7Bz%7D/%7Bx%7D/%7By%7D.png', (req, env) => {
+  const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+  return generateTilesHtml(req, tileViewerBaseUrl)
+})
+
+router.get('/images/:imageId/%7Bz%7D/%7Bx%7D/%7By%7D@2x.webp', (req, env) => {
+  const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+  return generateTilesHtml(req, tileViewerBaseUrl, 'retina')
+})
+
+router.get('/images/:imageId/%7Bz%7D/%7Bx%7D/%7By%7D.webp', (req, env) => {
+  const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+  return generateTilesHtml(req, tileViewerBaseUrl)
+})
+
+router.get(
+  '/manifests/:manifestId/%7Bz%7D/%7Bx%7D/%7By%7D@2x.webp',
+  (req, env) => {
+    const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+    return generateTilesHtml(req, tileViewerBaseUrl, 'retina')
+  }
+)
+
+router.get(
+  '/manifests/:manifestId/%7Bz%7D/%7Bx%7D/%7By%7D.webp',
+  (req, env) => {
+    const tileViewerBaseUrl = env.PUBLIC_TILE_VIEWER_BASE_URL
+    return generateTilesHtml(req, tileViewerBaseUrl)
+  }
+)
+
 // -------------------------------------------------------------------------------------------
 // TileJSON
 // -------------------------------------------------------------------------------------------
@@ -96,9 +146,12 @@ router.get('/tiles@2x.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/{z}/{x}/{y}@2x.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/{z}/{x}/{y}@2x.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/{z}/{x}/{y}@2x.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/tiles.json', async (req, env) => {
@@ -106,9 +159,12 @@ router.get('/tiles.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/{z}/{x}/{y}.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/{z}/{x}/{y}.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/{z}/{x}/{y}.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/maps/:mapId/tiles@2x.json', async (req, env) => {
@@ -117,9 +173,12 @@ router.get('/maps/:mapId/tiles@2x.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}@2x.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}@2x.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}@2x.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/maps/:mapId/tiles.json', async (req, env) => {
@@ -128,9 +187,12 @@ router.get('/maps/:mapId/tiles.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/maps/${mapId}/{z}/{x}/{y}.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/images/:imageId/tiles@2x.json', async (req, env) => {
@@ -139,9 +201,12 @@ router.get('/images/:imageId/tiles@2x.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}@2x.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}@2x.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}@2x.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/images/:imageId/tiles.json', async (req, env) => {
@@ -150,9 +215,12 @@ router.get('/images/:imageId/tiles.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/images/${imageId}/{z}/{x}/{y}.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/manifests/:manifestId/tiles@2x.json', async (req, env) => {
@@ -161,9 +229,12 @@ router.get('/manifests/:manifestId/tiles@2x.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}@2x.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}@2x.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}@2x.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 router.get('/manifests/:manifestId/tiles.json', async (req, env) => {
@@ -172,9 +243,12 @@ router.get('/manifests/:manifestId/tiles.json', async (req, env) => {
   const options = optionsFromQuery(req)
 
   const url = new URL(req.url)
-  const urlTemplate = `${env.PUBLIC_TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}.webp${url.search}`
+  const urlTemplates = [
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}.png${url.search}`,
+    `${env.PUBLIC_TILE_SERVER_BASE_URL}/manifests/${manifestId}/{z}/{x}/{y}.webp${url.search}`
+  ]
 
-  return generateTileJsonResponse(env, maps, options, urlTemplate)
+  return generateTileJsonResponse(env, maps, options, urlTemplates)
 })
 
 // -------------------------------------------------------------------------------------------

--- a/workers/tileserver/src/lib/tilejson.ts
+++ b/workers/tileserver/src/lib/tilejson.ts
@@ -13,7 +13,7 @@ export async function generateTileJsonResponse(
   env: WorkerEnv,
   georeferencedMaps: GeoreferencedMap[],
   options: TransformationOptions,
-  urlTemplate: string
+  urlTemplates: string[]
 ): Promise<Response> {
   // TODO: simplify this when this will be aligned with TransformationOptions from @allmaps/render
   let transformationType
@@ -43,8 +43,8 @@ export async function generateTileJsonResponse(
 
   return json({
     tilejson: '3.0.0',
-    id: urlTemplate,
-    tiles: [urlTemplate],
+    id: urlTemplates[0],
+    tiles: urlTemplates,
     fields: {},
     bounds,
     center


### PR DESCRIPTION
This pull request introduces two main improvements: enhanced map selection logic in the rendering package to provide robust fallbacks when spatial indexes are unavailable, and expanded support for both PNG and WebP tile formats in the tile server, including updates to the TileJSON responses to advertise both formats. These changes improve reliability and compatibility across different environments and clients.

**Rendering: Improved Map Selection Fallbacks**
- Added fallback methods (`#getMapIdsFromPoint`, `#getMapIdsFromBbox`) in `WarpedMapList` to select maps by point or bounding box when R-tree spatial indexes are not available, ensuring consistent selection behavior. These methods use geometric checks (`doBboxesIntersect`, `pointInBbox`, and polygon containment) for robust filtering. [[1]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L369-R411) [[2]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L400-R438) [[3]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L413-R460) [[4]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R1209-R1228)
- Imported new geometric utility functions and a polygon containment library to support the fallback logic. [[1]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R2) [[2]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R20-R28)

**Tile Server: Expanded Tile Format Support**
- Added new route handlers to serve both PNG and WebP tile images (including retina variants) for all tile endpoints, increasing compatibility with clients that may not support WebP. [[1]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359R47-R48) [[2]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359R92-R139)
- Updated all TileJSON endpoints to advertise both PNG and WebP URL templates, ensuring clients are aware of all available formats. [[1]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L99-R167) [[2]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L120-R181) [[3]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L131-R195) [[4]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L142-R209) [[5]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L153-R223) [[6]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L164-R237) [[7]](diffhunk://#diff-e1ef7cdd0e8311042cb5da5d65d8076e5cf3e6f90f757193f88551b08ab61359L175-R251)
- Modified the `generateTileJsonResponse` function to accept and return multiple tile URL templates, reflecting the expanded format support in the TileJSON output. [[1]](diffhunk://#diff-84fcc7c1d897af58a577abce750ab551667260985682ec8c62c3af592dba7195L16-R16) [[2]](diffhunk://#diff-84fcc7c1d897af58a577abce750ab551667260985682ec8c62c3af592dba7195L46-R47)