### PR TITLE
added minzoom and maxzoom to tilejson

### DIFF
--- a/workers/tileserver/src/lib/tilejson.ts
+++ b/workers/tileserver/src/lib/tilejson.ts
@@ -1,5 +1,6 @@
 import { json } from 'itty-router'
-import { WarpedMapList } from '@allmaps/render'
+import { WarpedMapList, type WarpedMap } from '@allmaps/render'
+import { lonLatToWebMercator } from '@allmaps/project'
 
 import { createCachedFetch } from './fetch.js'
 
@@ -7,6 +8,15 @@ import type { TransformationOptions } from './types.js'
 
 import type { GeoreferencedMap } from '@allmaps/annotation'
 import type { WorkerEnv } from '@allmaps/env/worker'
+import type { Bbox, Point, Size } from '@allmaps/types'
+
+const MIN_ZOOM = 0
+const MAX_TILEJSON_ZOOM = 30
+
+const DEFAULT_TILEJSON_VIEWPORT_SIZE: Size = [512, 512]
+
+// Web Mercator meters per CSS pixel at z0 for 256px XYZ tiles.
+const WEB_MERCATOR_INITIAL_RESOLUTION = 156543.03392804097
 
 // See https://github.com/mapbox/tilejson-spec/blob/master/3.0.0/example/osm.json
 export async function generateTileJsonResponse(
@@ -41,13 +51,68 @@ export async function generateTileJsonResponse(
     throw new Error('Could not compute bounding box and center of maps')
   }
 
+  const minzoom = MIN_ZOOM
+  const maxzoom = getMaxZoom(warpedMapList)
+  const centerZoom = getFitZoom(bounds, maxzoom)
+
   return json({
     tilejson: '3.0.0',
+    // TODO: add name and description fields
+    // name:
+    // description:
     id: urlTemplates[0],
     tiles: urlTemplates,
     fields: {},
     bounds,
-    center
-    // TODO: add minzoom and maxzoom
+    center: [...center, centerZoom],
+    minzoom,
+    maxzoom
   })
+}
+
+function getMaxZoom(warpedMapList: WarpedMapList<WarpedMap>): number {
+  const nativeZooms = warpedMapList.getWarpedMaps().map((warpedMap) => {
+    return Math.log2(
+      WEB_MERCATOR_INITIAL_RESOLUTION * warpedMap.resourceToProjectedGeoScale
+    )
+  })
+
+  return clampZoom(Math.ceil(Math.max(...nativeZooms)))
+}
+
+function getFitZoom(
+  bounds: Bbox,
+  maxzoom: number,
+  viewportSize = DEFAULT_TILEJSON_VIEWPORT_SIZE
+): number {
+  const projectedBbox = geoBboxToProjectedGeoBbox(bounds)
+  const projectedSize = bboxToSize(projectedBbox)
+
+  const zoomForWidth = Math.log2(
+    viewportSize[0] / (projectedSize[0] / WEB_MERCATOR_INITIAL_RESOLUTION)
+  )
+  const zoomForHeight = Math.log2(
+    viewportSize[1] / (projectedSize[1] / WEB_MERCATOR_INITIAL_RESOLUTION)
+  )
+
+  return clampZoom(Math.floor(Math.min(zoomForWidth, zoomForHeight)), maxzoom)
+}
+
+function geoBboxToProjectedGeoBbox([west, south, east, north]: Bbox): Bbox {
+  return [
+    ...lonLatToWebMercator([west, south] as Point),
+    ...lonLatToWebMercator([east, north] as Point)
+  ]
+}
+
+function bboxToSize([minX, minY, maxX, maxY]: Bbox): Size {
+  return [Math.abs(maxX - minX), Math.abs(maxY - minY)]
+}
+
+function clampZoom(zoom: number, maxzoom = MAX_TILEJSON_ZOOM): number {
+  if (!Number.isFinite(zoom)) {
+    return MIN_ZOOM
+  }
+
+  return Math.min(maxzoom, Math.max(MIN_ZOOM, zoom))
 }

--- a/workers/tileserver/src/lib/types.ts
+++ b/workers/tileserver/src/lib/types.ts
@@ -11,10 +11,10 @@ export type Tilejson = {
   id: string | undefined
   tiles: string[]
   fields: object
-  bounds: number[]
-  center: number[]
-  // maxzoom
-  // minzoom
+  bounds: [number, number, number, number]
+  center: [number, number, number]
+  minzoom: number
+  maxzoom: number
 }
 
 // TODO: align this with TransformationOptions from @allmaps/render


### PR DESCRIPTION
This pull request enhances the TileJSON generation logic in the tileserver by calculating and including appropriate zoom levels and improving type safety. The main changes involve computing `minzoom`, `maxzoom`, and a fitting `center` zoom for the TileJSON response, as well as updating type definitions to match the new response structure.

**TileJSON zoom and center enhancements:**

* [`workers/tileserver/src/lib/tilejson.ts`](diffhunk://#diff-84fcc7c1d897af58a577abce750ab551667260985682ec8c62c3af592dba7195L2-R19): Added logic to compute `minzoom`, `maxzoom`, and a fitting zoom for the `center` field based on the warped maps and their bounding boxes. Introduced helper functions for zoom calculation, bounding box projection, and clamping zoom levels. [[1]](diffhunk://#diff-84fcc7c1d897af58a577abce750ab551667260985682ec8c62c3af592dba7195L2-R19) [[2]](diffhunk://#diff-84fcc7c1d897af58a577abce750ab551667260985682ec8c62c3af592dba7195R54-R117)

**Type definition updates:**

* [`workers/tileserver/src/lib/types.ts`](diffhunk://#diff-802af0b1118f8fcb08000a9c9b9502add08a5a67e8950f5d826f9d91a181e9f3L14-R17): Updated the `Tilejson` type to require `bounds` as a fixed-length tuple, `center` as a three-element tuple, and added `minzoom` and `maxzoom` properties.