### PR TITLE
Added GitHub action that fixes lockfile if out-of-sync

### DIFF
--- a/.github/workflows/update-pnpm-lockfile.yml
+++ b/.github/workflows/update-pnpm-lockfile.yml
@@ -1,0 +1,54 @@
+name: Update pnpm lockfile
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-pnpm-lockfile-develop
+  cancel-in-progress: true
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Update lockfile
+        run: pnpm install --lockfile-only --no-frozen-lockfile
+
+      - name: Commit lockfile if it is the only changed file
+        run: |
+          changed_files="$(git status --porcelain | sed 's/^...//')"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changes."
+            exit 0
+          fi
+
+          if [ "$changed_files" != "pnpm-lock.yaml" ]; then
+            echo "Unexpected changed files:"
+            echo "$changed_files"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add pnpm-lock.yaml
+          git commit -m "update pnpm lockfile"
+          git push


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the updating of the `pnpm-lock.yaml` file on pushes to the `develop` branch. This ensures the lockfile stays up-to-date with the latest dependency changes and reduces manual maintenance.

**Automation:**

* Added `.github/workflows/update-pnpm-lockfile.yml` to automatically update and commit the `pnpm-lock.yaml` lockfile when dependencies change on the `develop` branch. The workflow checks out the code, enables `pnpm` via `corepack`, updates the lockfile, and commits the change if the lockfile is the only file modified.