### PR TITLE
Filter organizations by plan

### DIFF
--- a/apis/rest/src/routes/organizations.ts
+++ b/apis/rest/src/routes/organizations.ts
@@ -23,7 +23,11 @@ import {
   queryCanvases,
   queryManifests
 } from '@allmaps/api-shared/db'
-import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
+import {
+  needsElevatedLimitRole,
+  normalizeOrganizationsQueryParams,
+  setCacheControl
+} from '@allmaps/api-shared'
 
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { adminDetail } from '../openapi.js'
@@ -77,16 +81,15 @@ export function createOrganizationsRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/organizations',
-      async ({ db, env, query, request, set }) => {
+      async ({ db, env, request, set }) => {
+        const queryParams = normalizeOrganizationsQueryParams(request)
         const session = await auth.api.getSession({ headers: request.headers })
         if (session?.user.role === 'admin') {
           setCacheControl(set, 'private-no-store')
-          return listOrganizationsWithUsers(
-            db,
-            env.PUBLIC_REST_BASE_URL,
-            query.limit,
-            'admin'
-          )
+          return listOrganizationsWithUsers(db, env.PUBLIC_REST_BASE_URL, {
+            ...queryParams,
+            userRole: 'admin'
+          })
         }
 
         if (session?.user.id) {
@@ -101,17 +104,19 @@ export function createOrganizationsRoutes(
               db,
               env.PUBLIC_REST_BASE_URL,
               organizationIds,
-              query.limit,
-              'user'
+              { ...queryParams, userRole: 'user' }
             )
           }
         }
 
         setCacheControl(set, 'public-medium')
-        return listOrganizations(db, env.PUBLIC_REST_BASE_URL, query.limit)
+        return listOrganizations(db, env.PUBLIC_REST_BASE_URL, queryParams)
       },
       {
-        query: t.Object({ limit: t.Optional(t.Number()) }),
+        query: t.Object({
+          limit: t.Optional(t.Number()),
+          plan: t.Optional(t.Array(t.UnionEnum(['supporter', 'innovator'])))
+        }),
         detail: { summary: 'Get all organizations', tags: ['Organizations'] }
       }
     )

--- a/packages/api-shared/src/index.ts
+++ b/packages/api-shared/src/index.ts
@@ -18,7 +18,10 @@ export {
   needsElevatedLimitRole
 } from './shared/limits.js'
 export type { UserRole } from './shared/limits.js'
-export { normalizeMapsQueryParams } from './shared/query-params.js'
+export {
+  normalizeMapsQueryParams,
+  normalizeOrganizationsQueryParams
+} from './shared/query-params.js'
 export { queryRandom } from './shared/random.js'
 export { setCacheControl } from './elysia/cache.js'
 

--- a/packages/api-shared/src/queries/organizations.ts
+++ b/packages/api-shared/src/queries/organizations.ts
@@ -14,6 +14,7 @@ import { clampLimit } from '../shared/limits.js'
 
 import type { Db, DbOrTx } from '@allmaps/db'
 import type { UserRole } from '../shared/limits.js'
+import type { OrganizationPlan } from '../types.js'
 
 type DbOrganization = {
   id: string
@@ -28,6 +29,12 @@ type DbOrganization = {
     url: string
     type: 'domain'
   }[]
+}
+
+type ListOrganizationsOptions = {
+  limit?: number
+  plans?: OrganizationPlan[]
+  userRole?: UserRole
 }
 
 export function normalizeDomain(value: string): string | undefined {
@@ -168,6 +175,16 @@ export function fromDbOrganizationWithUsers(
   }
 }
 
+function getOrganizationPlanWhere(plans?: OrganizationPlan[]) {
+  if (plans && plans.length > 0) {
+    return {
+      plan: {
+        in: plans
+      }
+    }
+  }
+}
+
 export async function queryOrganizationUrls(
   db: DbOrTx,
   organizationId: string
@@ -208,15 +225,15 @@ export async function replaceOrganizationUrls(
 export async function listOrganizations(
   db: Db,
   restBaseUrl: string,
-  limit?: number,
-  userRole?: UserRole
+  options: ListOrganizationsOptions = {}
 ) {
   const dbOrganizations = await db.query.organizations.findMany({
     with: {
       urls: true
     },
+    where: getOrganizationPlanWhere(options.plans),
     orderBy: (organizations, { asc }) => asc(organizations.name),
-    limit: clampLimit(limit, userRole)
+    limit: clampLimit(options.limit, options.userRole)
   })
 
   return dbOrganizations.map((dbOrganization) =>
@@ -227,16 +244,16 @@ export async function listOrganizations(
 export async function listOrganizationsWithUsers(
   db: Db,
   restBaseUrl: string,
-  limit?: number,
-  userRole?: UserRole
+  options: ListOrganizationsOptions = {}
 ) {
   const [dbOrganizations, usersByOrganizationId] = await Promise.all([
     db.query.organizations.findMany({
       with: {
         urls: true
       },
+      where: getOrganizationPlanWhere(options.plans),
       orderBy: (organizations, { asc }) => asc(organizations.name),
-      limit: clampLimit(limit, userRole)
+      limit: clampLimit(options.limit, options.userRole)
     }),
     queryAllOrganizationUsers(db, restBaseUrl)
   ])
@@ -254,16 +271,16 @@ export async function listOrganizationsWithUsersByOrganizationIds(
   db: Db,
   restBaseUrl: string,
   organizationIds: string[],
-  limit?: number,
-  userRole?: UserRole
+  options: ListOrganizationsOptions = {}
 ) {
   const [dbOrganizations, usersByOrganizationId] = await Promise.all([
     db.query.organizations.findMany({
       with: {
         urls: true
       },
+      where: getOrganizationPlanWhere(options.plans),
       orderBy: (organizations, { asc }) => asc(organizations.name),
-      limit: clampLimit(limit, userRole)
+      limit: clampLimit(options.limit, options.userRole)
     }),
     queryOrganizationUsersByOrganizationIds(db, restBaseUrl, organizationIds)
   ])

--- a/packages/api-shared/src/shared/query-params.ts
+++ b/packages/api-shared/src/shared/query-params.ts
@@ -1,6 +1,12 @@
 import { ResponseError } from './errors.js'
 
-import type { ContainedBy, IntersectsWith, MapsQueryParams } from '../types.js'
+import type {
+  ContainedBy,
+  IntersectsWith,
+  MapsQueryParams,
+  OrganizationPlan,
+  OrganizationsQueryParams
+} from '../types.js'
 
 type MapsQueryParamName =
   | 'limit'
@@ -28,6 +34,8 @@ const mapsQueryParamNames: Record<string, MapsQueryParamName> = {
   modifiedafter: 'modifiedAfter',
   modifiedbefore: 'modifiedBefore'
 }
+
+const organizationPlans = new Set<OrganizationPlan>(['supporter', 'innovator'])
 
 const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/
 const utcDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
@@ -87,6 +95,39 @@ function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
   if (containedBy && containedBy.length === 4) {
     return containedBy as ContainedBy
   }
+}
+
+function parseOrganizationPlanParam(value: string) {
+  if (organizationPlans.has(value as OrganizationPlan)) {
+    return value as OrganizationPlan
+  }
+
+  throw new ResponseError(`Invalid query parameter plan: ${value}`, 400)
+}
+
+export function normalizeOrganizationsQueryParams(
+  request: Request
+): Partial<OrganizationsQueryParams> {
+  const searchParams = new URL(request.url).searchParams
+  const plans = new Set<OrganizationPlan>()
+  const params: Partial<OrganizationsQueryParams> = {}
+
+  for (const [key, value] of searchParams) {
+    switch (key.toLowerCase()) {
+      case 'limit':
+        params.limit = parseNumberParam('limit', value)
+        break
+      case 'plan':
+        plans.add(parseOrganizationPlanParam(value))
+        break
+    }
+  }
+
+  if (plans.size > 0) {
+    params.plans = [...plans]
+  }
+
+  return params
 }
 
 export function normalizeMapsQueryParams(

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -8,6 +8,12 @@ import type { UserRole } from './shared/limits.js'
 
 export type IntersectsWith = [number, number] | [number, number, number, number]
 export type ContainedBy = [number, number, number, number]
+export type OrganizationPlan = 'supporter' | 'innovator'
+
+export type OrganizationsQueryParams = {
+  limit: number
+  plans: OrganizationPlan[]
+}
 
 export type MapsQueryParams = {
   mapId: string


### PR DESCRIPTION
This pull request enhances the organizations API to support filtering organizations by their plan type (e.g., 'supporter', 'innovator') via query parameters. It also refactors query parameter parsing and updates the relevant database query functions to handle these new parameters in a more structured way.

Key changes include:

### API and Query Parameter Handling

* Added support for a `plan` query parameter in the `/organizations` endpoint, allowing clients to filter organizations by plan type. Updated the OpenAPI schema to reflect this new parameter.
* Introduced the `normalizeOrganizationsQueryParams` function to parse and validate `limit` and `plan` parameters from requests, replacing the previous direct usage of the `query` object. [[1]](diffhunk://#diff-7512d61abc482d4b1e08689fb5616b6f9bd50ad405a29e02182fca36d5d1e51dR100-R132) [[2]](diffhunk://#diff-a7760e9a83ffd98cd38c3912f3b9746e5eb76e98db62f5011d260a00e0a9d16eL26-R30) [[3]](diffhunk://#diff-71e7b23d8d15d4ccc86bc1654992c186640022e851cf3a492dabfb82d416a064L21-R24)

### Database Query Enhancements

* Refactored organization listing functions (`listOrganizations`, `listOrganizationsWithUsers`, `listOrganizationsWithUsersByOrganizationIds`) to accept a single `options` object containing `limit`, `plans`, and `userRole`, instead of separate parameters. [[1]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7L211-R236) [[2]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7L230-R256) [[3]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7L257-R283)
* Added a helper function `getOrganizationPlanWhere` to construct database query filters based on the `plans` parameter.

### Type Definitions

* Added new types: `OrganizationPlan` and `OrganizationsQueryParams` to standardize plan filtering and query parameter handling. [[1]](diffhunk://#diff-2f6e9e903fda249111970b037eb48da4e210d6d3a463dcaca6b8d2a8615bc75bR11-R16) [[2]](diffhunk://#diff-7512d61abc482d4b1e08689fb5616b6f9bd50ad405a29e02182fca36d5d1e51dL3-R9) [[3]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7R17) [[4]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7R34-R39)
* Updated the OpenAPI schema and code to allow multiple plan values in the query parameter as an array.

These changes collectively make the organizations API more flexible and robust, allowing clients to filter results by organization plan and improving the maintainability of query parameter handling.