### PR TITLE
fix(background-color): accept optional mask and correct scaling

### DIFF
--- a/packages/background-color/src/index.ts
+++ b/packages/background-color/src/index.ts
@@ -11,14 +11,25 @@ import type { Size, Ring } from '@allmaps/types'
 
 export function detectBackgroundColor(
   resourceSize: Size,
-  resourceMask: Ring,
-  imageBitmap: ImageBitmap
+  imageBitmap: ImageBitmap,
+  resourceMask?: Ring
 ) {
-  const scale = resourceSize[0] / imageBitmap.width
+  if (!resourceMask) {
+    const [width, height] = resourceSize
+    resourceMask = [
+      [0, 0],
+      [width, 0],
+      [width, height],
+      [0, height]
+    ]
+  }
+
+  const scale = imageBitmap.width / resourceSize[0]
   const scaledResourceMask = scalePoints(resourceMask, scale)
 
   const imageData = getImageData(imageBitmap, scaledResourceMask)
   const colors = getColorsArray(imageData)
+
   const histogram = getColorHistogram(colors)
   const backgroundColor = getMaxOccurringColor(histogram)
 


### PR DESCRIPTION
This pull request updates the `detectBackgroundColor` function in `packages/background-color/src/index.ts` to improve its flexibility and correctness. The main change is making the `resourceMask` parameter optional and providing a default mask when it is not specified. Additionally, the scaling calculation for the mask was corrected.

**Function signature and default behavior improvements:**

* Made the `resourceMask` parameter optional in the `detectBackgroundColor` function. If no mask is provided, the function now defaults to using the full resource size as the mask.

**Bug fix:**

* Fixed the scale calculation to use `imageBitmap.width / resourceSize[0]` instead of the previous inverse, ensuring the mask is scaled correctly to match the image.