### PR TITLE
small fix in api fetch for allmaps latest

### DIFF
--- a/apps/latest/src/lib/components/Latest.svelte
+++ b/apps/latest/src/lib/components/Latest.svelte
@@ -36,7 +36,7 @@
     const mapsUrl = `https://api.allmaps.org/maps?limit=${count}`
 
     try {
-      const response = await fetch(mapsUrl)
+      const response = await fetch(mapsUrl, { credentials: 'include' })
       apiMaps = await response.json()
 
       if (!Array.isArray(apiMaps)) {

--- a/apps/latest/src/routes/+page.svelte
+++ b/apps/latest/src/routes/+page.svelte
@@ -5,16 +5,15 @@
 
   import Latest from '$lib/components/Latest.svelte'
 
-  const DEFAULT_COUNT = 250
-  const MAX_COUNT = 1000
+  const DEFAULT_LIMIT = 100
 
-  let urlCount = $derived(
-    Number(page.url.searchParams.get('count')) || DEFAULT_COUNT
+  let urlLimit = $derived(
+    Number(page.url.searchParams.get('limit')) || DEFAULT_LIMIT
   )
-  let count = $derived(Math.max(1, Math.min(MAX_COUNT, urlCount)))
+  let limit = $derived(Math.max(1, urlLimit))
 </script>
 
 <Stats />
 <main class="p-3">
-  <Latest {count} showHeader={true} />
+  <Latest count={limit} showHeader={true} />
 </main>


### PR DESCRIPTION
This pull request updates the way the latest maps are fetched and displayed by switching from a `count` parameter to a `limit` parameter, and ensures that credentials are included in API requests. The changes standardize the naming convention for the pagination parameter and improve API security and compatibility.

**Pagination and parameter naming updates:**

* Changed the pagination parameter from `count` to `limit` throughout `+page.svelte`, including updating the default value and variable names, to standardize the API interface.
* Adjusted the way the limit is constrained, removing the previous maximum value and ensuring the limit is at least 1.

**API request improvements:**

* Updated `fetch` in `Latest.svelte` to include credentials by passing `{ credentials: 'include' }`, improving compatibility with APIs that require authentication or cookies.