### PR TITLE
Read data export file sizes from JSON instead of using HEAD requests

### DIFF
--- a/apps/homepage/src/components/DataTable.svelte
+++ b/apps/homepage/src/components/DataTable.svelte
@@ -5,6 +5,13 @@
     baseUrl: string
   }
 
+  type FilesManifest = {
+    files: {
+      filename: string
+      size: number
+    }[]
+  }
+
   const { baseUrl }: Props = $props()
 
   const files = $state([
@@ -38,26 +45,25 @@
   ])
 
   onMount(() => {
-    files.forEach((file, index) => {
-      const url = `${baseUrl}${file.filename}`
-      fetch(url, {
-        method: 'HEAD',
-        headers: {
-          // Cloudflare GZIPs plaintext and JSON files
-          // For these files, the Content-Length header
-          // will not be set.
-          // I've tried disabling compression by setting:
-          // 'Accept-Encoding': 'identify'
-          // However, this doesn't work.
-        }
-      }).then((response) => {
-        if (response.ok) {
-          const contentLength = response.headers.get('Content-Length')
-          files[index].size = Number(contentLength)
-        }
-      })
-    })
+    void loadFileSizes()
   })
+
+  async function loadFileSizes() {
+    const response = await fetch(`${baseUrl}files.json`).catch(() => undefined)
+
+    if (!response?.ok) {
+      return
+    }
+
+    const filesManifest = (await response.json()) as FilesManifest
+    const fileSizes = new Map(
+      filesManifest.files.map((file) => [file.filename, file.size])
+    )
+
+    files.forEach((file, index) => {
+      files[index].size = fileSizes.get(file.filename) ?? 0
+    })
+  }
 
   function formatSize(size: number) {
     return size ? `${Math.round(size / 1024 / 1024)} MB` : ''


### PR DESCRIPTION
This pull request refactors how file sizes are loaded in the `DataTable.svelte` component to improve efficiency and reliability. Instead of making individual `HEAD` requests for each file to determine its size, the code now fetches a single `files.json` manifest containing all file sizes at once. This reduces the number of network requests and avoids issues with missing `Content-Length` headers.

**Refactor: File size loading logic**

* Introduced a new `FilesManifest` type to represent the structure of the `files.json` manifest, which includes filenames and their corresponding sizes.
* Replaced per-file `HEAD` requests with a single fetch for `files.json` in the new `loadFileSizes` function, then mapped sizes to files using the manifest data.