### PR TITLE
Improved api limit handling in Allmaps Here

### DIFF
--- a/apps/here/src/lib/state/maps.svelte.ts
+++ b/apps/here/src/lib/state/maps.svelte.ts
@@ -20,8 +20,6 @@ const THRESHOLD_DISTANCE = 10 // 10 meters
 
 const MAX_AREA = 500_000_000_000
 
-const NEARBY_MAPS_COUNT = 40
-
 const MAPS_KEY = Symbol('maps')
 
 export class MapsState {
@@ -29,6 +27,7 @@ export class MapsState {
   #imageInfoState: ImageInfoState
   #uiState: UiState
   #annotationsBaseUrl: string
+  #limit: number
 
   #fetchCount = $state(0)
   #loading = $state(false)
@@ -69,12 +68,14 @@ export class MapsState {
     imageInfoState: ImageInfoState,
     errorState: ErrorState,
     uiState: UiState,
-    annotationsBaseUrl: string
+    annotationsBaseUrl: string,
+    limit: number
   ) {
     this.#sensorsState = sensorsState
     this.#imageInfoState = imageInfoState
     this.#uiState = uiState
     this.#annotationsBaseUrl = annotationsBaseUrl
+    this.#limit = limit
 
     $effect(() => {
       const newPosition = this.#sensorsState.position
@@ -122,12 +123,12 @@ export class MapsState {
       coords: { latitude, longitude }
     } = position
 
-    const url = `${this.#annotationsBaseUrl}/maps?limit=${NEARBY_MAPS_COUNT}&intersects=${[
+    const url = `${this.#annotationsBaseUrl}/maps?limit=${this.#limit}&intersects=${[
       latitude,
       longitude
     ].join(',')}&maxarea=${MAX_AREA}`
 
-    const annotations = await fetchJson(url)
+    const annotations = await fetchJson(url, { credentials: 'include' })
     const maps = parseAnnotation(annotations)
 
     this.#mapsFromCoordinates = new SvelteMap(
@@ -200,7 +201,8 @@ export function setMapsState(
   imageInfoState: ImageInfoState,
   errorState: ErrorState,
   uiState: UiState,
-  annotationsBaseUrl: string
+  annotationsBaseUrl: string,
+  limit: number
 ) {
   return setContext(
     MAPS_KEY,
@@ -209,7 +211,8 @@ export function setMapsState(
       imageInfoState,
       errorState,
       uiState,
-      annotationsBaseUrl
+      annotationsBaseUrl,
+      limit
     )
   )
 }

--- a/apps/here/src/routes/+layout.server.ts
+++ b/apps/here/src/routes/+layout.server.ts
@@ -11,6 +11,7 @@ import type { GeojsonRoute } from '$lib/shared/types.js'
 import type { LayoutServerLoad } from './$types.js'
 
 const herePublicEnv = parseHerePublicEnv(publicEnv)
+const DEFAULT_LIMIT = 50
 
 export const load: LayoutServerLoad = async ({ url, fetch }) => {
   let geojsonRoute: GeojsonRoute | undefined
@@ -22,6 +23,11 @@ export const load: LayoutServerLoad = async ({ url, fetch }) => {
   const fromParam = url.searchParams.get('from') || undefined
   const colorParam = url.searchParams.get('color') || undefined
   const positionParam = url.searchParams.get('position') || undefined
+  const limitParam = url.searchParams.get('limit') || undefined
+  const urlLimit = limitParam ? Number(limitParam) : DEFAULT_LIMIT
+  const limit = Number.isFinite(urlLimit)
+    ? Math.max(1, urlLimit)
+    : DEFAULT_LIMIT
 
   if (geojsonParam) {
     let response: Response | undefined
@@ -170,6 +176,7 @@ export const load: LayoutServerLoad = async ({ url, fetch }) => {
     from,
     color,
     position,
+    limit,
     env: herePublicEnv
   }
 }

--- a/apps/here/src/routes/+layout.svelte
+++ b/apps/here/src/routes/+layout.svelte
@@ -31,7 +31,8 @@
     imageInfoState,
     errorState,
     uiState,
-    data.env.PUBLIC_ANNOTATIONS_BASE_URL
+    data.env.PUBLIC_ANNOTATIONS_BASE_URL,
+    data.limit
   )
   // svelte-ignore state_referenced_locally
   setGeocodeState(data.env.PUBLIC_GEOCODE_EARTH_KEY)


### PR DESCRIPTION
This pull request introduces a configurable limit for the number of nearby maps fetched and displayed in the application, replacing the previous hardcoded value. The limit can now be specified via a URL parameter, with a default value applied if not provided. Additionally, credentials are now included in annotation fetch requests for improved authentication handling.

**Configurable map limit and improved fetch handling:**

* The hardcoded `NEARBY_MAPS_COUNT` constant was removed from `maps.svelte.ts`, and a `limit` parameter is now passed through the state and fetch logic, allowing dynamic control over how many maps are loaded. [[1]](diffhunk://#diff-9dfc3c60ff7c1c6ce791683a90a3a59e0caf6049b0edd6c0026d4f030d8dcb83L23-R30) [[2]](diffhunk://#diff-9dfc3c60ff7c1c6ce791683a90a3a59e0caf6049b0edd6c0026d4f030d8dcb83L72-R78) [[3]](diffhunk://#diff-9dfc3c60ff7c1c6ce791683a90a3a59e0caf6049b0edd6c0026d4f030d8dcb83L125-R131) [[4]](diffhunk://#diff-9dfc3c60ff7c1c6ce791683a90a3a59e0caf6049b0edd6c0026d4f030d8dcb83L203-R205) [[5]](diffhunk://#diff-9dfc3c60ff7c1c6ce791683a90a3a59e0caf6049b0edd6c0026d4f030d8dcb83L212-R215)
* The fetch request for annotations now includes credentials by default, improving support for authenticated requests.

**Layout and parameter propagation:**

* A `DEFAULT_LIMIT` constant was added to `+layout.server.ts`, and the `limit` value is parsed from the URL query parameters, validated, and passed through the server load function to the client. [[1]](diffhunk://#diff-550143423c5201ac5be6a72a1bc91f393e6c22fac4b0dfb72c41ac140cf92a66R14) [[2]](diffhunk://#diff-550143423c5201ac5be6a72a1bc91f393e6c22fac4b0dfb72c41ac140cf92a66R26-R30) [[3]](diffhunk://#diff-550143423c5201ac5be6a72a1bc91f393e6c22fac4b0dfb72c41ac140cf92a66R179)
* The new `limit` parameter is passed to the `setMapsState` function in `+layout.svelte`, ensuring the client-side state is initialized with the correct value.