### PR TITLE
Create org-specific data dumps for orgs that are innovator/supporter

### DIFF
--- a/tools/data-export/README.md
+++ b/tools/data-export/README.md
@@ -60,6 +60,11 @@ The current scaffold writes:
 - `maps-flattened.geojson`
 - `annotations.json`
 - `domains-counted.json`
+- `files.json`
+
+For organizations with a `supporter` or `innovator` plan, the export also
+writes organization-specific dumps to `DATA_EXPORT_OUTPUT_DIR/<organizationSlug>/`
+with the same files except `domains-counted.json`.
 
 The PMTiles command reads `maps-flattened.geojson` and writes:
 

--- a/tools/data-export/src/export.ts
+++ b/tools/data-export/src/export.ts
@@ -1,12 +1,21 @@
+import { join } from 'node:path'
+
 import { fromDbRow } from '@allmaps/api-shared'
 
 import { createDataExportWriters } from './writers.ts'
 import { streamMaps } from './stream.ts'
 
+import type { ApiMap, DbRow } from '@allmaps/api-shared/types'
 import type { DataExportEnv } from '@allmaps/env/data-export'
+import type { DataExportWriters } from './writers.ts'
+
+const dataExportOrganizationPlans = new Set(['supporter', 'innovator'])
 
 export async function exportData(env: DataExportEnv) {
   const writers = await createDataExportWriters({
+    outputDirectory: env.DATA_EXPORT_OUTPUT_DIR
+  })
+  const organizationWriters = createOrganizationDataExportWriters({
     outputDirectory: env.DATA_EXPORT_OUTPUT_DIR
   })
 
@@ -16,7 +25,14 @@ export async function exportData(env: DataExportEnv) {
       databaseUrl: env.DIRECT_DATABASE_URL ?? env.DATABASE_URL,
       async onRow(row) {
         try {
-          await writers.writeMap(fromDbRow(row, env.ANNOTATIONS_BASE_URL))
+          const map = fromDbRow(row, env.ANNOTATIONS_BASE_URL)
+
+          await writers.writeMap(map)
+
+          const organizationSlug = getDataExportOrganizationSlug(row)
+          if (organizationSlug) {
+            await organizationWriters.writeMap(organizationSlug, map)
+          }
         } catch (error) {
           throw new Error(`Unable to export map ${row.map.id}`, {
             cause: error
@@ -25,6 +41,48 @@ export async function exportData(env: DataExportEnv) {
       }
     })
   } finally {
-    await writers.close()
+    await Promise.all([writers.close(), organizationWriters.close()])
+  }
+}
+
+function createOrganizationDataExportWriters({
+  outputDirectory
+}: {
+  outputDirectory: string
+}) {
+  const writersByOrganizationSlug = new Map<string, DataExportWriters>()
+
+  return {
+    async writeMap(organizationSlug: string, map: ApiMap) {
+      let writers = writersByOrganizationSlug.get(organizationSlug)
+
+      if (!writers) {
+        writers = await createDataExportWriters({
+          outputDirectory: join(outputDirectory, organizationSlug),
+          includeDomainCounts: false
+        })
+        writersByOrganizationSlug.set(organizationSlug, writers)
+      }
+
+      await writers.writeMap(map)
+    },
+    async close() {
+      await Promise.all(
+        [...writersByOrganizationSlug.values()].map((writers) =>
+          writers.close()
+        )
+      )
+    }
+  }
+}
+
+function getDataExportOrganizationSlug(row: DbRow) {
+  const organization = row.image?.organizationUrl?.organization
+
+  if (
+    organization?.slug &&
+    dataExportOrganizationPlans.has(organization.plan ?? '')
+  ) {
+    return organization.slug
   }
 }

--- a/tools/data-export/src/writers.ts
+++ b/tools/data-export/src/writers.ts
@@ -19,6 +19,7 @@ import type { Writable } from 'node:stream'
 
 type DataExportWritersOptions = {
   outputDirectory: string
+  includeDomainCounts?: boolean
 }
 
 type DataExportFile = {
@@ -37,12 +38,14 @@ const dataExportFilenames = [
   'maps.geojson',
   'maps.geojsonl',
   'maps-flattened.geojson',
-  'annotations.json',
-  'domains-counted.json'
+  'annotations.json'
 ]
 
+const dataExportDomainCountFilenames = ['domains-counted.json']
+
 export async function createDataExportWriters({
-  outputDirectory
+  outputDirectory,
+  includeDomainCounts = true
 }: DataExportWritersOptions): Promise<DataExportWriters> {
   await mkdir(outputDirectory, { recursive: true })
 
@@ -73,7 +76,9 @@ export async function createDataExportWriters({
       const separator = isFirstMap ? '' : ','
       const annotation = generateAnnotation(map)
 
-      addMapDomain(domainCounts, map)
+      if (includeDomainCounts) {
+        addMapDomain(domainCounts, map)
+      }
 
       await write(mapsJson, `${separator}${JSON.stringify(map)}`)
       await write(mapsNdjson, `${JSON.stringify(map)}\n`)
@@ -105,12 +110,14 @@ export async function createDataExportWriters({
         close(annotationsJson)
       ])
 
-      await writeFile(
-        join(outputDirectory, 'domains-counted.json'),
-        `${JSON.stringify(serializeDomainCounts(domainCounts), null, 2)}\n`
-      )
+      if (includeDomainCounts) {
+        await writeFile(
+          join(outputDirectory, 'domains-counted.json'),
+          `${JSON.stringify(serializeDomainCounts(domainCounts), null, 2)}\n`
+        )
+      }
 
-      await writeFilesManifest(outputDirectory)
+      await writeFilesManifest(outputDirectory, includeDomainCounts)
     }
   }
 }
@@ -175,9 +182,16 @@ function getLastPathPart(url: string) {
   }
 }
 
-async function writeFilesManifest(outputDirectory: string) {
+async function writeFilesManifest(
+  outputDirectory: string,
+  includeDomainCounts: boolean
+) {
+  const filenames = includeDomainCounts
+    ? [...dataExportFilenames, ...dataExportDomainCountFilenames]
+    : dataExportFilenames
+
   const files: DataExportFile[] = await Promise.all(
-    dataExportFilenames.map(async (filename) => ({
+    filenames.map(async (filename) => ({
       filename,
       size: (await stat(join(outputDirectory, filename))).size
     }))


### PR DESCRIPTION
This pull request enhances the data export tool to support organization-specific exports for organizations with certain plans. It introduces a mechanism to generate separate data dumps per organization, omitting domain counts from these exports, and updates the manifest and output logic accordingly.

**Organization-specific export support:**

* Organization-specific data exports are now generated for organizations on the `supporter` or `innovator` plans, written to `DATA_EXPORT_OUTPUT_DIR/<organizationSlug>/` and excluding `domains-counted.json`. [[1]](diffhunk://#diff-ad1bdd8a731b9837b5f0afaf5342ebf88d50b5386f77a7f14cb434c903eaf6eaR1-R35) [[2]](diffhunk://#diff-ad1bdd8a731b9837b5f0afaf5342ebf88d50b5386f77a7f14cb434c903eaf6eaL28-R86) [[3]](diffhunk://#diff-33b9b94edd76c9cf0dab5e6761467b4be413569d4e232b8a9e4114cc6c039628R63-R67)

**Export logic and file handling improvements:**

* The `createDataExportWriters` function now accepts an `includeDomainCounts` option, allowing selective inclusion of domain count files in exports. [[1]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5R22) [[2]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5L40-R48) [[3]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5R79-R81)
* The files manifest (`files.json`) generation is updated to reflect whether domain counts are included, ensuring accuracy per export type. [[1]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5R113-R120) [[2]](diffhunk://#diff-bcb1a2968a44751c2f6ae4ca8438b6486f25d79e3923b10eaf9a48164f12e2e5L178-R194)

These changes ensure more granular and plan-aware data exports, improve maintainability, and provide clearer output structure for downstream consumers.