### PR TITLE
wasm-with-triangles

### DIFF
--- a/packages/render-wasm/src/lib.rs
+++ b/packages/render-wasm/src/lib.rs
@@ -10,7 +10,7 @@ use image::{DynamicImage, ImageDecoder, ImageEncoder};
 use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
-use renderer::{render, DecodedTile};
+use renderer::{render, render_triangles, DecodedTile};
 use transforms::Transform;
 
 #[wasm_bindgen(start)]
@@ -23,8 +23,8 @@ pub fn init() {
 /// Decode an image (JPEG, PNG or WebP, auto-detected from magic bytes) into an RGBA Vec.
 /// Returns an error message instead of panicking, so an unexpected tile format
 fn decode_image(data: &[u8]) -> Result<(Vec<u8>, u32, u32), String> {
-    let img = image::load_from_memory(data)
-        .map_err(|e| format!("Failed to decode image: {}", e))?;
+    let img =
+        image::load_from_memory(data).map_err(|e| format!("Failed to decode image: {}", e))?;
     let rgba = img.to_rgba8();
     let (width, height) = rgba.dimensions();
     Ok((rgba.into_raw(), width, height))
@@ -36,8 +36,8 @@ fn decode_png(data: &[u8]) -> Result<(Vec<u8>, u32, u32), String> {
     let decoder = PngDecoder::new(Cursor::new(data))
         .map_err(|e| format!("Failed to create PNG decoder: {}", e))?;
     let (width, height) = decoder.dimensions();
-    let img = DynamicImage::from_decoder(decoder)
-        .map_err(|e| format!("Failed to decode PNG: {}", e))?;
+    let img =
+        DynamicImage::from_decoder(decoder).map_err(|e| format!("Failed to decode PNG: {}", e))?;
     let rgba = img.to_rgba8();
     Ok((rgba.into_raw(), width, height))
 }
@@ -251,6 +251,66 @@ pub fn render_warped_tile_rgba(
         &transform,
         mask_polygon,
         canvas_to_geo,
+        output_width,
+        output_height,
+    )
+}
+
+#[wasm_bindgen]
+pub fn render_warped_triangles_rgba(
+    jpeg_tiles: &[u8],
+    tile_offsets: &[u32],
+    _tile_widths: &[u32],
+    _tile_heights: &[u32],
+    tile_columns: &[f64],
+    tile_rows: &[f64],
+    tile_scale_factors: &[f64],
+    tile_original_widths: &[f64],
+    tile_original_heights: &[f64],
+    resource_triangle_points: &[f64],
+    canvas_triangle_points: &[f64],
+    triangle_inside: &[u8],
+    output_width: u32,
+    output_height: u32,
+) -> Vec<u8> {
+    let tile_count = tile_offsets.len();
+
+    let mut decoded_tiles = Vec::with_capacity(tile_count);
+    for i in 0..tile_count {
+        let start = tile_offsets[i] as usize;
+        let end = if i + 1 < tile_count {
+            tile_offsets[i + 1] as usize
+        } else {
+            jpeg_tiles.len()
+        };
+
+        let tile_data = &jpeg_tiles[start..end];
+
+        let (rgba, w, h) = match decode_image(tile_data) {
+            Ok(decoded) => decoded,
+            Err(e) => {
+                web_sys::console::error_1(&format!("Skipping undecodable tile: {}", e).into());
+                continue;
+            }
+        };
+
+        decoded_tiles.push(DecodedTile::new(
+            rgba,
+            w,
+            h,
+            tile_columns[i],
+            tile_rows[i],
+            tile_scale_factors[i],
+            tile_original_widths[i],
+            tile_original_heights[i],
+        ));
+    }
+
+    render_triangles(
+        &decoded_tiles,
+        resource_triangle_points,
+        canvas_triangle_points,
+        triangle_inside,
         output_width,
         output_height,
     )

--- a/packages/render-wasm/src/lib.rs
+++ b/packages/render-wasm/src/lib.rs
@@ -10,7 +10,7 @@ use image::{DynamicImage, ImageDecoder, ImageEncoder};
 use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
-use renderer::{render, render_triangles, DecodedTile};
+use renderer::{render, render_into, render_triangles, render_triangles_into, DecodedTile};
 use transforms::Transform;
 
 #[wasm_bindgen(start)]
@@ -118,6 +118,203 @@ pub struct DecodedImage {
 pub fn decode_jpeg_test(jpeg_data: &[u8]) -> Result<DecodedImage, JsError> {
     let (_, width, height) = decode_image(jpeg_data).map_err(|e| JsError::new(&e))?;
     Ok(DecodedImage { width, height })
+}
+
+#[wasm_bindgen]
+pub struct RenderContext {
+    output_pixels: Vec<u8>,
+    output_width: u32,
+    output_height: u32,
+}
+
+#[wasm_bindgen]
+impl RenderContext {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        output_width: u32,
+        output_height: u32,
+        background_red: u8,
+        background_green: u8,
+        background_blue: u8,
+        has_background: bool,
+    ) -> RenderContext {
+        let pixel_count = (output_width * output_height) as usize;
+        let mut output_pixels = vec![0u8; pixel_count * 4];
+
+        if has_background {
+            for pixel in output_pixels.chunks_exact_mut(4) {
+                pixel[0] = background_red;
+                pixel[1] = background_green;
+                pixel[2] = background_blue;
+                pixel[3] = 255;
+            }
+        }
+
+        RenderContext {
+            output_pixels,
+            output_width,
+            output_height,
+        }
+    }
+
+    pub fn render_warped_tile_rgba(
+        &mut self,
+        jpeg_tiles: &[u8],
+        tile_offsets: &[u32],
+        _tile_widths: &[u32],
+        _tile_heights: &[u32],
+        tile_columns: &[f64],
+        tile_rows: &[f64],
+        tile_scale_factors: &[f64],
+        tile_original_widths: &[f64],
+        tile_original_heights: &[f64],
+        transform_type: &str,
+        transform_args: &[f64],
+        source_points: &[f64],
+        mask_polygon: &[f64],
+        canvas_to_geo: &[f64],
+        render_min_x: u32,
+        render_min_y: u32,
+        render_max_x: u32,
+        render_max_y: u32,
+    ) {
+        let tile_count = tile_offsets.len();
+
+        let mut decoded_tiles = Vec::with_capacity(tile_count);
+        for i in 0..tile_count {
+            let start = tile_offsets[i] as usize;
+            let end = if i + 1 < tile_count {
+                tile_offsets[i + 1] as usize
+            } else {
+                jpeg_tiles.len()
+            };
+
+            let tile_data = &jpeg_tiles[start..end];
+
+            let (rgba, w, h) = match decode_image(tile_data) {
+                Ok(decoded) => decoded,
+                Err(e) => {
+                    web_sys::console::error_1(&format!("Skipping undecodable tile: {}", e).into());
+                    continue;
+                }
+            };
+
+            decoded_tiles.push(DecodedTile::new(
+                rgba,
+                w,
+                h,
+                tile_columns[i],
+                tile_rows[i],
+                tile_scale_factors[i],
+                tile_original_widths[i],
+                tile_original_heights[i],
+            ));
+        }
+
+        let transform = Transform::parse(transform_type, transform_args, source_points);
+
+        render_into(
+            &decoded_tiles,
+            &transform,
+            mask_polygon,
+            canvas_to_geo,
+            &mut self.output_pixels,
+            self.output_width,
+            self.output_height,
+            render_min_x,
+            render_min_y,
+            render_max_x,
+            render_max_y,
+        )
+    }
+
+    pub fn render_warped_triangles_rgba(
+        &mut self,
+        jpeg_tiles: &[u8],
+        tile_offsets: &[u32],
+        _tile_widths: &[u32],
+        _tile_heights: &[u32],
+        tile_columns: &[f64],
+        tile_rows: &[f64],
+        tile_scale_factors: &[f64],
+        tile_original_widths: &[f64],
+        tile_original_heights: &[f64],
+        resource_triangle_points: &[f64],
+        canvas_triangle_points: &[f64],
+        triangle_inside: &[u8],
+        render_min_x: u32,
+        render_min_y: u32,
+        render_max_x: u32,
+        render_max_y: u32,
+    ) {
+        let tile_count = tile_offsets.len();
+
+        let mut decoded_tiles = Vec::with_capacity(tile_count);
+        for i in 0..tile_count {
+            let start = tile_offsets[i] as usize;
+            let end = if i + 1 < tile_count {
+                tile_offsets[i + 1] as usize
+            } else {
+                jpeg_tiles.len()
+            };
+
+            let tile_data = &jpeg_tiles[start..end];
+
+            let (rgba, w, h) = match decode_image(tile_data) {
+                Ok(decoded) => decoded,
+                Err(e) => {
+                    web_sys::console::error_1(&format!("Skipping undecodable tile: {}", e).into());
+                    continue;
+                }
+            };
+
+            decoded_tiles.push(DecodedTile::new(
+                rgba,
+                w,
+                h,
+                tile_columns[i],
+                tile_rows[i],
+                tile_scale_factors[i],
+                tile_original_widths[i],
+                tile_original_heights[i],
+            ));
+        }
+
+        render_triangles_into(
+            &decoded_tiles,
+            resource_triangle_points,
+            canvas_triangle_points,
+            triangle_inside,
+            &mut self.output_pixels,
+            self.output_width,
+            self.output_height,
+            render_min_x,
+            render_min_y,
+            render_max_x,
+            render_max_y,
+        )
+    }
+
+    pub fn encode_png(&self) -> Vec<u8> {
+        encode_png(&self.output_pixels, self.output_width, self.output_height)
+    }
+
+    pub fn encode_webp(&self) -> Vec<u8> {
+        encode_webp(&self.output_pixels, self.output_width, self.output_height)
+    }
+
+    pub fn encode_jpeg(&self, quality: u8) -> Vec<u8> {
+        encode_jpeg(
+            &self.output_pixels,
+            self.output_width,
+            self.output_height,
+            quality,
+        )
+        .unwrap_or_else(|e| {
+            web_sys::console::error_1(&format!("JPEG encoding failed: {}", e).into());
+            Vec::new()
+        })
+    }
 }
 
 /// Render warped tile from pre-decoded RGBA tiles (most efficient - no JPEG decoding)

--- a/packages/render-wasm/src/renderer.rs
+++ b/packages/render-wasm/src/renderer.rs
@@ -161,6 +161,42 @@ pub fn render(
     let pixel_count = (output_width * output_height) as usize;
     let mut output = vec![0u8; pixel_count * 4];
 
+    render_into(
+        tiles,
+        transform,
+        mask_polygon,
+        canvas_to_geo,
+        &mut output,
+        output_width,
+        output_height,
+        0,
+        0,
+        output_width,
+        output_height,
+    );
+
+    output
+}
+
+/// Render a map directly into an existing output buffer. Only pixels inside the
+/// supplied canvas bounds are evaluated.
+pub fn render_into(
+    tiles: &[DecodedTile],
+    transform: &Transform,
+    mask_polygon: &[f64],
+    canvas_to_geo: &[f64], // 6-element homogeneous transform
+    output: &mut [u8],
+    output_width: u32,
+    output_height: u32,
+    render_min_x: u32,
+    render_min_y: u32,
+    render_max_x: u32,
+    render_max_y: u32,
+) {
+    if output.len() < (output_width * output_height * 4) as usize {
+        return;
+    }
+
     let a = canvas_to_geo[0];
     let b = canvas_to_geo[1];
     let c = canvas_to_geo[2];
@@ -180,11 +216,16 @@ pub fn render(
 
     // If no tiles intersect, return empty image
     if visible_tiles.is_empty() {
-        return output;
+        return;
     }
 
-    for cy in 0..output_height {
-        for cx in 0..output_width {
+    let min_x = render_min_x.min(output_width);
+    let min_y = render_min_y.min(output_height);
+    let max_x = render_max_x.min(output_width);
+    let max_y = render_max_y.min(output_height);
+
+    for cy in min_y..max_y {
+        for cx in min_x..max_x {
             let fx = cx as f64;
             let fy = cy as f64;
 
@@ -240,14 +281,16 @@ pub fn render(
             let color = sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
 
             let idx = ((cy * output_width + cx) * 4) as usize;
+            if color[3] <= 0.0 {
+                continue;
+            }
+
             output[idx] = color[0].round().min(255.0).max(0.0) as u8;
             output[idx + 1] = color[1].round().min(255.0).max(0.0) as u8;
             output[idx + 2] = color[2].round().min(255.0).max(0.0) as u8;
             output[idx + 3] = color[3].round().min(255.0).max(0.0) as u8;
         }
     }
-
-    output
 }
 
 #[inline(always)]
@@ -279,14 +322,55 @@ pub fn render_triangles(
     let pixel_count = (output_width * output_height) as usize;
     let mut output = vec![0u8; pixel_count * 4];
 
+    render_triangles_into(
+        tiles,
+        resource_triangle_points,
+        canvas_triangle_points,
+        triangle_inside,
+        &mut output,
+        output_width,
+        output_height,
+        0,
+        0,
+        output_width,
+        output_height,
+    );
+
+    output
+}
+
+/// Render projected triangles directly into an existing output buffer. Only
+/// triangle pixels inside the supplied canvas bounds are evaluated.
+pub fn render_triangles_into(
+    tiles: &[DecodedTile],
+    resource_triangle_points: &[f64],
+    canvas_triangle_points: &[f64],
+    triangle_inside: &[u8],
+    output: &mut [u8],
+    output_width: u32,
+    output_height: u32,
+    render_min_x: u32,
+    render_min_y: u32,
+    render_max_x: u32,
+    render_max_y: u32,
+) {
     if tiles.is_empty() {
-        return output;
+        return;
+    }
+
+    if output.len() < (output_width * output_height * 4) as usize {
+        return;
     }
 
     let triangle_count = resource_triangle_points
         .len()
         .min(canvas_triangle_points.len())
         / 6;
+
+    let bounds_min_x = render_min_x.min(output_width);
+    let bounds_min_y = render_min_y.min(output_height);
+    let bounds_max_x = render_max_x.min(output_width);
+    let bounds_max_y = render_max_y.min(output_height);
 
     for triangle_index in 0..triangle_count {
         if triangle_inside
@@ -321,6 +405,11 @@ pub fn render_triangles(
         let max_x = clamp_to_canvas_ceil(c0x.max(c1x).max(c2x), output_width);
         let min_y = clamp_to_canvas_floor(c0y.min(c1y).min(c2y), output_height);
         let max_y = clamp_to_canvas_ceil(c0y.max(c1y).max(c2y), output_height);
+
+        let min_x = min_x.max(bounds_min_x);
+        let min_y = min_y.max(bounds_min_y);
+        let max_x = max_x.min(bounds_max_x);
+        let max_y = max_y.min(bounds_max_y);
 
         if min_x >= max_x || min_y >= max_y {
             continue;
@@ -361,6 +450,10 @@ pub fn render_triangles(
 
                 let color = sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
                 let idx = ((cy * output_width + cx) * 4) as usize;
+                if color[3] <= 0.0 {
+                    continue;
+                }
+
                 output[idx] = color[0].round().min(255.0).max(0.0) as u8;
                 output[idx + 1] = color[1].round().min(255.0).max(0.0) as u8;
                 output[idx + 2] = color[2].round().min(255.0).max(0.0) as u8;
@@ -368,6 +461,4 @@ pub fn render_triangles(
             }
         }
     }
-
-    output
 }

--- a/packages/render-wasm/src/renderer.rs
+++ b/packages/render-wasm/src/renderer.rs
@@ -15,10 +15,10 @@ impl BBox {
     /// Check if two bounding boxes intersect
     #[inline(always)]
     fn intersects(&self, other: &BBox) -> bool {
-        !(self.max_x < other.min_x ||
-          self.min_x > other.max_x ||
-          self.max_y < other.min_y ||
-          self.min_y > other.max_y)
+        !(self.max_x < other.min_x
+            || self.min_x > other.max_x
+            || self.max_y < other.min_y
+            || self.min_y > other.max_y)
     }
 
     /// Check if a point is inside this bbox
@@ -59,7 +59,12 @@ impl DecodedTile {
             width,
             height,
             scale_factor,
-            bbox: BBox { min_x, max_x, min_y, max_y },
+            bbox: BBox {
+                min_x,
+                max_x,
+                min_y,
+                max_y,
+            },
         }
     }
 
@@ -164,7 +169,8 @@ pub fn render(
     let f = canvas_to_geo[5];
 
     // OPTIMIZATION: Compute viewport bounding box for early culling
-    let viewport_bbox = compute_viewport_bbox(transform, canvas_to_geo, output_width, output_height);
+    let viewport_bbox =
+        compute_viewport_bbox(transform, canvas_to_geo, output_width, output_height);
 
     // OPTIMIZATION: Bounding box culling - filter tiles that don't intersect viewport
     let visible_tiles: Vec<&DecodedTile> = tiles
@@ -221,20 +227,145 @@ pub fn render(
             let tile_y = (ry - tile.origin_y()) / tile.scale_factor;
 
             // Safety check: ensure coordinates are within tile bounds
-            if tile_x < 0.0 || tile_x >= tile.width as f64 || tile_y < 0.0 || tile_y >= tile.height as f64 {
+            if tile_x < 0.0
+                || tile_x >= tile.width as f64
+                || tile_y < 0.0
+                || tile_y >= tile.height as f64
+            {
                 // Out of bounds - skip this pixel
                 continue;
             }
 
             // Bilinear sample
-            let color =
-                sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
+            let color = sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
 
             let idx = ((cy * output_width + cx) * 4) as usize;
             output[idx] = color[0].round().min(255.0).max(0.0) as u8;
             output[idx + 1] = color[1].round().min(255.0).max(0.0) as u8;
             output[idx + 2] = color[2].round().min(255.0).max(0.0) as u8;
             output[idx + 3] = color[3].round().min(255.0).max(0.0) as u8;
+        }
+    }
+
+    output
+}
+
+#[inline(always)]
+fn edge_function(ax: f64, ay: f64, bx: f64, by: f64, px: f64, py: f64) -> f64 {
+    (px - ax) * (by - ay) - (py - ay) * (bx - ax)
+}
+
+#[inline(always)]
+fn clamp_to_canvas_floor(value: f64, max: u32) -> u32 {
+    value.floor().max(0.0).min(max as f64) as u32
+}
+
+#[inline(always)]
+fn clamp_to_canvas_ceil(value: f64, max: u32) -> u32 {
+    value.ceil().max(0.0).min(max as f64) as u32
+}
+
+/// Render by rasterizing projected/canvas triangles and interpolating resource
+/// coordinates inside each triangle. Projection handling is baked into the
+/// triangle vertices on the JavaScript side, mirroring the WebGL renderer.
+pub fn render_triangles(
+    tiles: &[DecodedTile],
+    resource_triangle_points: &[f64],
+    canvas_triangle_points: &[f64],
+    triangle_inside: &[u8],
+    output_width: u32,
+    output_height: u32,
+) -> Vec<u8> {
+    let pixel_count = (output_width * output_height) as usize;
+    let mut output = vec![0u8; pixel_count * 4];
+
+    if tiles.is_empty() {
+        return output;
+    }
+
+    let triangle_count = resource_triangle_points
+        .len()
+        .min(canvas_triangle_points.len())
+        / 6;
+
+    for triangle_index in 0..triangle_count {
+        if triangle_inside
+            .get(triangle_index)
+            .is_some_and(|inside| *inside == 0)
+        {
+            continue;
+        }
+
+        let point_offset = triangle_index * 6;
+
+        let r0x = resource_triangle_points[point_offset];
+        let r0y = resource_triangle_points[point_offset + 1];
+        let r1x = resource_triangle_points[point_offset + 2];
+        let r1y = resource_triangle_points[point_offset + 3];
+        let r2x = resource_triangle_points[point_offset + 4];
+        let r2y = resource_triangle_points[point_offset + 5];
+
+        let c0x = canvas_triangle_points[point_offset];
+        let c0y = canvas_triangle_points[point_offset + 1];
+        let c1x = canvas_triangle_points[point_offset + 2];
+        let c1y = canvas_triangle_points[point_offset + 3];
+        let c2x = canvas_triangle_points[point_offset + 4];
+        let c2y = canvas_triangle_points[point_offset + 5];
+
+        let area = edge_function(c0x, c0y, c1x, c1y, c2x, c2y);
+        if area.abs() < f64::EPSILON {
+            continue;
+        }
+
+        let min_x = clamp_to_canvas_floor(c0x.min(c1x).min(c2x), output_width);
+        let max_x = clamp_to_canvas_ceil(c0x.max(c1x).max(c2x), output_width);
+        let min_y = clamp_to_canvas_floor(c0y.min(c1y).min(c2y), output_height);
+        let max_y = clamp_to_canvas_ceil(c0y.max(c1y).max(c2y), output_height);
+
+        if min_x >= max_x || min_y >= max_y {
+            continue;
+        }
+
+        for cy in min_y..max_y {
+            for cx in min_x..max_x {
+                let px = cx as f64 + 0.5;
+                let py = cy as f64 + 0.5;
+
+                let w0 = edge_function(c1x, c1y, c2x, c2y, px, py) / area;
+                let w1 = edge_function(c2x, c2y, c0x, c0y, px, py) / area;
+                let w2 = edge_function(c0x, c0y, c1x, c1y, px, py) / area;
+
+                let epsilon = -1e-9;
+                if w0 < epsilon || w1 < epsilon || w2 < epsilon {
+                    continue;
+                }
+
+                let rx = w0 * r0x + w1 * r1x + w2 * r2x;
+                let ry = w0 * r0y + w1 * r1y + w2 * r2y;
+
+                let tile = match tiles.iter().find(|t| t.contains(rx, ry)) {
+                    Some(t) => t,
+                    None => continue,
+                };
+
+                let tile_x = (rx - tile.origin_x()) / tile.scale_factor;
+                let tile_y = (ry - tile.origin_y()) / tile.scale_factor;
+
+                if tile_x < 0.0
+                    || tile_x >= tile.width as f64
+                    || tile_y < 0.0
+                    || tile_y >= tile.height as f64
+                {
+                    continue;
+                }
+
+                let color = sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
+                let idx = ((cy * output_width + cx) * 4) as usize;
+                output[idx] = color[0].round().min(255.0).max(0.0) as u8;
+                output[idx + 1] = color[1].round().min(255.0).max(0.0) as u8;
+                output[idx + 2] = color[2].round().min(255.0).max(0.0) as u8;
+                output[idx + 3] = color[3].round().min(255.0).max(0.0) as u8;
+            }
         }
     }
 

--- a/packages/render-wasm/src/transforms.rs
+++ b/packages/render-wasm/src/transforms.rs
@@ -44,14 +44,11 @@ impl<'a> Transform<'a> {
         match self {
             Transform::Straight { tx, ty, scale } => (tx + scale * x, ty + scale * y),
 
-            Transform::Helmert { w0, w1, w2, w3 } => {
-                (w0 + w2 * x - w3 * y, w1 + w2 * y + w3 * x)
-            }
+            Transform::Helmert { w0, w1, w2, w3 } => (w0 + w2 * x - w3 * y, w1 + w2 * y + w3 * x),
 
-            Transform::Polynomial1 { wx, wy } => (
-                wx[0] + wx[1] * x + wx[2] * y,
-                wy[0] + wy[1] * x + wy[2] * y,
-            ),
+            Transform::Polynomial1 { wx, wy } => {
+                (wx[0] + wx[1] * x + wx[2] * y, wy[0] + wy[1] * x + wy[2] * y)
+            }
 
             Transform::Polynomial2 { wx, wy } => {
                 let rx =

--- a/packages/render/src/renderers/WasmRenderer.ts
+++ b/packages/render/src/renderers/WasmRenderer.ts
@@ -1,16 +1,23 @@
-import { doBboxesIntersect } from '@allmaps/stdlib'
+import { doBboxesIntersect, mergePartialOptions } from '@allmaps/stdlib'
+import { isEqualProjection } from '@allmaps/project'
 
 import { BaseRenderer } from './BaseRenderer.js'
 import { Viewport } from '../viewport/Viewport.js'
 import {
+  createTriangulatedWarpedMapFactory,
+  TriangulatedWarpedMap
+} from '../maps/TriangulatedWarpedMap.js'
+import {
   CacheableRawJpegTile,
   type RawJpegData
 } from '../tilecache/CacheableRawJpegTile.js'
-import { invertHomogeneousTransform } from '../shared/homogeneous-transform.js'
+import {
+  applyHomogeneousTransform,
+  invertHomogeneousTransform
+} from '../shared/homogeneous-transform.js'
 
-import type { Renderer, IntArrayRenderOptions } from '../shared/types.js'
+import type { BaseRenderOptions, Renderer } from '../shared/types.js'
 import type { CachedTile } from '../tilecache/CacheableTile.js'
-import type { WarpedMap } from '../maps/WarpedMap.js'
 
 // Type for the WASM module
 type WasmModule = {
@@ -46,6 +53,22 @@ type WasmModule = {
     source_points: Float64Array,
     mask_polygon: Float64Array,
     canvas_to_geo: Float64Array,
+    output_width: number,
+    output_height: number
+  ): Uint8Array
+  render_warped_triangles_rgba(
+    jpeg_tiles: Uint8Array,
+    tile_offsets: Uint32Array,
+    tile_widths: Uint32Array,
+    tile_heights: Uint32Array,
+    tile_columns: Float64Array,
+    tile_rows: Float64Array,
+    tile_scale_factors: Float64Array,
+    tile_original_widths: Float64Array,
+    tile_original_heights: Float64Array,
+    resource_triangle_points: Float64Array,
+    canvas_triangle_points: Float64Array,
+    triangle_inside: Uint8Array,
     output_width: number,
     output_height: number
   ): Uint8Array
@@ -131,7 +154,7 @@ export type OutputFormat = 'png' | 'webp' | 'jpeg'
  * Caches raw JPEG bytes and decodes them in WASM for maximum performance
  */
 export class WasmRenderer
-  extends BaseRenderer<WarpedMap, RawJpegData>
+  extends BaseRenderer<TriangulatedWarpedMap, RawJpegData>
   implements Renderer
 {
   wasmModule: WasmModule
@@ -140,7 +163,7 @@ export class WasmRenderer
 
   constructor(
     wasmModule: WasmModule,
-    options?: Partial<IntArrayRenderOptions> & {
+    options?: Partial<BaseRenderOptions<TriangulatedWarpedMap>> & {
       outputFormat?: OutputFormat
       backgroundColor?: [number, number, number]
     }
@@ -150,7 +173,12 @@ export class WasmRenderer
       return wasmModule.decode_jpeg_test(new Uint8Array(jpegBytes))
     }
 
-    super(CacheableRawJpegTile.createFactory(decodeJpegForDimensions), options)
+    super(
+      CacheableRawJpegTile.createFactory(decodeJpegForDimensions),
+      mergePartialOptions(options, {
+        warpedMapFactory: createTriangulatedWarpedMapFactory()
+      })
+    )
     this.wasmModule = wasmModule
     this.outputFormat = options?.outputFormat || 'png'
     this.backgroundColor = options?.backgroundColor
@@ -213,14 +241,25 @@ export class WasmRenderer
         continue
       }
 
-      // Render this map using WASM
-      const mapPixels = await this.#renderMap(
-        warpedMap,
-        cachedTiles,
-        canvasToGeo,
-        outputWidth,
-        outputHeight
+      const shouldUseTriangleRenderer = !isEqualProjection(
+        warpedMap.internalProjection,
+        viewport.projection
       )
+
+      const mapPixels = shouldUseTriangleRenderer
+        ? await this.#renderMapWithTriangles(
+            warpedMap,
+            cachedTiles,
+            outputWidth,
+            outputHeight
+          )
+        : await this.#renderMap(
+            warpedMap,
+            cachedTiles,
+            canvasToGeo,
+            outputWidth,
+            outputHeight
+          )
 
       // Composite into output buffer (overwrite non-transparent pixels)
       for (let i = 0; i < outputPixels.length; i += 4) {
@@ -248,14 +287,7 @@ export class WasmRenderer
    * Render a single map using WASM with raw JPEG tiles
    * WASM decodes JPEG natively - no JavaScript decoding needed!
    */
-  async #renderMap(
-    warpedMap: WarpedMap,
-    cachedTiles: CachedTile<RawJpegData>[],
-    canvasToGeo: Float64Array,
-    outputWidth: number,
-    outputHeight: number
-  ): Promise<Uint8ClampedArray> {
-    // Use raw JPEG bytes from cache - WASM will decode them
+  #getTileBuffers(cachedTiles: CachedTile<RawJpegData>[]) {
     const jpegBuffers: Uint8Array[] = []
     const tileWidths: number[] = []
     const tileHeights: number[] = []
@@ -267,14 +299,10 @@ export class WasmRenderer
 
     for (const cachedTile of cachedTiles) {
       const tile = cachedTile.fetchableTile.tile
+      const rawJpegData = cachedTile.data
 
-      // cachedTile.data contains raw JPEG bytes (not decoded!)
-      const rawJpegData = cachedTile.data as RawJpegData
-
-      // Get raw JPEG bytes - WASM will decode (convert to Uint8Array for compatibility)
       jpegBuffers.push(new Uint8Array(rawJpegData.jpegBytes))
 
-      // Store tile metadata
       tileColumns.push(tile.column)
       tileRows.push(tile.row)
       tileScaleFactors.push(tile.tileZoomLevel.scaleFactor)
@@ -284,7 +312,6 @@ export class WasmRenderer
       tileHeights.push(rawJpegData.height)
     }
 
-    // Concatenate all JPEG buffers
     const totalLength = jpegBuffers.reduce((sum, buf) => sum + buf.length, 0)
     const concatenatedJpeg = new Uint8Array(totalLength)
     const tileOffsets = new Uint32Array(jpegBuffers.length)
@@ -294,6 +321,38 @@ export class WasmRenderer
       concatenatedJpeg.set(jpegBuffers[i], offset)
       offset += jpegBuffers[i].length
     }
+
+    return {
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths: new Uint32Array(tileWidths),
+      tileHeights: new Uint32Array(tileHeights),
+      tileColumns: new Float64Array(tileColumns),
+      tileRows: new Float64Array(tileRows),
+      tileScaleFactors: new Float64Array(tileScaleFactors),
+      tileOriginalWidths: new Float64Array(tileOriginalWidths),
+      tileOriginalHeights: new Float64Array(tileOriginalHeights)
+    }
+  }
+
+  async #renderMap(
+    warpedMap: TriangulatedWarpedMap,
+    cachedTiles: CachedTile<RawJpegData>[],
+    canvasToGeo: Float64Array,
+    outputWidth: number,
+    outputHeight: number
+  ): Promise<Uint8ClampedArray> {
+    const {
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights
+    } = this.#getTileBuffers(cachedTiles)
 
     // Extract transformation
     const transformer = warpedMap.projectedTransformer
@@ -312,18 +371,79 @@ export class WasmRenderer
     const rgbaPixels = this.wasmModule.render_warped_tile_rgba(
       concatenatedJpeg,
       tileOffsets,
-      new Uint32Array(tileWidths),
-      new Uint32Array(tileHeights),
-      new Float64Array(tileColumns),
-      new Float64Array(tileRows),
-      new Float64Array(tileScaleFactors),
-      new Float64Array(tileOriginalWidths),
-      new Float64Array(tileOriginalHeights),
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights,
       transformType,
       weights,
       sourcePoints,
       maskPolygon,
       canvasToGeo,
+      outputWidth,
+      outputHeight
+    )
+
+    return new Uint8ClampedArray(rgbaPixels)
+  }
+
+  async #renderMapWithTriangles(
+    warpedMap: TriangulatedWarpedMap,
+    cachedTiles: CachedTile<RawJpegData>[],
+    outputWidth: number,
+    outputHeight: number
+  ): Promise<Uint8ClampedArray> {
+    const {
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights
+    } = this.#getTileBuffers(cachedTiles)
+
+    const resourceTrianglePoints = new Float64Array(
+      warpedMap.resourceTrianglePoints.flatMap((point) => [point[0], point[1]])
+    )
+
+    const canvasTrianglePoints = new Float64Array(
+      warpedMap.projectedGeoTrianglePoints.flatMap((point) => {
+        if (!this.viewport) {
+          throw new Error('Cannot render without viewport')
+        }
+        const canvasPoint = applyHomogeneousTransform(
+          this.viewport.projectedGeoToCanvasHomogeneousTransform,
+          point
+        )
+        return [canvasPoint[0], canvasPoint[1]]
+      })
+    )
+
+    const triangleInside = new Uint8Array(
+      warpedMap.trianglePointsInside
+        .filter((_inside, index) => index % 3 === 0)
+        .map((inside) => (inside ? 1 : 0))
+    )
+
+    const rgbaPixels = this.wasmModule.render_warped_triangles_rgba(
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights,
+      resourceTrianglePoints,
+      canvasTrianglePoints,
+      triangleInside,
       outputWidth,
       outputHeight
     )

--- a/packages/render/src/renderers/WasmRenderer.ts
+++ b/packages/render/src/renderers/WasmRenderer.ts
@@ -21,6 +21,16 @@ import type { CachedTile } from '../tilecache/CacheableTile.js'
 
 // Type for the WASM module
 type WasmModule = {
+  RenderContext: {
+    new (
+      outputWidth: number,
+      outputHeight: number,
+      backgroundRed: number,
+      backgroundGreen: number,
+      backgroundBlue: number,
+      hasBackground: boolean
+    ): WasmRenderContext
+  }
   decode_jpeg_test(jpegBytes: Uint8Array): { width: number; height: number }
   encode_rgba_to_png(
     pixels: Uint8Array,
@@ -147,6 +157,50 @@ type WasmModule = {
   ): Uint8Array
 }
 
+type WasmRenderContext = {
+  render_warped_tile_rgba(
+    jpeg_tiles: Uint8Array,
+    tile_offsets: Uint32Array,
+    tile_widths: Uint32Array,
+    tile_heights: Uint32Array,
+    tile_columns: Float64Array,
+    tile_rows: Float64Array,
+    tile_scale_factors: Float64Array,
+    tile_original_widths: Float64Array,
+    tile_original_heights: Float64Array,
+    transform_type: string,
+    transform_args: Float64Array,
+    source_points: Float64Array,
+    mask_polygon: Float64Array,
+    canvas_to_geo: Float64Array,
+    render_min_x: number,
+    render_min_y: number,
+    render_max_x: number,
+    render_max_y: number
+  ): void
+  render_warped_triangles_rgba(
+    jpeg_tiles: Uint8Array,
+    tile_offsets: Uint32Array,
+    tile_widths: Uint32Array,
+    tile_heights: Uint32Array,
+    tile_columns: Float64Array,
+    tile_rows: Float64Array,
+    tile_scale_factors: Float64Array,
+    tile_original_widths: Float64Array,
+    tile_original_heights: Float64Array,
+    resource_triangle_points: Float64Array,
+    canvas_triangle_points: Float64Array,
+    triangle_inside: Uint8Array,
+    render_min_x: number,
+    render_min_y: number,
+    render_max_x: number,
+    render_max_y: number
+  ): void
+  encode_png(): Uint8Array
+  encode_webp(): Uint8Array
+  encode_jpeg(quality: number): Uint8Array
+}
+
 export type OutputFormat = 'png' | 'webp' | 'jpeg'
 
 /**
@@ -201,21 +255,18 @@ export class WasmRenderer
     this.requestFetchableTiles()
     await this.tileCache.allRequestedTilesLoaded()
 
-    // Initialize output buffer (will be filled by rendering each map)
     const outputWidth = viewport.canvasSize[0]
     const outputHeight = viewport.canvasSize[1]
-    const outputPixels = new Uint8ClampedArray(outputWidth * outputHeight * 4)
-
-    // Fill background color if specified (important for opaque formats like JPEG)
-    if (this.backgroundColor) {
-      const [r, g, b] = this.backgroundColor
-      for (let i = 0; i < outputPixels.length; i += 4) {
-        outputPixels[i] = r
-        outputPixels[i + 1] = g
-        outputPixels[i + 2] = b
-        outputPixels[i + 3] = 255
-      }
-    }
+    const [backgroundRed, backgroundGreen, backgroundBlue] = this
+      .backgroundColor || [0, 0, 0]
+    const renderContext = new this.wasmModule.RenderContext(
+      outputWidth,
+      outputHeight,
+      backgroundRed,
+      backgroundGreen,
+      backgroundBlue,
+      Boolean(this.backgroundColor)
+    )
 
     // Get canvas-to-geo transform (same for all maps)
     const geoToCanvas = viewport.projectedGeoToCanvasHomogeneousTransform
@@ -241,45 +292,92 @@ export class WasmRenderer
         continue
       }
 
+      const renderBounds = this.#getCanvasRenderBounds(
+        warpedMap,
+        outputWidth,
+        outputHeight
+      )
+      if (!renderBounds) {
+        continue
+      }
+
       const shouldUseTriangleRenderer = !isEqualProjection(
         warpedMap.internalProjection,
         viewport.projection
       )
 
-      const mapPixels = shouldUseTriangleRenderer
-        ? await this.#renderMapWithTriangles(
-            warpedMap,
-            cachedTiles,
-            outputWidth,
-            outputHeight
-          )
-        : await this.#renderMap(
-            warpedMap,
-            cachedTiles,
-            canvasToGeo,
-            outputWidth,
-            outputHeight
-          )
-
-      // Composite into output buffer (overwrite non-transparent pixels)
-      for (let i = 0; i < outputPixels.length; i += 4) {
-        const alpha = mapPixels[i + 3]
-        if (alpha > 0) {
-          outputPixels[i] = mapPixels[i]
-          outputPixels[i + 1] = mapPixels[i + 1]
-          outputPixels[i + 2] = mapPixels[i + 2]
-          outputPixels[i + 3] = mapPixels[i + 3]
-        }
+      if (shouldUseTriangleRenderer) {
+        this.#renderMapWithTrianglesInto(
+          warpedMap,
+          cachedTiles,
+          renderContext,
+          outputWidth,
+          outputHeight,
+          renderBounds
+        )
+      } else {
+        this.#renderMapInto(
+          warpedMap,
+          cachedTiles,
+          canvasToGeo,
+          renderContext,
+          outputWidth,
+          outputHeight,
+          renderBounds
+        )
       }
     }
 
     // Encode output based on format
     if (this.outputFormat === 'webp') {
-      return this.#encodeWebP(outputPixels, outputWidth, outputHeight)
+      return renderContext.encode_webp()
     } else if (this.outputFormat === 'jpeg') {
-      return this.#encodeJPEG(outputPixels, outputWidth, outputHeight)
+      return renderContext.encode_jpeg(85)
     } else {
-      return this.#encodePNG(outputPixels, outputWidth, outputHeight)
+      return renderContext.encode_png()
+    }
+  }
+
+  #getCanvasRenderBounds(
+    warpedMap: TriangulatedWarpedMap,
+    outputWidth: number,
+    outputHeight: number
+  ) {
+    if (!this.viewport) {
+      throw new Error('Cannot render without viewport')
+    }
+
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+
+    for (const projectedGeoPoint of warpedMap.projectedGeoMask) {
+      const canvasPoint = applyHomogeneousTransform(
+        this.viewport.projectedGeoToCanvasHomogeneousTransform,
+        projectedGeoPoint
+      )
+
+      minX = Math.min(minX, canvasPoint[0])
+      minY = Math.min(minY, canvasPoint[1])
+      maxX = Math.max(maxX, canvasPoint[0])
+      maxY = Math.max(maxY, canvasPoint[1])
+    }
+
+    const renderMinX = Math.max(0, Math.floor(minX))
+    const renderMinY = Math.max(0, Math.floor(minY))
+    const renderMaxX = Math.min(outputWidth, Math.ceil(maxX))
+    const renderMaxY = Math.min(outputHeight, Math.ceil(maxY))
+
+    if (renderMinX >= renderMaxX || renderMinY >= renderMaxY) {
+      return
+    }
+
+    return {
+      minX: renderMinX,
+      minY: renderMinY,
+      maxX: renderMaxX,
+      maxY: renderMaxY
     }
   }
 
@@ -390,6 +488,59 @@ export class WasmRenderer
     return new Uint8ClampedArray(rgbaPixels)
   }
 
+  #renderMapInto(
+    warpedMap: TriangulatedWarpedMap,
+    cachedTiles: CachedTile<RawJpegData>[],
+    canvasToGeo: Float64Array,
+    renderContext: WasmRenderContext,
+    outputWidth: number,
+    outputHeight: number,
+    renderBounds: { minX: number; minY: number; maxX: number; maxY: number }
+  ) {
+    const {
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights
+    } = this.#getTileBuffers(cachedTiles)
+
+    const transformer = warpedMap.projectedTransformer
+    const transformation = transformer.getToResourceTransformation()
+    const { weights, sourcePoints } =
+      transformation.getTransformationDataAsFloat64Array()
+    const transformType = transformation.type
+
+    const maskPolygon = new Float64Array(
+      warpedMap.resourceMask.flatMap((p: [number, number]) => [p[0], p[1]])
+    )
+
+    renderContext.render_warped_tile_rgba(
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights,
+      transformType,
+      weights,
+      sourcePoints,
+      maskPolygon,
+      canvasToGeo,
+      renderBounds.minX,
+      renderBounds.minY,
+      renderBounds.maxX,
+      renderBounds.maxY
+    )
+  }
+
   async #renderMapWithTriangles(
     warpedMap: TriangulatedWarpedMap,
     cachedTiles: CachedTile<RawJpegData>[],
@@ -449,6 +600,69 @@ export class WasmRenderer
     )
 
     return new Uint8ClampedArray(rgbaPixels)
+  }
+
+  #renderMapWithTrianglesInto(
+    warpedMap: TriangulatedWarpedMap,
+    cachedTiles: CachedTile<RawJpegData>[],
+    renderContext: WasmRenderContext,
+    outputWidth: number,
+    outputHeight: number,
+    renderBounds: { minX: number; minY: number; maxX: number; maxY: number }
+  ) {
+    const {
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights
+    } = this.#getTileBuffers(cachedTiles)
+
+    const resourceTrianglePoints = new Float64Array(
+      warpedMap.resourceTrianglePoints.flatMap((point) => [point[0], point[1]])
+    )
+
+    const canvasTrianglePoints = new Float64Array(
+      warpedMap.projectedGeoTrianglePoints.flatMap((point) => {
+        if (!this.viewport) {
+          throw new Error('Cannot render without viewport')
+        }
+        const canvasPoint = applyHomogeneousTransform(
+          this.viewport.projectedGeoToCanvasHomogeneousTransform,
+          point
+        )
+        return [canvasPoint[0], canvasPoint[1]]
+      })
+    )
+
+    const triangleInside = new Uint8Array(
+      warpedMap.trianglePointsInside
+        .filter((_inside, index) => index % 3 === 0)
+        .map((inside) => (inside ? 1 : 0))
+    )
+
+    renderContext.render_warped_triangles_rgba(
+      concatenatedJpeg,
+      tileOffsets,
+      tileWidths,
+      tileHeights,
+      tileColumns,
+      tileRows,
+      tileScaleFactors,
+      tileOriginalWidths,
+      tileOriginalHeights,
+      resourceTrianglePoints,
+      canvasTrianglePoints,
+      triangleInside,
+      renderBounds.minX,
+      renderBounds.minY,
+      renderBounds.maxX,
+      renderBounds.maxY
+    )
   }
 
   /**


### PR DESCRIPTION
This pull request introduces a new triangle-based rendering pipeline and refactors the rendering code to support rendering directly into existing output buffers. It also adds a new `RenderContext` struct for more efficient, stateful rendering from JavaScript/WebAssembly, and exposes new WASM bindings for triangle rendering and output encoding. Additionally, the code is refactored for improved readability and maintainability.

**Major new rendering features:**

* Added triangle-based rendering functions (`render_triangles` and `render_triangles_into`) that rasterize projected triangles and interpolate resource coordinates, mirroring the WebGL renderer. This enables more flexible and accurate rendering workflows. [[1]](diffhunk://#diff-29f65a63887e2e08371a29256413e2d780fd8873e9ffcd5755c6720da1e85377L13-R13) [[2]](diffhunk://#diff-36893e714af7c121f85879168a09c23015795fc7d12741e2d0c5e3427164dff0L224-R464)
* Introduced the `RenderContext` struct, which allows for efficient, stateful rendering and encoding workflows from JavaScript/WebAssembly. This includes methods for rendering warped tiles and triangles, and for encoding the output as PNG, WebP, or JPEG.

**Rendering pipeline refactoring:**

* Refactored the main rendering function to support direct rendering into a provided output buffer via the new `render_into` function, and updated the WASM bindings to use these new interfaces. [[1]](diffhunk://#diff-36893e714af7c121f85879168a09c23015795fc7d12741e2d0c5e3427164dff0R164-R199) [[2]](diffhunk://#diff-29f65a63887e2e08371a29256413e2d780fd8873e9ffcd5755c6720da1e85377R123-R319)
* Added new WASM-exposed functions for triangle-based rendering (`render_warped_triangles_rgba`) and updated the direct tile rendering path.

**Code quality improvements:**

* Improved code formatting and readability in several places (e.g., struct initializations, function signatures, and logic blocks). [[1]](diffhunk://#diff-36893e714af7c121f85879168a09c23015795fc7d12741e2d0c5e3427164dff0L18-R21) [[2]](diffhunk://#diff-36893e714af7c121f85879168a09c23015795fc7d12741e2d0c5e3427164dff0L62-R67) [[3]](diffhunk://#diff-36893e714af7c121f85879168a09c23015795fc7d12741e2d0c5e3427164dff0L167-R209) [[4]](diffhunk://#diff-64ee301730b93eda823319c9ca25c952d29c68ed8b9ecc06201cf8c9238d4ab0L47-R51)

These changes lay the groundwork for more advanced rendering workflows and improved performance in the WebAssembly renderer.