### PR TITLE
added rights & provider

### DIFF
--- a/packages/iiif-parser/src/classes/canvas.ts
+++ b/packages/iiif-parser/src/classes/canvas.ts
@@ -16,7 +16,8 @@ import type {
   Summary,
   Annotations,
   Homepage,
-  Rendering
+  Rendering,
+  Provider
 } from '../lib/types.js'
 import {
   parseVersion2String,
@@ -67,6 +68,8 @@ export class Canvas {
   seeAlso?: SeeAlso
   summary?: Summary
   requiredStatement?: RequiredStatement
+  rights?: string
+  provider?: Provider
 
   annotations?: Annotations
 
@@ -92,6 +95,7 @@ export class Canvas {
       this.thumbnail = parseVersion2Thumbnail(parsedCanvas.thumbnail)
       this.rendering = parseVersion2Rendering(parsedCanvas.rendering)
       this.homepage = parseVersion2Related(parsedCanvas.related)
+      this.rights = parsedCanvas.license?.[0]
 
       this.image = new EmbeddedImage(parsedCanvas.images[0].resource, {
         parsedCanvas
@@ -113,6 +117,8 @@ export class Canvas {
       this.seeAlso = parsedCanvas.seeAlso
       this.summary = parsedCanvas.summary
       this.requiredStatement = parsedCanvas.requiredStatement
+      this.rights = parsedCanvas.rights
+      this.provider = parsedCanvas.provider
 
       this.annotations = parsedCanvas.annotations
 

--- a/packages/iiif-parser/src/classes/collection.ts
+++ b/packages/iiif-parser/src/classes/collection.ts
@@ -31,6 +31,7 @@ import type {
   SeeAlso,
   Summary,
   RequiredStatement,
+  Provider,
   Annotations,
   Homepage,
   Rendering,
@@ -161,6 +162,8 @@ export class Collection extends EmbeddedCollection {
   seeAlso?: SeeAlso
   summary?: Summary
   requiredStatement?: RequiredStatement
+  rights?: string
+  provider?: Provider
 
   annotations?: Annotations
 
@@ -181,6 +184,7 @@ export class Collection extends EmbeddedCollection {
 
       this.rendering = parseVersion2Rendering(parsedCollection.rendering)
       this.homepage = parseVersion2Related(parsedCollection.related)
+      this.rights = parsedCollection.license?.[0]
 
       const manifests =
         'manifests' in parsedCollection && parsedCollection.manifests
@@ -208,6 +212,8 @@ export class Collection extends EmbeddedCollection {
       this.seeAlso = parsedCollection.seeAlso
       this.summary = parsedCollection.summary
       this.requiredStatement = parsedCollection.requiredStatement
+      this.rights = parsedCollection.rights
+      this.provider = parsedCollection.provider
 
       this.annotations = parsedCollection.annotations
 

--- a/packages/iiif-parser/src/classes/manifest.ts
+++ b/packages/iiif-parser/src/classes/manifest.ts
@@ -35,6 +35,7 @@ import type {
   SeeAlso,
   Summary,
   RequiredStatement,
+  Provider,
   Annotations,
   Homepage,
   Rendering,
@@ -120,6 +121,8 @@ export class Manifest extends EmbeddedManifest {
   seeAlso?: SeeAlso
   summary?: Summary
   requiredStatement?: RequiredStatement
+  rights?: string
+  provider?: Provider
 
   annotations?: Annotations
 
@@ -145,6 +148,7 @@ export class Manifest extends EmbeddedManifest {
       this.thumbnail = parseVersion2Thumbnail(parsedManifest.thumbnail)
       this.rendering = parseVersion2Rendering(parsedManifest.rendering)
       this.homepage = parseVersion2Related(parsedManifest.related)
+      this.rights = parsedManifest.license?.[0]
     } else if ('type' in parsedManifest) {
       // IIIF Presentation API 3.0
 
@@ -153,6 +157,8 @@ export class Manifest extends EmbeddedManifest {
       this.seeAlso = parsedManifest.seeAlso
       this.summary = parsedManifest.summary
       this.requiredStatement = parsedManifest.requiredStatement
+      this.rights = parsedManifest.rights
+      this.provider = parsedManifest.provider
 
       this.annotations = parsedManifest.annotations
 

--- a/packages/iiif-parser/src/lib/types.ts
+++ b/packages/iiif-parser/src/lib/types.ts
@@ -82,6 +82,17 @@ export type SeeAlso = {
   profile?: string
 }[]
 
+export type Agent = {
+  id: string
+  type: 'Agent'
+  label?: LanguageString
+  homepage?: Homepage
+  logo?: Thumbnail
+  seeAlso?: SeeAlso
+}
+
+export type Provider = Agent[]
+
 export type Annotations = {
   id: string
   type: 'AnnotationPage'

--- a/packages/iiif-parser/src/schemas/presentation.2.ts
+++ b/packages/iiif-parser/src/schemas/presentation.2.ts
@@ -56,6 +56,8 @@ export const RenderingItem2Schema = z.object({
 
 export const Rendering2Schema = oneOrMany(RenderingItem2Schema)
 
+export const License2Schema = oneOrMany(z.string())
+
 const ValidLanguageValue2Schema = z
   .union([
     z.object({ '@value': Value2Schema, '@language': z.string().optional() }),
@@ -116,6 +118,7 @@ export const Canvas2Schema = z.object({
   description: PossibleLanguageValue2Schema.optional(),
   related: Related2Schema.optional(),
   attribution: Attribution2Schema.optional(),
+  license: License2Schema.optional(),
   thumbnail: Thumbnail2Schema.optional(),
   rendering: Rendering2Schema.optional(),
   metadata: Metadata2Schema.optional(),
@@ -136,6 +139,7 @@ export const Manifest2Schema = z.object({
   metadata: Metadata2Schema.optional(),
   related: Related2Schema.optional(),
   attribution: Attribution2Schema.optional(),
+  license: License2Schema.optional(),
   rendering: Rendering2Schema.optional(),
   thumbnail: Thumbnail2Schema.optional(),
   navDate: NavDateSchema.optional(),
@@ -208,5 +212,6 @@ export const Collection2Schema = z.object({
   navPlace: NavPlaceSchema.optional(),
   related: Related2Schema.optional(),
   attribution: Attribution2Schema.optional(),
+  license: License2Schema.optional(),
   rendering: Rendering2Schema.optional()
 })

--- a/packages/iiif-parser/src/schemas/presentation.3.ts
+++ b/packages/iiif-parser/src/schemas/presentation.3.ts
@@ -82,6 +82,19 @@ export const Metadata3Schema = filterValidItems(ValidMetadataItem3Schema)
 // Invalid requiredStatement values are intentionally treated as absent.
 export const RequiredStatement3Schema = MetadataItem3Schema
 
+export const Rights3Schema = z.string()
+
+export const Agent3Schema = z.object({
+  id: z.string().url(),
+  type: z.literal('Agent'),
+  label: LanguageValue3Schema.optional(),
+  homepage: Homepage3Schema.optional(),
+  logo: Thumbnail3Schema.optional(),
+  seeAlso: SeeAlso3Schema.optional()
+})
+
+export const Provider3Schema = Agent3Schema.array()
+
 export const AnnotationImageBody3Schema = z.object({
   type: z.literal('Image'),
   width: z.number().int().optional(),
@@ -139,6 +152,8 @@ export const Canvas3Schema = z.object({
   seeAlso: SeeAlso3Schema.optional(),
   summary: Summary3Schema.optional(),
   requiredStatement: RequiredStatement3Schema.optional(),
+  rights: Rights3Schema.optional(),
+  provider: Provider3Schema.optional(),
   annotations: NonPaintingAnnotations3.optional()
 })
 
@@ -156,6 +171,8 @@ export const Manifest3Schema = z.object({
   rendering: Rendering3Schema.optional(),
   seeAlso: SeeAlso3Schema.optional(),
   summary: Summary3Schema.optional(),
+  rights: Rights3Schema.optional(),
+  provider: Provider3Schema.optional(),
   requiredStatement: RequiredStatement3Schema.optional(),
   annotations: NonPaintingAnnotations3.optional()
 })
@@ -204,6 +221,8 @@ export const Collection3Schema = z.object({
   rendering: Rendering3Schema.optional(),
   seeAlso: SeeAlso3Schema.optional(),
   summary: Summary3Schema.optional(),
+  rights: Rights3Schema.optional(),
+  provider: Provider3Schema.optional(),
   requiredStatement: RequiredStatement3Schema.optional(),
   annotations: NonPaintingAnnotations3.optional()
 })

--- a/packages/iiif-parser/test/output/collection.3.northwestern-267bed1b-f808-4c51-acb1-0288378819d2.parsed.json
+++ b/packages/iiif-parser/test/output/collection.3.northwestern-267bed1b-f808-4c51-acb1-0288378819d2.parsed.json
@@ -236,6 +236,37 @@
       "Northwestern University Libraries’ Map & Atlas Collection allows access to an ever-growing selection of our cartographic resources in high resolution."
     ]
   },
+  "provider": [
+    {
+      "homepage": [
+        {
+          "format": "text/html",
+          "id": "https://dc.library.northwestern.edu/",
+          "label": {
+            "none": [
+              "Northwestern University Libraries Digital Collections Homepage"
+            ]
+          },
+          "language": ["en"],
+          "type": "Text"
+        }
+      ],
+      "id": "https://www.library.northwestern.edu/",
+      "label": {
+        "none": ["Northwestern University Libraries"]
+      },
+      "logo": [
+        {
+          "format": "image/webp",
+          "height": 139,
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
+          "type": "Image",
+          "width": 1190
+        }
+      ],
+      "type": "Agent"
+    }
+  ],
   "requiredStatement": {
     "label": {
       "none": ["Attribution"]

--- a/packages/iiif-parser/test/output/manifest.2.bl-vdc-100052171660.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.bl-vdc-100052171660.parsed.json
@@ -55,6 +55,7 @@
       }
     }
   ],
+  "rights": "https://creativecommons.org/publicdomain/mark/1.0/",
   "description": {
     "none": ["Item supplied by the British Library"]
   },

--- a/packages/iiif-parser/test/output/manifest.2.gallica.bnf.12148.btv1b53243704g.f1.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.gallica.bnf.12148.btv1b53243704g.f1.parsed.json
@@ -5,6 +5,7 @@
   "label": {
     "none": ["BnF, département Cartes et plans, GE DD-2998"]
   },
+  "rights": "https://gallica.bnf.fr/html/und/conditions-dutilisation-des-contenus-de-gallica",
   "majorVersion": 2,
   "canvases": [
     {

--- a/packages/iiif-parser/test/output/manifest.2.heidelberg-schinkel1858tafeln1.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.heidelberg-schinkel1858tafeln1.parsed.json
@@ -1047,6 +1047,7 @@
       }
     }
   ],
+  "rights": "http://creativecommons.org/publicdomain/mark/1.0/deed.de",
   "thumbnail": [
     {
       "id": "https://digi.ub.uni-heidelberg.de/diglit/schinkel1858tafeln1/introimage",

--- a/packages/iiif-parser/test/output/manifest.2.leiden-130206.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.leiden-130206.parsed.json
@@ -34,6 +34,7 @@
     ]
   },
   "majorVersion": 2,
+  "rights": "Download provided. <a href='https://creativecommons.org/licenses/by/4.0/'>Use of this resource is governed by the terms and conditions of the Creative Commons CC BY License</a>",
   "metadata": [
     {
       "label": {

--- a/packages/iiif-parser/test/output/manifest.2.princeton-fa4fb452-5f1d-42ab-a471-53afc176c948.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.princeton-fa4fb452-5f1d-42ab-a471-53afc176c948.parsed.json
@@ -237,6 +237,7 @@
       "id": "http://arks.princeton.edu/ark:/88435/w6634614q"
     }
   ],
+  "rights": "http://rightsstatements.org/vocab/NKC/1.0/",
   "thumbnail": [
     {
       "id": "https://iiif-cloud.princeton.edu/iiif/2/f7%2Fd6%2F70%2Ff7d670bee780421db09afe918b920978%2Fintermediate_file/full/!200,150/0/default.jpg"

--- a/packages/iiif-parser/test/output/manifest.2.utlmaps_0217cef0-3269-438f-8d3a-e90c790e3e51.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.utlmaps_0217cef0-3269-438f-8d3a-e90c790e3e51.parsed.json
@@ -264,6 +264,7 @@
       }
     }
   ],
+  "rights": "https://creativecommons.org/publicdomain/mark/1.0/",
   "thumbnail": [
     {
       "id": "https://curio.lib.utexas.edu/assets/DAMS/utlmaps/utlmaps_0217cef0-3269-438f-8d3a-e90c790e3e51/TN/utlmaps_0217cef0-3269-438f-8d3a-e90c790e3e51.jpg"

--- a/packages/iiif-parser/test/output/manifest.2.zlb-34231622.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.zlb-34231622.parsed.json
@@ -8,6 +8,7 @@
     ]
   },
   "majorVersion": 2,
+  "rights": "iiif_license",
   "canvases": [
     {
       "uri": "https://digital.zlb.de/viewer/api/v1/records/34231622/pages/1/canvas/",

--- a/packages/iiif-parser/test/output/manifest.3.codexxolotl.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.3.codexxolotl.parsed.json
@@ -359,6 +359,15 @@
       "format": "text/html"
     }
   ],
+  "provider": [
+    {
+      "id": "https://codexxolotl.com/",
+      "label": {
+        "none": ["Codex Xolotl"]
+      },
+      "type": "Agent"
+    }
+  ],
   "seeAlso": [
     {
       "id": "https://dlc.services/iiif-img/22/2/?pretty_print=1",

--- a/packages/iiif-parser/test/output/manifest.3.ia-masterhighwaypla00char.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.3.ia-masterhighwaypla00char.parsed.json
@@ -4258,6 +4258,34 @@
       "format": "text/html"
     }
   ],
+  "provider": [
+    {
+      "homepage": [
+        {
+          "format": "text/html",
+          "id": "https://archive.org",
+          "label": {
+            "en": ["Internet Archive Homepage"]
+          },
+          "type": "Text"
+        }
+      ],
+      "id": "https://archive.org",
+      "label": {
+        "en": ["The Internet Archive"]
+      },
+      "logo": [
+        {
+          "format": "image/png",
+          "height": 79,
+          "id": "https://archive.org/images/glogo.png",
+          "type": "Image",
+          "width": 79
+        }
+      ],
+      "type": "Agent"
+    }
+  ],
   "summary": {
     "none": [
       "\"February 1, 1948\"",

--- a/packages/iiif-parser/test/output/manifest.3.jd-03909-006-4.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.3.jd-03909-006-4.parsed.json
@@ -75,6 +75,33 @@
       "type": "Image"
     }
   ],
+  "provider": [
+    {
+      "homepage": [
+        {
+          "id": "https://commons.wikimedia.org/wiki/Main_Page",
+          "label": {
+            "en": ["Wikimedia Commons"]
+          },
+          "language": ["en"],
+          "type": "Text"
+        }
+      ],
+      "id": "https://commons.wikimedia.org/wiki/Main_Page",
+      "label": {
+        "en": ["Wikimedia Commons"]
+      },
+      "logo": [
+        {
+          "id": "https://upload.wikimedia.org/wikipedia/en/4/4a/Commons-logo.svg",
+          "type": "Image",
+          "width": 150
+        }
+      ],
+      "type": "Agent"
+    }
+  ],
+  "rights": "http://creativecommons.org/publicdomain/zero/1.0/",
   "summary": {
     "en": ["Jan 1925.   41 Sheet(s)."]
   }

--- a/packages/iiif-parser/test/output/manifest.3.northwestern-faf0c573-76e7-4002-933f-2bdff0d656e4.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.3.northwestern-faf0c573-76e7-4002-933f-2bdff0d656e4.parsed.json
@@ -143,6 +143,7 @@
       "height": 300
     }
   ],
+  "rights": "http://rightsstatements.org/vocab/NoC-US/1.0/",
   "seeAlso": [
     {
       "id": "https://api.dc.library.northwestern.edu/api/v2/works/faf0c573-76e7-4002-933f-2bdff0d656e4",

--- a/packages/iiif-parser/test/output/manifest.3.riksarkivet-arkis-40008772.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.3.riksarkivet-arkis-40008772.parsed.json
@@ -145,6 +145,36 @@
   ],
   "type": "manifest",
   "uri": "https://lbiiif.riksarkivet.se/arkis!40008772/manifest",
+  "provider": [
+    {
+      "homepage": [
+        {
+          "format": "text/html",
+          "id": "https://riksarkivet.se",
+          "label": {
+            "en": ["National Archives of Sweden"],
+            "sv": ["Riksarkivet"]
+          },
+          "language": ["sv"],
+          "type": "Homepage"
+        }
+      ],
+      "id": "http://data.riksarkivet.se/agent/Riksarkivet",
+      "label": {
+        "en": ["National Archives of Sweden"],
+        "sv": ["Riksarkivet"]
+      },
+      "logo": [
+        {
+          "format": "image/png",
+          "id": "https://riksarkivet.se/Administration/Images/Layout/logo.png",
+          "type": "Image"
+        }
+      ],
+      "type": "Agent"
+    }
+  ],
+  "rights": "https://creativecommons.org/publicdomain/mark/1.0/",
   "thumbnail": [
     {
       "format": "image/jpg",

--- a/packages/iiif-parser/test/output/manifest.3.sfo-1762679999.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.3.sfo-1762679999.parsed.json
@@ -40,6 +40,25 @@
   "majorVersion": 3,
   "type": "manifest",
   "uri": "https://collection.sfomuseum.org/objects/1762679999/manifest/",
+  "provider": [
+    {
+      "homepage": [
+        {
+          "format": "text/html",
+          "id": "https://collection.sfomuseum.org/",
+          "label": {
+            "en": ["SFO Museum Aviation Collection"]
+          },
+          "type": "Text"
+        }
+      ],
+      "id": "https://collection.sfomuseum.org/",
+      "label": {
+        "en": ["SFO Museum Aviation Collection"]
+      },
+      "type": "Agent"
+    }
+  ],
   "summary": {
     "en": [
       "Monochrome blue postcard depicting route map of American Airlines Flagship flights; with text, “The pencil line shows the route of my Flagship Flight” on right side; American Airlines logo on top right; American Airlines logotype on bottom right. "


### PR DESCRIPTION
This pull request adds support for parsing and exposing the `rights` and `provider` fields in IIIF Presentation API v2 and v3 resources (`Manifest`, `Collection`, and `Canvas`). It updates type definitions, schemas, and parsing logic to handle these fields, and adjusts test outputs to reflect the new data.

**Support for `rights` and `provider` fields:**

* Added `rights` and `provider` properties to the `Manifest`, `Collection`, and `Canvas` classes, including parsing logic for both IIIF v2 (`license`) and v3 (`rights`/`provider`) fields. [[1]](diffhunk://#diff-36bbd1ff1eb3664503198ca41d28f190acf39b36cb3e8583e8d2ad060c75a0d3R71-R72) [[2]](diffhunk://#diff-36bbd1ff1eb3664503198ca41d28f190acf39b36cb3e8583e8d2ad060c75a0d3R98) [[3]](diffhunk://#diff-36bbd1ff1eb3664503198ca41d28f190acf39b36cb3e8583e8d2ad060c75a0d3R120-R121) [[4]](diffhunk://#diff-664207c4ae21798eb128581c50c208f0ccaab0e01bc370e4fd7d4b75eb47e316R165-R166) [[5]](diffhunk://#diff-664207c4ae21798eb128581c50c208f0ccaab0e01bc370e4fd7d4b75eb47e316R187) [[6]](diffhunk://#diff-664207c4ae21798eb128581c50c208f0ccaab0e01bc370e4fd7d4b75eb47e316R215-R216) [[7]](diffhunk://#diff-5bd9bc56ce9b0289a261f840682fa76e5e7c41ee278326830ef2557cd32434eaR124-R125) [[8]](diffhunk://#diff-5bd9bc56ce9b0289a261f840682fa76e5e7c41ee278326830ef2557cd32434eaR151) [[9]](diffhunk://#diff-5bd9bc56ce9b0289a261f840682fa76e5e7c41ee278326830ef2557cd32434eaR160-R161)
* Updated type definitions to include `Provider` and `Agent` types, reflecting the IIIF v3 specification. [[1]](diffhunk://#diff-8e87adcf2cb1126207448f0ed5fe661044033c66b4761c92e93fa72f2cac7a83R85-R95) [[2]](diffhunk://#diff-5bd9bc56ce9b0289a261f840682fa76e5e7c41ee278326830ef2557cd32434eaR38) [[3]](diffhunk://#diff-664207c4ae21798eb128581c50c208f0ccaab0e01bc370e4fd7d4b75eb47e316R34) [[4]](diffhunk://#diff-36bbd1ff1eb3664503198ca41d28f190acf39b36cb3e8583e8d2ad060c75a0d3L19-R20)

**Schema updates:**

* Extended v2 and v3 JSON schemas to support `license`/`rights` and `provider` fields for `Manifest`, `Collection`, and `Canvas`. [[1]](diffhunk://#diff-cf3bc115c3e36464d18783928a250b2118e0b44ccb4427e6d900da7c1d1ad66eR59-R60) [[2]](diffhunk://#diff-cf3bc115c3e36464d18783928a250b2118e0b44ccb4427e6d900da7c1d1ad66eR121) [[3]](diffhunk://#diff-cf3bc115c3e36464d18783928a250b2118e0b44ccb4427e6d900da7c1d1ad66eR142) [[4]](diffhunk://#diff-cf3bc115c3e36464d18783928a250b2118e0b44ccb4427e6d900da7c1d1ad66eR215) [[5]](diffhunk://#diff-a2a567a173f423101578d085cafeeef3cc049869fe479f567d4b379ecf73cd17R85-R97) [[6]](diffhunk://#diff-a2a567a173f423101578d085cafeeef3cc049869fe479f567d4b379ecf73cd17R155-R156) [[7]](diffhunk://#diff-a2a567a173f423101578d085cafeeef3cc049869fe479f567d4b379ecf73cd17R174-R175) [[8]](diffhunk://#diff-a2a567a173f423101578d085cafeeef3cc049869fe479f567d4b379ecf73cd17R224-R225)

**Test output updates:**

* Adjusted test output JSON files to include the new `rights` and `provider` fields, verifying correct parsing and serialization. [[1]](diffhunk://#diff-b83c66a8c2e5ce84186d9bc6f8ec085d330eedfb0dfc13373507909bd4678236R239-R269) [[2]](diffhunk://#diff-e3a29633feeb3725977eda9c627c63fc428ae1d3d2509ba86ce928a82c65c5cdR58) [[3]](diffhunk://#diff-c10639d0c4898dc46b8c60b0cd6b56502fe48f6388709beeac889dd36957c713R8) [[4]](diffhunk://#diff-938635a021fee308787133c836de9560a95d4392893f4e6092491b6f168ca714R1050) [[5]](diffhunk://#diff-1cb68bd25690bede4404b443de19f9cffdb1468109e33ab242617186477b858cR37) [[6]](diffhunk://#diff-e24953a0b7cd70fc6cdad4a49c5f4465edefe72a2178ca01298f06b938fd7be7R240) [[7]](diffhunk://#diff-90bc1355c0f8449c0155ab1b7460920a01658f46fc668124c42ba89785e8390bR267) [[8]](diffhunk://#diff-d765cf2bf923eb7bc61cd24c7ab4564af66fb38ccea8c9d21396fe7f071daa05R11) [[9]](diffhunk://#diff-a0938611231f2bb0c56a64251a63268c38fd1a22b5520c3478b2a844f22e2aeaR362-R370) [[10]](diffhunk://#diff-43e06161939435b202b1cb74f566b80e91a8d7d20da9b174eada9f3829415384R4261-R4288) [[11]](diffhunk://#diff-d7a569e24edf3c5892f09ed61475ad6d81c1eb7c747133cba66172f5728372cbR78-R104) [[12]](diffhunk://#diff-c10dcad94cce91fb711de0365ba8b0c6533e9b5e2de0da6d394c79a6baa8c021R146)

These changes ensure the parser fully supports the `rights` and `provider` metadata for IIIF resources, improving compliance with the IIIF Presentation APIs and enabling downstream consumers to access this important information.