### PR TITLE
Added location field to organizations in database and API

### DIFF
--- a/apis/rest/src/routes/organizations.ts
+++ b/apis/rest/src/routes/organizations.ts
@@ -2,11 +2,13 @@ import { t } from 'elysia'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import { createAuth } from '@allmaps/db/auth'
+import type { Db } from '@allmaps/db'
 import type { RestEnv } from '@allmaps/env/rest'
 import {
   normalizeOrganizationSlug,
   normalizeHomepageUrl,
   normalizeDomains,
+  normalizeOrganizationLocation,
   listOrganizations,
   listOrganizationsWithUsers,
   listOrganizationsWithUsersByOrganizationIds,
@@ -38,6 +40,14 @@ const OrganizationBody = t.Object({
   logo: t.Optional(t.Nullable(t.String())),
   homepage: t.Optional(t.Nullable(t.String())),
   plan: t.Optional(t.Nullable(t.UnionEnum(['supporter', 'innovator']))),
+  location: t.Optional(
+    t.Nullable(
+      t.Object({
+        type: t.Literal('Point'),
+        coordinates: t.Tuple([t.Number(), t.Number()])
+      })
+    )
+  ),
   domains: t.Optional(t.Array(t.String()))
 })
 
@@ -58,6 +68,11 @@ const organizationMutationDetail = {
   'x-badges': [{ name: 'Admin or paid organization member', color: '#df0' }]
 }
 
+const organizationsQuerySchema = t.Object({
+  limit: t.Optional(t.Number()),
+  plan: t.Optional(t.Array(t.UnionEnum(['supporter', 'innovator'])))
+})
+
 async function createIiifFromBody<T>(
   body: CreateIiifBody,
   create: (url: string) => Promise<T>
@@ -67,6 +82,68 @@ async function createIiifFromBody<T>(
   }
 
   return create(body.url)
+}
+
+async function listOrganizationsForRequest({
+  auth,
+  db,
+  env,
+  request,
+  set
+}: {
+  auth: BetterAuthContext['auth']
+  db: Db
+  env: RestEnv
+  request: Request
+  set: { headers: Record<string, string | number> }
+}) {
+  const queryParams = normalizeOrganizationsQueryParams(request)
+  const session = await auth.api.getSession({ headers: request.headers })
+
+  if (session?.user.role === 'admin') {
+    setCacheControl(set, 'private-no-store')
+    return listOrganizationsWithUsers(db, env.PUBLIC_REST_BASE_URL, {
+      ...queryParams,
+      userRole: 'admin'
+    })
+  }
+
+  if (session?.user.id) {
+    const organizationIds = await queryOrganizationIdsByUserId(
+      db,
+      session.user.id
+    )
+
+    if (organizationIds.length > 0) {
+      setCacheControl(set, 'private-no-store')
+      return listOrganizationsWithUsersByOrganizationIds(
+        db,
+        env.PUBLIC_REST_BASE_URL,
+        organizationIds,
+        { ...queryParams, userRole: 'user' }
+      )
+    }
+  }
+
+  setCacheControl(set, 'public-medium')
+  return listOrganizations(db, env.PUBLIC_REST_BASE_URL, queryParams)
+}
+
+function organizationsToGeojson(
+  organizations: Awaited<ReturnType<typeof listOrganizationsForRequest>>
+) {
+  return {
+    type: 'FeatureCollection' as const,
+    features: organizations.map((organization) => {
+      const { location, ...properties } = organization
+
+      return {
+        type: 'Feature' as const,
+        properties,
+        geometry: location ?? null
+      }
+    })
+  }
 }
 
 export function createOrganizationsRoutes(
@@ -81,43 +158,25 @@ export function createOrganizationsRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/organizations',
-      async ({ db, env, request, set }) => {
-        const queryParams = normalizeOrganizationsQueryParams(request)
-        const session = await auth.api.getSession({ headers: request.headers })
-        if (session?.user.role === 'admin') {
-          setCacheControl(set, 'private-no-store')
-          return listOrganizationsWithUsers(db, env.PUBLIC_REST_BASE_URL, {
-            ...queryParams,
-            userRole: 'admin'
-          })
-        }
-
-        if (session?.user.id) {
-          const organizationIds = await queryOrganizationIdsByUserId(
-            db,
-            session.user.id
-          )
-
-          if (organizationIds.length > 0) {
-            setCacheControl(set, 'private-no-store')
-            return listOrganizationsWithUsersByOrganizationIds(
-              db,
-              env.PUBLIC_REST_BASE_URL,
-              organizationIds,
-              { ...queryParams, userRole: 'user' }
-            )
-          }
-        }
-
-        setCacheControl(set, 'public-medium')
-        return listOrganizations(db, env.PUBLIC_REST_BASE_URL, queryParams)
-      },
+      async ({ db, env, request, set }) =>
+        listOrganizationsForRequest({ auth, db, env, request, set }),
       {
-        query: t.Object({
-          limit: t.Optional(t.Number()),
-          plan: t.Optional(t.Array(t.UnionEnum(['supporter', 'innovator'])))
-        }),
+        query: organizationsQuerySchema,
         detail: { summary: 'Get all organizations', tags: ['Organizations'] }
+      }
+    )
+    .get(
+      '/organizations.geojson',
+      async ({ db, env, request, set }) =>
+        organizationsToGeojson(
+          await listOrganizationsForRequest({ auth, db, env, request, set })
+        ),
+      {
+        query: organizationsQuerySchema,
+        detail: {
+          summary: 'Get all organizations as GeoJSON',
+          tags: ['Organizations']
+        }
       }
     )
     .get(
@@ -406,12 +465,21 @@ export function createOrganizationsRoutes(
           })
         }
 
+        const validLocation = normalizeOrganizationLocation(body.location)
+        if (body.location !== undefined && validLocation === undefined) {
+          return status(400, {
+            error:
+              'Invalid location. Use a GeoJSON Point with [longitude, latitude] coordinates.'
+          })
+        }
+
         const organization = await createOrganization(
           db,
           env.PUBLIC_REST_BASE_URL,
           {
             ...body,
             homepage: validHomepage,
+            location: validLocation,
             slug: validSlug,
             domains: validDomains
           }
@@ -472,6 +540,14 @@ export function createOrganizationsRoutes(
           })
         }
 
+        const validLocation = normalizeOrganizationLocation(body.location)
+        if (body.location !== undefined && validLocation === undefined) {
+          return status(400, {
+            error:
+              'Invalid location. Use a GeoJSON Point with [longitude, latitude] coordinates.'
+          })
+        }
+
         const { domains, ...patch } = body
         const organization = await updateOrganization(
           db,
@@ -480,6 +556,7 @@ export function createOrganizationsRoutes(
           {
             ...patch,
             ...(body.homepage !== undefined ? { homepage: validHomepage } : {}),
+            ...(body.location !== undefined ? { location: validLocation } : {}),
             ...(validSlug !== undefined ? { slug: validSlug } : {})
           },
           domains !== undefined ? validDomains : undefined

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -48,6 +48,7 @@
     "@allmaps/ui": "workspace:^",
     "better-auth": "catalog:",
     "bits-ui": "catalog:",
+    "phosphor-svelte": "^3.0.1",
     "zod": "catalog:"
   }
 }

--- a/apps/console/src/lib/types.ts
+++ b/apps/console/src/lib/types.ts
@@ -4,6 +4,10 @@ export type Organization = {
   slug: string
   logo?: string | null
   homepage?: string | null
+  location?: {
+    type: 'Point'
+    coordinates: [number, number]
+  } | null
   createdAt: string
   domains: string[]
   plan: 'supporter' | 'innovator' | null

--- a/apps/console/src/routes/organizations/+page.svelte
+++ b/apps/console/src/routes/organizations/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { replaceState } from '$app/navigation'
   import { page } from '$app/state'
+  import { GpsFix as GpsFixIcon } from 'phosphor-svelte'
 
   import SearchFilter from '$lib/components/SearchFilter.svelte'
   import DataTable from '$lib/components/DataTable.svelte'
@@ -205,12 +206,25 @@
           {#each displayedOrganizations as organization (organization.id)}
             <tr class="hover:bg-gray-50 transition">
               <td class="px-3 py-2 @lg:px-4 @lg:py-3 whitespace-nowrap">
-                <a
-                  href={routes.organization(getOrganizationId(organization.id))}
-                  class="font-sans text-sm font-medium hover:text-pink"
-                >
-                  {organization.name}
-                </a>
+                <div class="flex items-center gap-1.5">
+                  <a
+                    href={routes.organization(
+                      getOrganizationId(organization.id)
+                    )}
+                    class="font-sans text-sm font-medium hover:text-pink"
+                  >
+                    {organization.name}
+                  </a>
+                  {#if organization.location}
+                    <span title="Has location" class="text-blue-500">
+                      <GpsFixIcon
+                        size="14"
+                        weight="bold"
+                        aria-label="Has location"
+                      />
+                    </span>
+                  {/if}
+                </div>
               </td>
               <td class="px-3 py-2 @lg:px-4 @lg:py-3 whitespace-nowrap">
                 {#if organization.plan === 'supporter'}

--- a/apps/console/src/routes/organizations/[organizationId]/+page.svelte
+++ b/apps/console/src/routes/organizations/[organizationId]/+page.svelte
@@ -39,6 +39,7 @@
   let editOrgSlug = $state('')
   let editHomepage = $state('')
   let editPlan = $state<'supporter' | 'innovator' | ''>('')
+  let editLocation = $state('')
   let editDomains = $state<string[]>([])
   let error = $state<string | null>(null)
   let initializedOrganizationId = $state<string | null>(null)
@@ -121,6 +122,12 @@
     editOrgSlug = nextOrganization.slug
     editHomepage = nextOrganization.homepage ?? ''
     editPlan = nextOrganization.plan ?? ''
+    editLocation = nextOrganization.location
+      ? [
+          nextOrganization.location.coordinates[1],
+          nextOrganization.location.coordinates[0]
+        ].join(', ')
+      : ''
     editDomains = nextOrganization.domains ?? []
     initializedOrganizationId = organizationId
   }
@@ -132,6 +139,7 @@
     editOrgSlug = ''
     editHomepage = ''
     editPlan = ''
+    editLocation = ''
     editDomains = []
     initializedOrganizationId = null
   })
@@ -362,6 +370,24 @@
           </label>
           <AppSelect bind:value={editPlan} items={planItems} />
           <input type="hidden" name="plan" value={editPlan} />
+        </div>
+
+        <div>
+          <label
+            for="orgLocation"
+            class="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Location
+          </label>
+          <input
+            id="orgLocation"
+            type="text"
+            inputmode="decimal"
+            name="location"
+            bind:value={editLocation}
+            class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Latitude, longitude"
+          />
         </div>
 
         <div>

--- a/apps/console/src/routes/organizations/[organizationId]/+page.svelte
+++ b/apps/console/src/routes/organizations/[organizationId]/+page.svelte
@@ -24,13 +24,15 @@
   const organizationQuery = $derived(getOrganization(organizationId))
   const organization = $derived(organizationQuery.current ?? null)
   const isLoadingOrganization = $derived(
-    !organizationQuery.ready || organizationQuery.loading
+    !organization && (!organizationQuery.ready || organizationQuery.loading)
   )
   const loadError = $derived(
-    organizationQuery.error ??
-      (organizationQuery.ready && !organization
-        ? new Error('Organization not found')
-        : null)
+    !organization
+      ? (organizationQuery.error ??
+          (organizationQuery.ready
+            ? new Error('Organization not found')
+            : null))
+      : null
   )
 
   let editOrgName = $state('')

--- a/apps/console/src/routes/organizations/organizations.remote.ts
+++ b/apps/console/src/routes/organizations/organizations.remote.ts
@@ -41,6 +41,42 @@ const createOrganizationSchema = z.object({
   slug: slugSchema
 }) satisfies z.ZodType<CreateOrganizationInput>
 
+function parseLocationInput(value: string) {
+  const location = value.trim()
+
+  if (!location) {
+    return null
+  }
+
+  const coordinates = location
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .map(Number)
+
+  if (coordinates.length !== 2) {
+    throw new Error('Invalid location. Use Latitude, longitude.')
+  }
+
+  const [latitude, longitude] = coordinates
+  const isLatitude = (coordinate: number) =>
+    Number.isFinite(coordinate) && coordinate >= -90 && coordinate <= 90
+  const isLongitude = (coordinate: number) =>
+    Number.isFinite(coordinate) && coordinate >= -180 && coordinate <= 180
+
+  if (!isLatitude(latitude)) {
+    throw new Error('Invalid latitude. Enter location as Latitude, longitude.')
+  }
+
+  if (!isLongitude(longitude)) {
+    throw new Error('Invalid longitude. Enter location as Latitude, longitude.')
+  }
+
+  return {
+    type: 'Point' as const,
+    coordinates: [longitude, latitude] as [number, number]
+  }
+}
+
 const updateOrganizationFormSchema = z.object({
   organizationId: organizationIdSchema,
   name: z.string().trim().min(1),
@@ -52,6 +88,7 @@ const updateOrganizationFormSchema = z.object({
   plan: z
     .union([z.enum(['supporter', 'innovator']), z.literal('')])
     .transform((value) => value || null),
+  location: z.string().transform(parseLocationInput),
   domains: z.string().transform((value) =>
     value
       .split('\n')

--- a/apps/console/src/routes/users/[userId]/+page.svelte
+++ b/apps/console/src/routes/users/[userId]/+page.svelte
@@ -35,7 +35,7 @@
   )
   const organizations = $derived(organizationsQuery?.current ?? [])
   const isLoadingUser = $derived(
-    userQuery ? !userQuery.ready || userQuery.loading : false
+    userQuery ? !user && (!userQuery.ready || userQuery.loading) : false
   )
   const isLoadingOrganizations = $derived(
     organizationsQuery
@@ -43,8 +43,10 @@
       : false
   )
   const loadError = $derived(
-    userQuery?.error ??
-      (userQuery?.ready && !user ? new Error('User not found') : null)
+    !user
+      ? (userQuery?.error ??
+          (userQuery?.ready ? new Error('User not found') : null))
+      : null
   )
 
   const userOrganizations = $derived(user?.organizations ?? [])

--- a/packages/api-shared/src/db.ts
+++ b/packages/api-shared/src/db.ts
@@ -50,6 +50,8 @@ export {
   normalizeHomepageUrl,
   normalizeDomain,
   normalizeDomains,
+  normalizeOrganizationLocation,
+  organizationLocationGeographySql,
   fromDbOrganization,
   fromDbOrganizationWithUsers,
   queryOrganizationUrls,

--- a/packages/api-shared/src/queries/organizations.ts
+++ b/packages/api-shared/src/queries/organizations.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 
 import { generateRandomId } from '@allmaps/id/sync'
 
@@ -13,8 +13,10 @@ import {
 import { clampLimit } from '../shared/limits.js'
 
 import type { Db, DbOrTx } from '@allmaps/db'
+import type { SQL } from 'drizzle-orm'
 import type { UserRole } from '../shared/limits.js'
 import type { OrganizationPlan } from '../types.js'
+import type { OrganizationLocation } from '@allmaps/db/schema/auth'
 
 type DbOrganization = {
   id: string
@@ -23,6 +25,7 @@ type DbOrganization = {
   logo: string | null
   homepage: string | null
   plan: string | null
+  location: OrganizationLocation | null
   createdAt: Date
   updatedAt?: Date
   urls: {
@@ -133,6 +136,74 @@ export function normalizeDomains(domains: string[] | undefined) {
   return { validDomains: [...valid], invalidDomains: invalid }
 }
 
+export function normalizeOrganizationLocation(
+  location: unknown
+): OrganizationLocation | null | undefined {
+  if (location === undefined) {
+    return
+  }
+
+  if (location === null) {
+    return null
+  }
+
+  if (
+    typeof location !== 'object' ||
+    !location ||
+    !('type' in location) ||
+    !('coordinates' in location)
+  ) {
+    return
+  }
+
+  const { type, coordinates } = location
+
+  if (
+    type !== 'Point' ||
+    !Array.isArray(coordinates) ||
+    coordinates.length !== 2
+  ) {
+    return
+  }
+
+  const [longitude, latitude] = coordinates
+
+  if (
+    typeof longitude !== 'number' ||
+    typeof latitude !== 'number' ||
+    !Number.isFinite(longitude) ||
+    !Number.isFinite(latitude) ||
+    longitude < -180 ||
+    longitude > 180 ||
+    latitude < -90 ||
+    latitude > 90
+  ) {
+    return
+  }
+
+  return {
+    type: 'Point',
+    coordinates: [longitude, latitude]
+  }
+}
+
+export function organizationLocationGeographySql(
+  location: SQL = sql`${authSchema.organizations.location}`
+) {
+  return sql`
+    CASE
+      WHEN ${location} IS NULL THEN NULL
+      ELSE ST_SetSRID(
+        ST_MakePoint(
+          ((${location}->'coordinates'->>0))::double precision,
+          ((${location}->'coordinates'->>1))::double precision
+        ),
+        4326
+      )::geography
+    END
+  `
+}
+
 export function fromDbOrganization(
   restBaseUrl: string,
   dbOrganization: DbOrganization
@@ -146,6 +217,7 @@ export function fromDbOrganization(
     logo: dbOrganization.logo,
     homepage: dbOrganization.homepage,
     plan: dbOrganization.plan,
+    location: dbOrganization.location,
     createdAt: dbOrganization.createdAt,
     domains: dbOrganization.urls
       .filter(({ type }) => type === 'domain')
@@ -376,6 +448,7 @@ export async function createOrganization(
     logo?: string | null
     homepage?: string | null
     plan?: 'supporter' | 'innovator' | null
+    location?: OrganizationLocation | null
     domains?: string[]
   }
 ) {
@@ -398,6 +471,7 @@ export async function createOrganization(
       logo: data.logo ?? null,
       homepage: data.homepage ?? null,
       plan: data.plan ?? null,
+      location: data.location ?? null,
       createdAt: new Date()
     })
     .returning()
@@ -418,6 +492,7 @@ export async function updateOrganization(
     logo: string | null
     homepage: string | null
     plan: 'supporter' | 'innovator' | null
+    location: OrganizationLocation | null
   }>,
   domains?: string[]
 ) {

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -9,6 +9,10 @@ import type { UserRole } from './shared/limits.js'
 export type IntersectsWith = [number, number] | [number, number, number, number]
 export type ContainedBy = [number, number, number, number]
 export type OrganizationPlan = 'supporter' | 'innovator'
+export type OrganizationLocation = {
+  type: 'Point'
+  coordinates: [number, number]
+}
 
 export type OrganizationsQueryParams = {
   limit: number

--- a/packages/db/drizzle/20260608085833_swift_mongoose/migration.sql
+++ b/packages/db/drizzle/20260608085833_swift_mongoose/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" ADD COLUMN "location" jsonb;

--- a/packages/db/drizzle/20260608085833_swift_mongoose/snapshot.json
+++ b/packages/db/drizzle/20260608085833_swift_mongoose/snapshot.json
@@ -1,0 +1,3145 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "1157fe37-fc0e-4937-a5f9-e0f9608d012e",
+  "prevIds": [
+    "c4319c6c-8542-44b4-9079-39c55cfc83ff"
+  ],
+  "ddl": [
+    {
+      "name": "iiif",
+      "entityType": "schemas"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "canvases",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "canvases_images",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "images",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "manifests",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "manifests_canvases",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "list_items",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "lists",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "maps",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organization_urls",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ops",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "snapshots",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "homepage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "full_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_anonymous",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"canvases\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"images\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "embedded",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"manifests\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "manifest_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "list_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "manifest_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "deletable",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "latest",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "geometry(Polygon)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_mask",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "geometry(Polygon,4326)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "geo_mask",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "CASE WHEN \"maps\".\"geo_mask\" IS NOT NULL THEN ST_Area(geography(\"maps\".\"geo_mask\")) ELSE NULL END",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "area",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "CASE WHEN ST_Area(geography(\"maps\".\"geo_mask\")) > 0 THEN sqrt(ST_Area(\"maps\".\"resource_mask\") / ST_Area(geography(\"maps\".\"geo_mask\"))) ELSE NULL END",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "scale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operation",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"slug\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_canvas_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_image_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_composite_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "images_domain_index",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_domain_index",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_manifest_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_canvas_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_composite_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_checksum",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"map_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_map_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"image_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_image_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"canvas_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_canvas_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"manifest_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_manifest_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "checksum",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_checksum_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_image_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"latest\" = true",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_latest_image_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "latest",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_latest_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_updated_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "geo_mask",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "GIST",
+      "concurrently": false,
+      "name": "maps_geo_mask_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_urls_organization_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "url",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_urls_url_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "canvases_images_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "canvases_images_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "manifest_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "manifests",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "manifests_canvases_manifest_id_manifests_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "manifests_canvases_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "list_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_list_id_lists_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "manifest_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "manifests",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_manifest_id_manifests_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "map_id",
+        "map_image_id",
+        "map_checksum",
+        "map_version"
+      ],
+      "schemaTo": "public",
+      "tableTo": "maps",
+      "columnsTo": [
+        "id",
+        "image_id",
+        "checksum",
+        "version"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_DOUrIXsmsloB_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "lists_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "maps_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_urls_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "columns": [
+        "canvas_id",
+        "image_id"
+      ],
+      "nameExplicit": false,
+      "name": "canvases_images_pkey",
+      "entityType": "pks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "columns": [
+        "manifest_id",
+        "canvas_id"
+      ],
+      "nameExplicit": false,
+      "name": "manifests_canvases_pkey",
+      "entityType": "pks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "columns": [
+        "id",
+        "image_id",
+        "checksum",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "maps_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "columns": [
+        "organization_id",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "organization_urls_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "columns": [
+        "collection",
+        "doc_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "ops_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "columns": [
+        "collection",
+        "doc_id"
+      ],
+      "nameExplicit": false,
+      "name": "snapshots_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "public",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "public",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "public",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "public",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "canvases_pkey",
+      "schema": "iiif",
+      "table": "canvases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "images_pkey",
+      "schema": "iiif",
+      "table": "images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "manifests_pkey",
+      "schema": "iiif",
+      "table": "manifests",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "lists_pkey",
+      "schema": "public",
+      "table": "lists",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_urls_url_key",
+      "schema": "public",
+      "table": "organization_urls",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"slug\" ~ '^[a-z](?:[a-z0-9-]*[a-z0-9])?$'",
+      "name": "organizations_slug_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "value": "\"slug\" IS NULL OR \"slug\" ~ '^[a-z](?:[a-z0-9-]*[a-z0-9])?$'",
+      "name": "users_slug_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "value": "\n      (\n        num_nonnulls(\"image_id\", \"canvas_id\", \"manifest_id\") = 1\n        AND\n        \"map_id\" IS NULL AND \"map_version\" IS NULL AND \"map_image_id\" IS NULL AND \"map_checksum\" IS NULL\n      ) OR (\n        num_nonnulls(\"image_id\", \"canvas_id\", \"manifest_id\") = 0\n        AND\n        \"map_id\" IS NOT NULL AND \"map_version\" IS NOT NULL AND \"map_image_id\" IS NOT NULL AND \"map_checksum\" IS NOT NULL\n      )",
+      "name": "single_foreign_key",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "definition": "select \"id\", \"image_id\", \"checksum\", \"image_checksum\", \"version\", \"latest\", \"created_at\", \"updated_at\", \"data\", \"resource_mask\", \"geo_mask\", \"area\", \"scale\" from \"maps\" where \"maps\".\"latest\" = true",
+      "with": null,
+      "withNoData": null,
+      "using": null,
+      "tablespace": null,
+      "materialized": false,
+      "name": "maps_latest",
+      "entityType": "views",
+      "schema": "public"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -88,6 +88,11 @@ export function createAuth(env: BetterAuthEnv) {
                 type: 'string',
                 required: false,
                 input: true
+              },
+              location: {
+                type: 'json',
+                required: false,
+                input: true
               }
             }
           }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -4,10 +4,16 @@ import {
   text,
   timestamp,
   boolean,
+  jsonb,
   index,
   check,
   uniqueIndex
 } from 'drizzle-orm/pg-core'
+
+export type OrganizationLocation = {
+  type: 'Point'
+  coordinates: [number, number]
+}
 
 export const users = pgTable(
   'users',
@@ -111,7 +117,8 @@ export const organizations = pgTable(
     createdAt: timestamp('created_at').notNull(),
     metadata: text('metadata'),
     homepage: text('homepage'),
-    plan: text('plan')
+    plan: text('plan'),
+    location: jsonb('location').$type<OrganizationLocation>()
   },
   (table) => [
     uniqueIndex('organizations_slug_uidx').on(table.slug),


### PR DESCRIPTION
This pull request adds support for storing, validating, and displaying organization location data as GeoJSON Points throughout the Allmaps API and Console. It introduces schema changes, backend validation and normalization, new API endpoints, and UI enhancements to handle and visualize organization locations.

**Backend: Organization Location Support**

* Added a `location` field (GeoJSON Point) to the organization schema and database queries, including normalization and validation logic in `normalizeOrganizationLocation` and a helper for PostGIS queries (`organizationLocationGeographySql`). [[1]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7R28) [[2]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7R139-R206) [[3]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7R451) [[4]](diffhunk://#diff-a149258aa6fd4f939723f4443d93f3bedde0da817e4b386e7eeef71fcdd044f7R474)
* Updated the REST API routes to accept, validate, and return organization locations, including new query schemas and error handling for invalid locations. [[1]](diffhunk://#diff-a7760e9a83ffd98cd38c3912f3b9746e5eb76e98db62f5011d260a00e0a9d16eR43-R50) [[2]](diffhunk://#diff-a7760e9a83ffd98cd38c3912f3b9746e5eb76e98db62f5011d260a00e0a9d16eR468-R482) [[3]](diffhunk://#diff-a7760e9a83ffd98cd38c3912f3b9746e5eb76e98db62f5011d260a00e0a9d16eR543-R550) [[4]](diffhunk://#diff-a7760e9a83ffd98cd38c3912f3b9746e5eb76e98db62f5011d260a00e0a9d16eR559)
* Added a `/organizations.geojson` endpoint to return all organizations as a GeoJSON FeatureCollection, supporting location-based use cases.

**Frontend: Console UI Enhancements**

* Updated the organization type and forms to support editing and displaying location (latitude, longitude), including validation and conversion to GeoJSON format. [[1]](diffhunk://#diff-5d2f907b8a04a67fe6f0679d3c16c7159e3d62fb537fb97c7f76fd5ac95bf0ddR7-R10) [apps/console/src/routes/organizations/[organizationId]/+page.svelteR125-R130](diffhunk://#diff-1bf8dcb8c262b4e1f307cf1d8364609d69c5cbfe1c9ff67446df275c5855fe60R125-R130), [apps/console/src/routes/organizations/[organizationId]/+page.svelteR142](diffhunk://#diff-1bf8dcb8c262b4e1f307cf1d8364609d69c5cbfe1c9ff67446df275c5855fe60R142), [[2]](diffhunk://#diff-8b992576e737800ef7907375c09a0a3c956512bc97cbb79e95a520a83f00384fR44-R79) [[3]](diffhunk://#diff-8b992576e737800ef7907375c09a0a3c956512bc97cbb79e95a520a83f00384fR91) [apps/console/src/routes/organizations/[organizationId]/+page.svelteR375-R392](diffhunk://#diff-1bf8dcb8c262b4e1f307cf1d8364609d69c5cbfe1c9ff67446df275c5855fe60R375-R392))
* Added a location icon in the organizations table to visually indicate organizations with a location set. [[1]](diffhunk://#diff-0251d268c46e99389c244b133172186574f82c65a11401324afac899489601b6R4) [[2]](diffhunk://#diff-0251d268c46e99389c244b133172186574f82c65a11401324afac899489601b6R209-R227)

**Other Improvements**

* Improved loading and error handling logic for organization and user pages to be more robust when data is missing or loading. ([apps/console/src/routes/organizations/[organizationId]/+page.svelteL27-R42](diffhunk://#diff-1bf8dcb8c262b4e1f307cf1d8364609d69c5cbfe1c9ff67446df275c5855fe60L27-R42), [apps/console/src/routes/users/[userId]/+page.svelteL38-R49](diffhunk://#diff-463bf81dde52d6b0295f74c940b49f2063392f6490c56807b790d720d8f51635L38-R49))
* Added the `phosphor-svelte` dependency for icon support in the UI.