### PR TITLE
improved thumbnail component

### DIFF
--- a/packages/components/src/lib/components/Thumbnail.svelte
+++ b/packages/components/src/lib/components/Thumbnail.svelte
@@ -1,25 +1,127 @@
 <script lang="ts">
   import { Image, type ImageRequest } from '@allmaps/iiif-parser'
+  import { pink } from '@allmaps/tailwind'
 
-  import type { Fit } from '@allmaps/types'
+  import type { Fit, Ring } from '@allmaps/types'
+
+  type ThumbnailResourceMask = {
+    resourceMask: Ring
+    color?: string
+    fill?: string
+    fillOpacity?: number
+    stroke?: string
+    strokeOpacity?: number
+    strokeWidth?: number
+  }
+
+  type ImageBox = {
+    left: number
+    top: number
+    width: number
+    height: number
+  }
+
+  type ThumbnailRegion = {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
 
   type Props = {
-    imageInfo: unknown
-    width: number
+    imageInfo?: unknown
+    imageBitmap?: ImageBitmap
+    width?: number
     height?: number
-    mode: Fit
+    sourceWidth?: number
+    sourceHeight?: number
+    region?: ThumbnailRegion
+    mode?: Fit
     borderColor?: string
+    resourceMasks?: (Ring | ThumbnailResourceMask)[]
     alt?: string
   }
 
   let {
     imageInfo,
+    imageBitmap,
     width,
-    height = width,
+    height,
+    sourceWidth: sourceWidthProp,
+    sourceHeight: sourceHeightProp,
+    region,
     mode = 'cover',
     borderColor,
+    resourceMasks = [],
     alt
   }: Props = $props()
+
+  let canvas = $state<HTMLCanvasElement>()
+
+  function getSourceWidth() {
+    return sourceWidthProp || imageBitmap?.width || parsedImage?.width || 0
+  }
+
+  function getSourceHeight() {
+    return sourceHeightProp || imageBitmap?.height || parsedImage?.height || 0
+  }
+
+  function getDisplaySourceWidth() {
+    return region?.width || sourceWidth
+  }
+
+  function getDisplaySourceHeight() {
+    return region?.height || sourceHeight
+  }
+
+  function getRenderWidth() {
+    return width || imageBitmap?.width || parsedImage?.width || 1
+  }
+
+  function getRenderHeight() {
+    return height || width || imageBitmap?.height || parsedImage?.height || 1
+  }
+
+  function getImageBox(
+    sourceWidth: number,
+    sourceHeight: number,
+    renderWidth: number,
+    renderHeight: number,
+    mode: Fit
+  ): ImageBox {
+    if (!sourceWidth || !sourceHeight || !renderWidth || !renderHeight) {
+      return { left: 0, top: 0, width: renderWidth, height: renderHeight }
+    }
+
+    if (mode === 'cover' || mode === 'contain') {
+      const widthRatio = renderWidth / sourceWidth
+      const heightRatio = renderHeight / sourceHeight
+      const ratio =
+        mode === 'cover'
+          ? Math.max(widthRatio, heightRatio)
+          : Math.min(widthRatio, heightRatio)
+      const boxWidth = sourceWidth * ratio
+      const boxHeight = sourceHeight * ratio
+
+      return {
+        left: (renderWidth - boxWidth) / 2,
+        top: (renderHeight - boxHeight) / 2,
+        width: boxWidth,
+        height: boxHeight
+      }
+    }
+
+    return { left: 0, top: 0, width: renderWidth, height: renderHeight }
+  }
+
+  function getBoxStyle(box: ImageBox) {
+    return [
+      `left: ${(box.left / renderWidth) * 100}%`,
+      `top: ${(box.top / renderHeight) * 100}%`,
+      `width: ${(box.width / renderWidth) * 100}%`,
+      `height: ${(box.height / renderHeight) * 100}%`
+    ].join('; ')
+  }
 
   function getTilesWidth(imageRequestGrid: ImageRequest[][]) {
     const firstRow = imageRequestGrid[0]
@@ -33,11 +135,9 @@
     )
   }
 
-  function getColumnPercentages(
-    imageRequestGrid: ImageRequest[][],
-    tilesWidth: number
-  ) {
+  function getColumnPercentages(imageRequestGrid: ImageRequest[][]) {
     const firstRow = imageRequestGrid[0]
+    const tilesWidth = getTilesWidth(imageRequestGrid)
     if (tilesWidth === 0) {
       return new Array(firstRow.length).fill(0)
     }
@@ -45,91 +145,216 @@
     return firstRow.map((row) => ((row.size?.width || 0) / tilesWidth) * 100)
   }
 
-  function getLeftStyle(tilesWidth: number, tilesHeight: number) {
-    return `${(100 - (tilesWidth / tilesHeight) * 100) / 2}%`
+  function getRowPercentages(imageRequestGrid: ImageRequest[][]) {
+    const tilesHeight = getTilesHeight(imageRequestGrid)
+    if (tilesHeight === 0) {
+      return new Array(imageRequestGrid.length).fill(0)
+    }
+
+    return imageRequestGrid.map(
+      (row) => ((row[0].size?.height || 0) / tilesHeight) * 100
+    )
   }
 
-  function getTopStyle(tilesWidth: number, tilesHeight: number) {
-    return `${(100 - (tilesHeight / tilesWidth) * 100) / 2}%`
+  function isThumbnailResourceMask(
+    resourceMask: Ring | ThumbnailResourceMask
+  ): resourceMask is ThumbnailResourceMask {
+    return 'resourceMask' in resourceMask
   }
 
-  let parsedImage = $derived(Image.parse(imageInfo))
+  function normalizeResourceMask(
+    resourceMask: Ring | ThumbnailResourceMask
+  ): ThumbnailResourceMask {
+    if (isThumbnailResourceMask(resourceMask)) {
+      return resourceMask
+    }
+
+    return { resourceMask }
+  }
+
+  function getMaskPoints(resourceMask: Ring) {
+    return resourceMask
+      .map((point) =>
+        region ? [point[0] - region.x, point[1] - region.y] : point
+      )
+      .map((point) => point.join(','))
+      .join(' ')
+  }
+
+  function getMaskFill(mask: ThumbnailResourceMask) {
+    return mask.fill || 'none'
+  }
+
+  function getMaskFillOpacity(mask: ThumbnailResourceMask) {
+    return mask.fillOpacity ?? 0.12
+  }
+
+  function getMaskStroke(mask: ThumbnailResourceMask) {
+    return mask.stroke || mask.color || pink
+  }
+
+  function getMaskStrokeOpacity(mask: ThumbnailResourceMask) {
+    return mask.strokeOpacity ?? 0.65
+  }
+
+  function getMaskStrokeWidth(mask: ThumbnailResourceMask) {
+    return (
+      mask.strokeWidth ?? Math.max(displaySourceWidth, displaySourceHeight) / 80
+    )
+  }
+
+  let parsedImage = $derived(imageInfo ? Image.parse(imageInfo) : undefined)
+  let sourceWidth = $derived(getSourceWidth())
+  let sourceHeight = $derived(getSourceHeight())
+  let displaySourceWidth = $derived(getDisplaySourceWidth())
+  let displaySourceHeight = $derived(getDisplaySourceHeight())
+  let renderWidth = $derived(getRenderWidth())
+  let renderHeight = $derived(getRenderHeight())
+  let imageBox = $derived(
+    getImageBox(
+      displaySourceWidth,
+      displaySourceHeight,
+      renderWidth,
+      renderHeight,
+      mode
+    )
+  )
+  let borderBox = $derived(
+    mode === 'cover'
+      ? { left: 0, top: 0, width: renderWidth, height: renderHeight }
+      : imageBox
+  )
   let imageRequest = $derived(
-    parsedImage && parsedImage.getImageRequest({ width, height }, mode)
+    parsedImage && region
+      ? {
+          region,
+          size: {
+            width: imageBox.width,
+            height: imageBox.height
+          }
+        }
+      : parsedImage &&
+          parsedImage.getImageRequest(
+            { width: renderWidth, height: renderHeight },
+            mode
+          )
+  )
+  let normalizedResourceMasks = $derived(
+    resourceMasks.map(normalizeResourceMask)
   )
 
-  let borderBoxWidth = $derived(mode === 'cover' ? width : parsedImage?.width)
-  let borderBoxHeight = $derived(
-    mode === 'cover' ? height : parsedImage?.height
-  )
-  let borderBoxAspectRatio = $derived(
-    borderBoxWidth && borderBoxHeight ? borderBoxWidth / borderBoxHeight : 0
-  )
+  $effect(() => {
+    if (!canvas || !imageBitmap) {
+      return
+    }
+
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return
+    }
+
+    if (region && sourceWidth && sourceHeight) {
+      const xScale = imageBitmap.width / sourceWidth
+      const yScale = imageBitmap.height / sourceHeight
+      const cropX = region.x * xScale
+      const cropY = region.y * yScale
+      const cropWidth = region.width * xScale
+      const cropHeight = region.height * yScale
+      const canvasWidth = Math.max(1, Math.round(cropWidth))
+      const canvasHeight = Math.max(1, Math.round(cropHeight))
+
+      canvas.width = canvasWidth
+      canvas.height = canvasHeight
+      context.clearRect(0, 0, canvasWidth, canvasHeight)
+      context.drawImage(
+        imageBitmap,
+        cropX,
+        cropY,
+        cropWidth,
+        cropHeight,
+        0,
+        0,
+        canvasWidth,
+        canvasHeight
+      )
+    } else {
+      canvas.width = imageBitmap.width
+      canvas.height = imageBitmap.height
+      context.clearRect(0, 0, imageBitmap.width, imageBitmap.height)
+      context.drawImage(imageBitmap, 0, 0)
+    }
+  })
 </script>
 
 <div
-  style:aspect-ratio="{width} / {height}"
-  style="--border-color: {borderColor}; --border-box-aspect-ratio: {borderBoxAspectRatio}"
-  class="flex overflow-hidden"
+  style:aspect-ratio="{renderWidth} / {renderHeight}"
+  style="--border-color: {borderColor}"
+  class="relative flex w-full overflow-hidden"
 >
-  {#if parsedImage && imageRequest && !Array.isArray(imageRequest)}
-    <img
-      class="w-full h-full {mode === 'cover'
-        ? 'object-cover'
-        : 'object-contain'}"
-      alt={alt || `Thumbnail for ${parsedImage.uri}`}
-      src={parsedImage.getImageUrl(imageRequest)}
-    />
-  {:else if parsedImage && imageRequest && Array.isArray(imageRequest)}
-    {@const tilesWidth = getTilesWidth(imageRequest)}
-    {@const tilesHeight = getTilesHeight(imageRequest)}
-    {@const orientationPortrait =
-      (mode === 'contain' && parsedImage.width > parsedImage.height) ||
-      (mode === 'cover' && parsedImage.width < parsedImage.height)}
-    {@const columnPercentages = getColumnPercentages(imageRequest, tilesWidth)}
+  <div class="absolute" style={getBoxStyle(imageBox)}>
+    {#if imageBitmap}
+      <canvas bind:this={canvas} class="h-full w-full"></canvas>
+    {:else if parsedImage && imageRequest && !Array.isArray(imageRequest)}
+      <img
+        class="h-full w-full"
+        alt={alt || `Thumbnail for ${parsedImage.uri}`}
+        src={parsedImage.getImageUrl(imageRequest)}
+      />
+    {:else if parsedImage && imageRequest && Array.isArray(imageRequest)}
+      {@const columnPercentages = getColumnPercentages(imageRequest)}
+      {@const rowPercentages = getRowPercentages(imageRequest)}
 
-    <!-- style:left={!orientationPortrait
-        ? getLeftStyle(tilesWidth, tilesHeight)
-        : ''}
-      style:top={orientationPortrait
-        ? getTopStyle(tilesWidth, tilesHeight)
-        : ''} -->
-    <div
-      class="relative grid"
-      class:w-full={orientationPortrait}
-      class:h-full={!orientationPortrait}
-      style:grid-template-columns={columnPercentages
-        .map((percentage) => `${percentage}%`)
-        .join(' ')}
-      style:aspect-ratio="{tilesWidth} / {tilesHeight}"
-      style:left={mode === 'cover' ? getLeftStyle(tilesWidth, tilesHeight) : ''}
-      style:top={mode === 'contain' ? getTopStyle(tilesWidth, tilesHeight) : ''}
-      style:height="{(borderBoxHeight / borderBoxWidth) * 100}%"
-    >
-      {#each imageRequest as row, rowIndex (rowIndex)}
-        {#each row as tile, columnIndex (columnIndex)}
-          <img
-            class="max-w-full h-full"
-            src={parsedImage.getImageUrl(tile)}
-            alt={alt ||
-              `Thumbnail for ${parsedImage.uri} (${rowIndex}, ${columnIndex})`}
+      <div
+        class="grid h-full w-full"
+        style:grid-template-columns={columnPercentages
+          .map((percentage) => `${percentage}%`)
+          .join(' ')}
+        style:grid-template-rows={rowPercentages
+          .map((percentage) => `${percentage}%`)
+          .join(' ')}
+      >
+        {#each imageRequest as row, rowIndex (rowIndex)}
+          {#each row as tile, columnIndex (columnIndex)}
+            <img
+              class="h-full w-full"
+              src={parsedImage.getImageUrl(tile)}
+              alt={alt ||
+                `Thumbnail for ${parsedImage.uri} (${rowIndex}, ${columnIndex})`}
+            />
+          {/each}
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  {#if displaySourceWidth && displaySourceHeight && normalizedResourceMasks.length}
+    <div class="pointer-events-none absolute" style={getBoxStyle(imageBox)}>
+      <svg
+        class="h-full w-full"
+        viewBox="0 0 {displaySourceWidth} {displaySourceHeight}"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        {#each normalizedResourceMasks as mask, index (index)}
+          <polygon
+            class="transition-all"
+            points={getMaskPoints(mask.resourceMask)}
+            fill={getMaskFill(mask)}
+            fill-opacity={getMaskFillOpacity(mask)}
+            stroke={getMaskStroke(mask)}
+            stroke-opacity={getMaskStrokeOpacity(mask)}
+            stroke-width={getMaskStrokeWidth(mask)}
           />
         {/each}
-      {/each}
+      </svg>
     </div>
   {/if}
+
   {#if borderColor}
-    <!-- TODO: make this a slot/snippet, so clients can render
-      their own border box -->
     <div
-      class="absolute left-0 top-0 w-full h-full flex justify-center items-center pointer-events-none"
-    >
-      <div
-        class="{borderBoxAspectRatio < 1
-          ? 'h-full'
-          : 'w-full'} aspect-(--border-box-aspect-ratio)
-      outline-4 outline-(--border-color)"
-      ></div>
-    </div>
+      class="pointer-events-none absolute outline-4 outline-(--border-color)"
+      style={getBoxStyle(borderBox)}
+      aria-hidden="true"
+    ></div>
   {/if}
 </div>


### PR DESCRIPTION
This pull request significantly refactors and extends the `Thumbnail.svelte` component to support more flexible rendering, especially for cropped images, overlays, and resource masks. The changes improve how thumbnails are rendered from IIIF image sources, add support for drawing overlays (such as polygons), and allow direct rendering from `ImageBitmap` objects. The component's API is also extended for greater configurability.

**Major feature additions and improvements:**

*Support for Cropped Images and ImageBitmap Rendering:*
- Added support for rendering cropped regions of images and direct rendering from an `ImageBitmap`, including logic to handle cropping and scaling on a `<canvas>`. [[1]](diffhunk://#diff-d3cc59bc93a30dbb581f37f00c1a16704aefbf874292d8108553004f76975b60R3-R125) [[2]](diffhunk://#diff-d3cc59bc93a30dbb581f37f00c1a16704aefbf874292d8108553004f76975b60L36-R319)

*Resource Masks and Overlays:*
- Introduced the `resourceMasks` prop, allowing overlays of polygonal masks (e.g., `Ring` or `ThumbnailResourceMask`) with customizable fill, stroke, and opacity, rendered as SVG polygons over the thumbnail. [[1]](diffhunk://#diff-d3cc59bc93a30dbb581f37f00c1a16704aefbf874292d8108553004f76975b60R3-R125) [[2]](diffhunk://#diff-d3cc59bc93a30dbb581f37f00c1a16704aefbf874292d8108553004f76975b60L121-L133)

*Enhanced Layout and Responsiveness:*
- Refactored layout logic to use computed `renderWidth`, `renderHeight`, and `imageBox`, ensuring correct aspect ratios and positioning for both image and overlays, regardless of cropping or tiling. [[1]](diffhunk://#diff-d3cc59bc93a30dbb581f37f00c1a16704aefbf874292d8108553004f76975b60R3-R125) [[2]](diffhunk://#diff-d3cc59bc93a30dbb581f37f00c1a16704aefbf874292d8108553004f76975b60L36-R319)

*API and Type Improvements:*
- Extended the component's props to include `imageBitmap`, `region`, `sourceWidth`, `sourceHeight`, and improved typing for resource masks and regions, making the component more flexible and type-safe.

*Border Rendering Update:*
- Refactored border rendering to use the computed `borderBox` and aspect ratio, ensuring the border always matches the displayed image region, and made it accessible with `aria-hidden`.

These changes make the `Thumbnail.svelte` component much more versatile and ready for advanced use cases involving overlays, cropping, and custom image sources.