### PR TITLE
no autofocus on mobile

### DIFF
--- a/apps/viewer/src/lib/components/Info.svelte
+++ b/apps/viewer/src/lib/components/Info.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { browser } from '$app/environment'
+
   import { Info as InfoIcon } from 'phosphor-svelte'
 
   import { Popover } from '@allmaps/components'
@@ -35,6 +37,31 @@
   }: Props = $props()
 
   let open = $state(false)
+  let autoFocusUrlInput = $state(false)
+
+  function updateAutoFocusUrlInput(coarsePointerQuery: MediaQueryList) {
+    autoFocusUrlInput = !coarsePointerQuery.matches
+  }
+
+  $effect(() => {
+    if (!browser) {
+      return
+    }
+
+    const coarsePointerQuery = window.matchMedia('(pointer: coarse)')
+    const handleCoarsePointerChange = () =>
+      updateAutoFocusUrlInput(coarsePointerQuery)
+
+    updateAutoFocusUrlInput(coarsePointerQuery)
+    coarsePointerQuery.addEventListener('change', handleCoarsePointerChange)
+
+    return () => {
+      coarsePointerQuery.removeEventListener(
+        'change',
+        handleCoarsePointerChange
+      )
+    }
+  })
 
   let labelStrings = $derived.by(() => {
     let manifestLabel: string | undefined
@@ -144,7 +171,7 @@
     jsonModeHeightClass="h-24"
     submitButton={false}
     roundedFull={false}
-    autoFocus={true}
+    autoFocus={autoFocusUrlInput}
   />
 {/snippet}
 


### PR DESCRIPTION
This pull request updates the `Info.svelte` component to improve the handling of input focus for users on different device types. The main change is to conditionally enable auto-focus on the URL input based on whether the device uses a coarse pointer (typically touch devices), enhancing accessibility and user experience.

Accessibility and device adaptation:

* Added logic to detect if the user is on a device with a coarse pointer (e.g., touchscreens) using `window.matchMedia('(pointer: coarse)')`, and only enable auto-focus on the URL input for devices without a coarse pointer. This prevents unwanted keyboard pop-ups on mobile devices.
* Updated the `autoFocus` prop on the URL input to use the new `autoFocusUrlInput` state, which is set based on the pointer type.
* Ensured the pointer detection and focus logic only runs in the browser environment by checking the `browser` variable.

These changes make the input experience more intuitive for both desktop and mobile users.