### PR TITLE
Fix for incorrect low-res rendering

### DIFF
--- a/packages/render/src/maps/WebGL2WarpedMap.ts
+++ b/packages/render/src/maps/WebGL2WarpedMap.ts
@@ -972,23 +972,24 @@ export class WebGL2WarpedMap extends TriangulatedWarpedMap {
     this.updateCachedTilesForTextures()
 
     // Don't update if request without tiles, or if
-    // same request is (non-null) subset of previous request
+    // same request is (non-null) subset of previous uploaded request
     // This reduces (expensive) texture updates when just reducing the number of tiles
     // (But keeps them when all tiles are gone to free up texture)
     // And blocking updates on equal requests is important to
     // prevent triggering an infinite loop
     // caused by the TEXTURESUPDATED event at the end
+    if (this.cachedTilesForTexture.length == 0) {
+      return
+    }
     if (
-      this.cachedTilesForTexture.length == 0 ||
-      (this.cachedTilesForTexture.length !== 0 &&
-        subSetArray(
-          this.previousCachedTilesForTexture.map(
-            (textureTile) => textureTile.fetchableTile.tileUrl
-          ),
-          this.cachedTilesForTexture.map(
-            (textureTile) => textureTile.fetchableTile.tileUrl
-          )
-        ))
+      subSetArray(
+        this.previousCachedTilesForTexture.map(
+          (textureTile) => textureTile.fetchableTile.tileUrl
+        ),
+        this.cachedTilesForTexture.map(
+          (textureTile) => textureTile.fetchableTile.tileUrl
+        )
+      )
     ) {
       return
     }
@@ -1132,6 +1133,8 @@ export class WebGL2WarpedMap extends TriangulatedWarpedMap {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
+    this.previousCachedTilesForTexture = this.cachedTilesForTexture
+
     this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.TEXTURESUPDATED))
   }
 
@@ -1205,7 +1208,6 @@ export class WebGL2WarpedMap extends TriangulatedWarpedMap {
     )
     cachedTilesForTextures = [...cachedTilesForTexturesByTileUrl.values()]
 
-    this.previousCachedTilesForTexture = this.cachedTilesForTexture
     this.cachedTilesForTexture = cachedTilesForTextures
 
     return

--- a/packages/render/src/renderers/BaseRenderer.ts
+++ b/packages/render/src/renderers/BaseRenderer.ts
@@ -1,5 +1,6 @@
 import {
   bboxToCenter,
+  bufferBbox,
   computeBbox,
   squaredDistance,
   intersectBboxes,
@@ -27,7 +28,7 @@ import {
   getTileResolution
 } from '../shared/tiles.js'
 
-import type { Size, Tile } from '@allmaps/types'
+import type { Bbox, Size, Tile, TileZoomLevel } from '@allmaps/types'
 
 import type { Viewport } from '../viewport/Viewport.js'
 import type { WarpedMap, WarpedMapWithImage } from '../maps/WarpedMap.js'
@@ -907,13 +908,34 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
 
     // Find tiles covering this intersection of bboxes of to-resource-back-transformed viewport and mask
     // by computing the tiles covering this bbox's rectangle at the tilezoomlevel
-    let tiles = computeTilesCoveringRingAtTileZoomLevel(
+    const unpaddedTiles = computeTilesCoveringRingAtTileZoomLevel(
       bboxToRectangle(
         resourceBufferedViewportRingBboxAndResourceAppliedMaskBboxIntersection
       ),
       tileZoomLevel,
       [warpedMap.image.width, warpedMap.image.height]
     )
+
+    const resourceTileRequestBbox = this.getResourceTileRequestBbox(
+      warpedMap,
+      resourceBufferedViewportRingBboxAndResourceAppliedMaskBboxIntersection,
+      tileZoomLevel,
+      unpaddedTiles
+    )
+
+    if (!resourceTileRequestBbox) {
+      return []
+    }
+
+    let tiles =
+      resourceTileRequestBbox ===
+      resourceBufferedViewportRingBboxAndResourceAppliedMaskBboxIntersection
+        ? unpaddedTiles
+        : computeTilesCoveringRingAtTileZoomLevel(
+            bboxToRectangle(resourceTileRequestBbox),
+            tileZoomLevel,
+            [warpedMap.image.width, warpedMap.image.height]
+          )
 
     // Don't include tiles that have zoomlevels close to sprite tiles of this map
     tiles = this.filterOutTilesCloseToSpriteTiles(tiles, warpedMap)
@@ -1054,6 +1076,50 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
     warpedMap.setOverviewFetchableTilesForViewport(overviewFetchableTiles)
 
     return overviewFetchableTiles
+  }
+
+  private getResourceTileRequestBbox(
+    warpedMap: WarpedMapWithImage,
+    resourceBbox: Bbox,
+    tileZoomLevel: TileZoomLevel,
+    tiles: Tile[]
+  ) {
+    if (
+      !['thinPlateSpline', 'polynomial2', 'polynomial3'].includes(
+        warpedMap.transformationType
+      )
+    ) {
+      return resourceBbox
+    }
+
+    const columns = tiles.map((tile) => tile.column)
+    const rows = tiles.map((tile) => tile.row)
+    const columnSpan = Math.max(...columns) - Math.min(...columns) + 1
+    const rowSpan = Math.max(...rows) - Math.min(...rows) + 1
+
+    if (tiles.length <= 4) {
+      return intersectBboxes(
+        bufferBbox(
+          resourceBbox,
+          tileZoomLevel.originalWidth,
+          tileZoomLevel.originalHeight
+        ),
+        warpedMap.resourceAppliedMaskBbox
+      )
+    }
+
+    if (columnSpan <= 2 || rowSpan <= 2) {
+      return intersectBboxes(
+        bufferBbox(
+          resourceBbox,
+          columnSpan <= 2 ? tileZoomLevel.originalWidth : 0,
+          rowSpan <= 2 ? tileZoomLevel.originalHeight : 0
+        ),
+        warpedMap.resourceAppliedMaskBbox
+      )
+    }
+
+    return resourceBbox
   }
 
   protected updateMapsForViewport(


### PR DESCRIPTION
This pull request introduces improvements to how tiles are selected and textures are updated in the rendering pipeline, with a focus on optimizing performance and reducing unnecessary texture uploads. The changes ensure that texture updates are only triggered when needed and that tile requests are more accurately calculated for specific transformation types.

### Texture update optimization

* The logic for skipping unnecessary texture updates in `WebGL2WarpedMap` was improved: now, texture updates are avoided if the current tile set is empty or is a subset of the previously uploaded set, which reduces expensive operations and prevents infinite loops. (`WebGL2WarpedMap.ts`)
* The assignment of `previousCachedTilesForTexture` was moved to occur only after a successful texture upload, ensuring accurate tracking of the last uploaded tiles. (`WebGL2WarpedMap.ts`) [[1]](diffhunk://#diff-ec5d8c19993e928e9451d996526b1a74024def390760047bdad2b2aef57a74c7R1136-R1137) [[2]](diffhunk://#diff-ec5d8c19993e928e9451d996526b1a74024def390760047bdad2b2aef57a74c7L1208)

### Tile request calculation improvements

* A new method, `getResourceTileRequestBbox`, was added to `BaseRenderer` to adjust the bounding box for tile requests based on the transformation type and tile layout. This method buffers the tile request area for certain transformation types, improving rendering accuracy and efficiency. (`BaseRenderer.ts`)
* The tile selection logic in `BaseRenderer` now uses the potentially buffered bounding box from `getResourceTileRequestBbox`, ensuring that the correct set of tiles is requested for rendering. (`BaseRenderer.ts`)

### Type and import updates

* Type imports were updated to include `Bbox` and `TileZoomLevel`, and the `bufferBbox` utility was imported where needed. (`BaseRenderer.ts`) [[1]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19R3) [[2]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19L30-R31)