### PR TITLE
more overlap between layers, and no more area slider

### DIFF
--- a/apps/explore/src/lib/shared/mask-bands.ts
+++ b/apps/explore/src/lib/shared/mask-bands.ts
@@ -1,4 +1,6 @@
-import type { FilterSpecification } from 'maplibre-gl'
+import type { ExpressionSpecification, FilterSpecification } from 'maplibre-gl'
+
+export const masksSourceMaxzoom = 14
 
 export type MaskBand = {
   id: string
@@ -6,6 +8,8 @@ export type MaskBand = {
   sourceLayer: string
   minzoom: number
   maxzoom: number
+  fullMinzoom: number
+  fullMaxzoom: number
   lineWidth: number
   lineOpacity: number
 }
@@ -17,6 +21,8 @@ export const maskBands = [
     sourceLayer: 'masks_global',
     minzoom: 0,
     maxzoom: 6,
+    fullMinzoom: 0,
+    fullMaxzoom: 5,
     lineWidth: 1.25,
     lineOpacity: 0.4
   },
@@ -26,6 +32,8 @@ export const maskBands = [
     sourceLayer: 'masks_continent',
     minzoom: 2,
     maxzoom: 8,
+    fullMinzoom: 3,
+    fullMaxzoom: 7,
     lineWidth: 1.5,
     lineOpacity: 0.5
   },
@@ -35,6 +43,8 @@ export const maskBands = [
     sourceLayer: 'masks_country',
     minzoom: 4,
     maxzoom: 10,
+    fullMinzoom: 5,
+    fullMaxzoom: 9,
     lineWidth: 1.75,
     lineOpacity: 0.6
   },
@@ -44,6 +54,8 @@ export const maskBands = [
     sourceLayer: 'masks_region',
     minzoom: 6,
     maxzoom: 12,
+    fullMinzoom: 7,
+    fullMaxzoom: 11,
     lineWidth: 2,
     lineOpacity: 0.7
   },
@@ -52,7 +64,9 @@ export const maskBands = [
     layerId: 'masks-city',
     sourceLayer: 'masks_city',
     minzoom: 8,
-    maxzoom: 14,
+    maxzoom: 18,
+    fullMinzoom: 9,
+    fullMaxzoom: 17,
     lineWidth: 2.5,
     lineOpacity: 0.8
   },
@@ -61,7 +75,9 @@ export const maskBands = [
     layerId: 'masks-local',
     sourceLayer: 'masks_local',
     minzoom: 10,
-    maxzoom: 15,
+    maxzoom: 24,
+    fullMinzoom: 11,
+    fullMaxzoom: 24,
     lineWidth: 3,
     lineOpacity: 0.9
   }
@@ -69,11 +85,34 @@ export const maskBands = [
 
 export const maskLayerIds = maskBands.map((maskBand) => maskBand.layerId)
 
-export function getMaskFilter(maxArea: number): FilterSpecification {
-  return [
-    'all',
-    ['>=', 'area', 0],
-    ['<=', 'area', maxArea],
-    ['!=', 'imageServiceDomain', 'iiif.nypl.org']
-  ]
+export function getMaskOpacity(maskBand: MaskBand): ExpressionSpecification {
+  const stops: unknown[] = ['interpolate', ['linear'], ['zoom']]
+
+  if (maskBand.minzoom === 0) {
+    stops.push(
+      maskBand.minzoom,
+      maskBand.lineOpacity,
+      maskBand.fullMaxzoom,
+      maskBand.lineOpacity
+    )
+  } else {
+    stops.push(
+      maskBand.minzoom,
+      0,
+      maskBand.fullMinzoom,
+      maskBand.lineOpacity,
+      maskBand.fullMaxzoom,
+      maskBand.lineOpacity
+    )
+  }
+
+  if (maskBand.fullMaxzoom < maskBand.maxzoom) {
+    stops.push(maskBand.maxzoom, 0)
+  }
+
+  return stops as ExpressionSpecification
+}
+
+export function getMaskFilter(): FilterSpecification {
+  return ['!=', 'imageServiceDomain', 'iiif.nypl.org']
 }

--- a/apps/explore/src/routes/+page.svelte
+++ b/apps/explore/src/routes/+page.svelte
@@ -22,7 +22,13 @@
   import { PUBLIC_GEOCODE_EARTH_API_KEY } from '$env/static/public'
 
   import { formatTimeAgo } from '$lib/shared/format.js'
-  import { getMaskFilter, maskBands, maskLayerIds } from '$lib/shared/mask-bands.js'
+  import {
+    getMaskFilter,
+    getMaskOpacity,
+    maskBands,
+    maskLayerIds,
+    masksSourceMaxzoom
+  } from '$lib/shared/mask-bands.js'
 
   import type { Bbox } from '@allmaps/types'
   import type { GeocoderGeoJsonFeature } from '@allmaps/components/geocoder'
@@ -41,11 +47,6 @@
   let features: MapGeoJSONFeature[] = $state([])
 
   let lastModifiedAgo: string | undefined = $state('')
-
-  const minMaxArea = 100_000
-  const maxMaxAea = 300_000_000_000_000
-
-  let maxAreaSqrt = $state(Math.sqrt(maxMaxAea))
 
   function updateFeatures() {
     const newFeatures = map.queryRenderedFeatures({
@@ -135,7 +136,8 @@
     map.on('load', () => {
       map.addSource('masks', {
         type: 'vector',
-        url: `pmtiles://${pmtilesUrl}`
+        tiles: [`pmtiles://${pmtilesUrl}/{z}/{x}/{y}`],
+        maxzoom: masksSourceMaxzoom
       })
 
       for (const maskBand of maskBands) {
@@ -153,9 +155,9 @@
           paint: {
             'line-color': '#ff56ba',
             'line-width': maskBand.lineWidth,
-            'line-opacity': maskBand.lineOpacity
+            'line-opacity': getMaskOpacity(maskBand)
           },
-          filter: getMaskFilter(maxAreaSqrt ** 2)
+          filter: getMaskFilter()
         })
       }
 
@@ -194,7 +196,7 @@
   $effect(() => {
     if (layersAdded) {
       for (const maskLayerId of maskLayerIds) {
-        map.setFilter(maskLayerId, getMaskFilter(maxAreaSqrt ** 2))
+        map.setFilter(maskLayerId, getMaskFilter())
       }
       updateFeatures()
     }
@@ -264,18 +266,6 @@
           </li>
         {/each}
       </ol>
-      <div>
-        <label
-          >Max. area: <input
-            class="w-full"
-            bind:value={maxAreaSqrt}
-            min={Math.sqrt(minMaxArea)}
-            max={Math.sqrt(maxMaxAea)}
-            step={(Math.sqrt(maxMaxAea) - Math.sqrt(minMaxArea)) / 100}
-            type="range"
-          /></label
-        >
-      </div>
     </aside>
   </div>
 </div>


### PR DESCRIPTION
This pull request makes several improvements to how mask bands are configured and rendered on the map, focusing on more flexible zoom and opacity handling, and simplifying filter logic. The changes add new properties to mask bands for finer zoom control, introduce a dynamic opacity expression based on zoom levels, and remove the area-based filter and UI for mask filtering.

**Mask band configuration and rendering improvements:**

* Added `fullMinzoom` and `fullMaxzoom` properties to each `MaskBand` in `mask-bands.ts` for more granular control over when each mask band is fully visible. (`[[1]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L1-R12)`, `[[2]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343R24-R25)`, `[[3]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343R35-R36)`, `[[4]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343R46-R47)`, `[[5]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343R57-R58)`, `[[6]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L55-R69)`, `[[7]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L64-R117)`)
* Updated the maximum zoom for `masks-city` and `masks-local` bands, extending their visibility range. (`[[1]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L55-R69)`, `[[2]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L64-R117)`)

**Opacity and filter logic updates:**

* Replaced the static `lineOpacity` with a new `getMaskOpacity` function that returns a zoom-dependent opacity expression, making mask band opacity fade in/out smoothly at specified zoom levels. (`[[1]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L1-R12)`, `[[2]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L64-R117)`, `[[3]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L25-R31)`, `[[4]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L156-R160)`)
* Simplified the mask filter logic by removing the area-based filter; `getMaskFilter` now only excludes features from a specific domain. All related UI and code for filtering by area have been removed. (`[[1]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L64-R117)`, `[[2]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L45-L49)`, `[[3]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L156-R160)`, `[[4]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L197-R199)`, `[[5]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L267-L278)`)

**Map source and layer setup:**

* Changed the mask vector source setup to use explicit tile URLs and set `maxzoom` using the new `masksSourceMaxzoom` constant, aligning with the new zoom configuration. (`[[1]](diffhunk://#diff-3fd59c9b36b79ad81d72cba06dc998b0689169d1aecde6693dfd4a9853264343L1-R12)`, `[[2]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L138-R140)`, `[[3]](diffhunk://#diff-d0504cf565ef5f4dafd92349295e1006a3448f43ef1edb1859fcb2acd17f88c6L25-R31)`)

These changes make mask rendering more flexible and visually smooth, while simplifying both the codebase and the user interface.