### PR TITLE
improved map menu, using webp preview images

### DIFF
--- a/apps/viewer/src/lib/components/Examples.svelte
+++ b/apps/viewer/src/lib/components/Examples.svelte
@@ -28,7 +28,7 @@
         <img
           alt={`Preview of ${example.title}`}
           class="border-2 bg-white/50 border-pink/20 rounded-lg aspect-3/2 overflow-clip"
-          src={`${previewUrl}/${example.allmapsId}.jpg?fit=best&background=fff&width=600&height=400`}
+          src={`${previewUrl}/${example.allmapsId}.webp?fit=best&width=600&height=400`}
         />
 
         <span class="underline">{example.title}</span>

--- a/apps/viewer/src/lib/components/MapMenu.svelte
+++ b/apps/viewer/src/lib/components/MapMenu.svelte
@@ -16,10 +16,15 @@
     CaretRight as CaretRightIcon,
     Globe as GlobeIcon
   } from 'phosphor-svelte'
+  import { generateAnnotation } from '@allmaps/annotation'
 
   import { getSourceState } from '$lib/state/source.svelte.js'
+  import { flattenPartOf } from '$lib/shared/metadata.js'
 
-  import type { GeoreferencedMap } from '@allmaps/annotation'
+  import type {
+    GeoreferencedMap,
+    PartOfItem
+  } from '@allmaps/annotation'
   import type { WarpedMapLayer } from '@allmaps/maplibre'
   import type { Snippet } from 'svelte'
 
@@ -57,6 +62,17 @@
 
   // Get image URI for URL generation
   const imageUri = $derived(georeferencedMap.resource.id)
+  const manifestUri = $derived.by(() => {
+    return findFirstPartOfItemOfType(
+      georeferencedMap.resource.partOf,
+      'Manifest'
+    )?.id
+  })
+  const theseusViewerUrl = $derived(
+    manifestUri
+      ? `https://theseusviewer.org/?iiif-content=${encodeURIComponent(manifestUri)}`
+      : undefined
+  )
   const editorUrl = $derived(
     imageUri
       ? `https://editor.allmaps.org/#/mask?url=${encodeURIComponent(imageUri)}`
@@ -114,6 +130,17 @@
     warpedMapLayer.sendMapsToBack([mapId])
   }
 
+  function findFirstPartOfItemOfType(
+    partOf: GeoreferencedMap['resource']['partOf'],
+    type: string
+  ) {
+    for (const partOfItem of flattenPartOf(partOf)) {
+      if (partOfItem.type === type) {
+        return partOfItem
+      }
+    }
+  }
+
   async function handleCopyAnnotationUrl() {
     try {
       // const annotationUrl = `https://annotations.allmaps.org/maps/${mapId}`
@@ -123,11 +150,33 @@
     }
   }
 
-  async function handleCopyImageUrl() {
+  async function handleCopyAnnotation() {
+    try {
+      await navigator.clipboard.writeText(
+        JSON.stringify(generateAnnotation(georeferencedMap), null, 2)
+      )
+    } catch (error) {
+      console.error('Failed to copy annotation:', error)
+    }
+  }
+
+  async function handleCopyImageId() {
     try {
       await navigator.clipboard.writeText(imageUri)
     } catch (error) {
-      console.error('Failed to copy image URL:', error)
+      console.error('Failed to copy image ID:', error)
+    }
+  }
+
+  async function handleCopyManifestId() {
+    if (!manifestUri) {
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(manifestUri)
+    } catch (error) {
+      console.error('Failed to copy manifest ID:', error)
     }
   }
 
@@ -292,15 +341,55 @@
         <span>Copy Annotation URL</span>
       </DropdownMenu.Item>
 
-      <!-- Copy Image URL -->
+      <!-- Copy Annotation -->
       <DropdownMenu.Item
         class="flex h-9 cursor-pointer select-none items-center gap-2 rounded-md px-3 text-sm outline-none transition-colors hover:bg-gray-100 data-highlighted:bg-gray-100"
-        onSelect={handleCopyImageUrl}
-        disabled={!imageUri}
+        onSelect={handleCopyAnnotation}
+        disabled={!georeferencedMap}
       >
         <CopyIcon class="size-4" />
-        <span>Copy Image URL</span>
+        <span>Copy Annotation</span>
       </DropdownMenu.Item>
+
+      <DropdownMenu.Separator class="my-1 h-px bg-gray-200" />
+
+      <!-- IIIF submenu -->
+      <DropdownMenu.Sub>
+        <DropdownMenu.SubTrigger
+          class="flex h-9 cursor-pointer select-none items-center gap-2 rounded-md px-3 text-sm outline-none transition-colors hover:bg-gray-100 data-highlighted:bg-gray-100"
+        >
+          <ImageIcon class="size-4" />
+          <span class="flex-1">IIIF</span>
+          <CaretRightIcon class="size-4 ml-auto" />
+        </DropdownMenu.SubTrigger>
+        <DropdownMenu.SubContent
+          class="z-50 min-w-[200px] rounded-lg border border-gray-200 bg-white px-1 py-1.5 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+        >
+          <DropdownMenu.Item
+            class="flex h-9 cursor-pointer select-none items-center gap-2 rounded-md px-3 text-sm outline-none transition-colors hover:bg-gray-100 data-highlighted:bg-gray-100"
+            onSelect={handleCopyImageId}
+            disabled={!imageUri}
+          >
+            <CopyIcon class="size-4" />
+            <span>Copy Image ID</span>
+          </DropdownMenu.Item>
+
+          {#if manifestUri}
+            <DropdownMenu.Item
+              class="flex h-9 cursor-pointer select-none items-center gap-2 rounded-md px-3 text-sm outline-none transition-colors hover:bg-gray-100 data-highlighted:bg-gray-100"
+              onSelect={handleCopyManifestId}
+            >
+              <CopyIcon class="size-4" />
+              <span>Copy Manifest ID</span>
+            </DropdownMenu.Item>
+
+            {@render externalLinkMenuItem(
+              'Open in Theseus Viewer',
+              theseusViewerUrl
+            )}
+          {/if}
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Sub>
 
       <DropdownMenu.Separator class="my-1 h-px bg-gray-200" />
 

--- a/apps/viewer/src/lib/shared/metadata.ts
+++ b/apps/viewer/src/lib/shared/metadata.ts
@@ -28,7 +28,7 @@ function countManifestsById(
   return manifestCounts
 }
 
-function* flattenPartOf(partOf?: PartOf): Generator<PartOfItem> {
+export function* flattenPartOf(partOf?: PartOf): Generator<PartOfItem> {
   if (partOf) {
     for (const partOfItem of partOf) {
       yield partOfItem


### PR DESCRIPTION
This pull request enhances the IIIF and annotation features in the `MapMenu` component and improves image handling in the `Examples` component. The most important changes are:

**IIIF & Annotation Menu Improvements:**
- Added a new "Copy Annotation" menu item that copies the full annotation JSON to the clipboard using `generateAnnotation`. [[1]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bL126-R179) [[2]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bL295-R393)
- Refactored the IIIF submenu to allow copying both the Image ID and Manifest ID, and to provide a direct link to open the manifest in the Theseus Viewer if available. [[1]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bR65-R75) [[2]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bL126-R179) [[3]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bL295-R393)
- Added helper methods and imports (`flattenPartOf`, `findFirstPartOfItemOfType`) to support manifest detection and menu logic. [[1]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bR19-R27) [[2]](diffhunk://#diff-3f81059b21ff8adde3f14f4a0776fed800f3115b8f3335587157842afc4ae22bR133-R143) [[3]](diffhunk://#diff-d41fc2cd3812e4273427bd6b9146f1cbdcc8d6c79cf838fdd57edc0063a54e98L31-R31)

**Image Handling:**
- Updated the `Examples.svelte` component to use `.webp` images instead of `.jpg` for previews, and removed the `background=fff` parameter.