### PR TITLE
Create a JSON file containing the file size of all exported files

### DIFF
--- a/tools/data-export/src/writers.ts
+++ b/tools/data-export/src/writers.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from 'node:fs'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { once } from 'node:events'
 
@@ -21,10 +21,25 @@ type DataExportWritersOptions = {
   outputDirectory: string
 }
 
+type DataExportFile = {
+  filename: string
+  size: number
+}
+
 export type DataExportWriters = {
   close: () => Promise<void>
   writeMap: (map: ApiMap) => Promise<void>
 }
+
+const dataExportFilenames = [
+  'maps.json',
+  'maps.ndjson',
+  'maps.geojson',
+  'maps.geojsonl',
+  'maps-flattened.geojson',
+  'annotations.json',
+  'domains-counted.json'
+]
 
 export async function createDataExportWriters({
   outputDirectory
@@ -94,6 +109,8 @@ export async function createDataExportWriters({
         join(outputDirectory, 'domains-counted.json'),
         `${JSON.stringify(serializeDomainCounts(domainCounts), null, 2)}\n`
       )
+
+      await writeFilesManifest(outputDirectory)
     }
   }
 }
@@ -156,4 +173,18 @@ function getLastPathPart(url: string) {
   } catch {
     return url
   }
+}
+
+async function writeFilesManifest(outputDirectory: string) {
+  const files: DataExportFile[] = await Promise.all(
+    dataExportFilenames.map(async (filename) => ({
+      filename,
+      size: (await stat(join(outputDirectory, filename))).size
+    }))
+  )
+
+  await writeFile(
+    join(outputDirectory, 'files.json'),
+    `${JSON.stringify({ files }, null, 2)}\n`
+  )
 }


### PR DESCRIPTION
This pull request enhances the data export functionality by introducing a manifest file that lists all exported data files along with their sizes. This helps users and downstream processes easily verify and consume the exported files.

**Manifest file generation:**

* Added a new `DataExportFile` type and a list of expected export filenames to track exported files and their sizes. (`tools/data-export/src/writers.ts`) [[1]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5L2-R2) [[2]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5R24-R43)
* Implemented the `writeFilesManifest` function to generate a `files.json` manifest containing the filenames and sizes of all exported files. (`tools/data-export/src/writers.ts`)
* Updated the export process to write the manifest (`files.json`) after all data files are written. (`tools/data-export/src/writers.ts`)