### PR TITLE
more overlap between mask layers

### DIFF
--- a/tools/data-export/README.md
+++ b/tools/data-export/README.md
@@ -66,16 +66,17 @@ The PMTiles command reads `maps-flattened.geojson` and writes:
 - `maps.pmtiles`
 
 `maps.pmtiles` contains one vector source layer per map area band. Area is in
-square meters and the bands overlap in zoom so Explore can render adjacent
-scales together:
+square meters. The zoom ranges keep each band available for Explore's visual
+fade window. City and local-scale maps are kept through z14 so they can be
+overzoomed when Explore is zoomed further in:
 
 | Source layer      |                                   Area | Tile zooms |
 | ----------------- | -------------------------------------: | ---------: |
-| `masks_global`    |                `>= 10,000,000,000,000` |        0-5 |
-| `masks_continent` | `1,000,000,000,000-10,000,000,000,000` |        2-7 |
-| `masks_country`   |     `10,000,000,000-1,000,000,000,000` |        4-9 |
-| `masks_region`    |           `100,000,000-10,000,000,000` |       6-11 |
-| `masks_city`      |                `1,000,000-100,000,000` |       8-13 |
+| `masks_global`    |                `>= 10,000,000,000,000` |        0-6 |
+| `masks_continent` | `1,000,000,000,000-10,000,000,000,000` |        2-8 |
+| `masks_country`   |     `10,000,000,000-1,000,000,000,000` |       4-10 |
+| `masks_region`    |           `100,000,000-10,000,000,000` |       6-12 |
+| `masks_city`      |                `1,000,000-100,000,000` |       8-14 |
 | `masks_local`     |                          `< 1,000,000` |      10-14 |
 
 Next implementation steps:

--- a/tools/data-export/src/tile-bands.ts
+++ b/tools/data-export/src/tile-bands.ts
@@ -14,7 +14,7 @@ export const tileBands = [
     minArea: 10_000_000_000_000,
     maxArea: Infinity,
     minzoom: 0,
-    maxzoom: 5
+    maxzoom: 6
   },
   {
     id: 'continent',
@@ -22,7 +22,7 @@ export const tileBands = [
     minArea: 1_000_000_000_000,
     maxArea: 10_000_000_000_000,
     minzoom: 2,
-    maxzoom: 7
+    maxzoom: 8
   },
   {
     id: 'country',
@@ -30,7 +30,7 @@ export const tileBands = [
     minArea: 10_000_000_000,
     maxArea: 1_000_000_000_000,
     minzoom: 4,
-    maxzoom: 9
+    maxzoom: 10
   },
   {
     id: 'region',
@@ -38,7 +38,7 @@ export const tileBands = [
     minArea: 100_000_000,
     maxArea: 10_000_000_000,
     minzoom: 6,
-    maxzoom: 11
+    maxzoom: 12
   },
   {
     id: 'city',
@@ -46,7 +46,7 @@ export const tileBands = [
     minArea: 1_000_000,
     maxArea: 100_000_000,
     minzoom: 8,
-    maxzoom: 13
+    maxzoom: 14
   },
   {
     id: 'local',


### PR DESCRIPTION
This pull request updates the zoom ranges for the vector source layers used to generate `maps.pmtiles`, ensuring that city and local-scale maps remain available through higher zoom levels for better overzooming and visual fade effects in Explore. The changes keep the documentation and the tile band definitions in sync.

**Tile band zoom range adjustments:**

* Increased the `maxzoom` for each tile band (`masks_global`, `masks_continent`, `masks_country`, `masks_region`, `masks_city`) by 1 to extend their availability at higher zoom levels in both the code (`tile-bands.ts`) and documentation (`README.md`). [[1]](diffhunk://#diff-e8281f215224a4c6d4bba0cf79157e3eab306ad1437cf419c39497aa9bc9565eL17-R49) [[2]](diffhunk://#diff-33b9b94edd76c9cf0dab5e6761467b4be413569d4e232b8a9e4114cc6c039628L69-R79)

**Documentation improvements:**

* Updated the explanation in `README.md` to clarify that the new zoom ranges support Explore's visual fade window and allow city and local-scale maps to be overzoomed when zoomed in further.