### PR TITLE
Allow point-only GeoJSON in Allmaps Here. Closes #536.

### DIFF
--- a/apps/here/src/lib/components/Here.svelte
+++ b/apps/here/src/lib/components/Here.svelte
@@ -239,73 +239,77 @@
         })
       }
 
-      if (
-        geojsonRoute &&
-        geojsonRoute.route &&
-        resourceTransformerState.transformer
-      ) {
+      if (geojsonRoute && resourceTransformerState.transformer) {
         const transformer = resourceTransformerState.transformer
 
-        const projectedGeojsonRoute = transformer.transformToResource(
-          // TODO: we should align GeoJSON geometry types and Point/LineString/etc.
-          geojsonRoute.route.coordinates.map(
-            (point): Point => [point[0], point[1]]
-          )
-        )
-        geojsonRouteFeature.setGeometry(
-          new LineString(projectedGeojsonRoute.map((c) => [c[0], -c[1]]))
-        )
-
-        const geojsonMarkerFeatures = geojsonRoute.markers.map((marker) => {
-          if (isGeojsonPoint(marker.geometry)) {
-            const projectedPoint = transformer.transformToResource(
-              // TODO: we should align GeoJSON geometry types and Point/LineString/etc.
-              marker.geometry.coordinates as Point
+        if (geojsonRoute.route) {
+          const projectedGeojsonRoute = transformer.transformToResource(
+            // TODO: we should align GeoJSON geometry types and Point/LineString/etc.
+            geojsonRoute.route.coordinates.map(
+              (point): Point => [point[0], point[1]]
             )
+          )
+          geojsonRouteFeature.setGeometry(
+            new LineString(projectedGeojsonRoute.map((c) => [c[0], -c[1]]))
+          )
+        } else {
+          geojsonRouteFeature.setGeometry(undefined)
+        }
 
-            let title: string | undefined
-            let image: string | undefined
-            let url: string | undefined
-            let description: string | undefined
+        const geojsonMarkerFeatures = geojsonRoute.markers.flatMap((marker) => {
+          if (!isGeojsonPoint(marker.geometry)) {
+            return []
+          }
 
-            if (marker.properties && typeof marker.properties === 'object') {
-              if (
-                'title' in marker.properties &&
-                typeof marker.properties.title === 'string'
-              ) {
-                title = marker.properties.title
-              }
+          const projectedPoint = transformer.transformToResource(
+            // TODO: we should align GeoJSON geometry types and Point/LineString/etc.
+            marker.geometry.coordinates as Point
+          )
 
-              if (
-                'image' in marker.properties &&
-                typeof marker.properties.image === 'string'
-              ) {
-                image = marker.properties.image
-              }
+          let title: string | undefined
+          let image: string | undefined
+          let url: string | undefined
+          let description: string | undefined
 
-              if (
-                'description' in marker.properties &&
-                typeof marker.properties.description === 'string'
-              ) {
-                description = marker.properties.description
-              }
-
-              if (
-                'url' in marker.properties &&
-                typeof marker.properties.url === 'string'
-              ) {
-                url = marker.properties.url
-              }
+          if (marker.properties && typeof marker.properties === 'object') {
+            if (
+              'title' in marker.properties &&
+              typeof marker.properties.title === 'string'
+            ) {
+              title = marker.properties.title
             }
 
-            return new Feature({
+            if (
+              'image' in marker.properties &&
+              typeof marker.properties.image === 'string'
+            ) {
+              image = marker.properties.image
+            }
+
+            if (
+              'description' in marker.properties &&
+              typeof marker.properties.description === 'string'
+            ) {
+              description = marker.properties.description
+            }
+
+            if (
+              'url' in marker.properties &&
+              typeof marker.properties.url === 'string'
+            ) {
+              url = marker.properties.url
+            }
+          }
+
+          return [
+            new Feature({
               geometry: new OLPoint([projectedPoint[0], -projectedPoint[1]]),
               title,
               image,
               url,
               description
             })
-          }
+          ]
         })
 
         geojsonMarkersLayer.getSource()?.addFeatures(geojsonMarkerFeatures)

--- a/apps/here/src/lib/components/Route.svelte
+++ b/apps/here/src/lib/components/Route.svelte
@@ -53,6 +53,26 @@
         })
       : 0
   )
+
+  let markerCount = $derived(geojsonRoute?.markers.length || 0)
+
+  let currentGeojsonLabel = $derived.by(() => {
+    if (geojsonRoute?.route) {
+      return markerCount
+        ? `Current route: ${length.toFixed(2)} km with ${markerCount} POIs`
+        : `Current route: ${length.toFixed(2)} km`
+    }
+
+    if (markerCount === 1) {
+      return 'Current GeoJSON: 1 POI'
+    }
+
+    if (markerCount > 1) {
+      return `Current GeoJSON: ${markerCount} POIs`
+    }
+
+    return 'Current GeoJSON loaded'
+  })
 </script>
 
 <div
@@ -85,12 +105,7 @@
           {#if geojsonRoute?.error}
             <span>Error: {geojsonRoute?.error}</span>
           {:else}
-            <div>
-              <span>Current route: {length.toFixed(2)} km</span>
-              {#if geojsonRoute?.markers.length}
-                <span>with {geojsonRoute.markers.length} POIs</span>
-              {/if}
-            </div>
+            <span>{currentGeojsonLabel}</span>
           {/if}
           <button
             class="cursor-pointer px-2 py-1 shrink-0 bg-white/30 rounded"
@@ -117,8 +132,9 @@
         >
       </div>
       <p class="text-xs text-center px-8">
-        The GeoJSON file must be a FeatureCollection <br />with Point and
-        LineString Features, or a single LineString Feature.
+        The GeoJSON file must be a FeatureCollection <br />with Point and/or
+        LineString Features, a single Point Feature, or a single LineString
+        Feature.
       </p>
     </div>
   {/if}

--- a/apps/here/src/lib/components/Thumbnail.svelte
+++ b/apps/here/src/lib/components/Thumbnail.svelte
@@ -5,6 +5,7 @@
   import { Thumbnail } from '@allmaps/ui'
   import { GcpTransformer } from '@allmaps/transform'
   import { pink, red } from '@allmaps/tailwind'
+  import { isGeojsonPoint } from '@allmaps/stdlib'
 
   import { getImageInfoState } from '$lib/state/image-info.svelte.js'
   import { getSensorsState } from '$lib/state/sensors.svelte.js'
@@ -88,6 +89,22 @@
       resourceRouteCoordinates.map((point) => point.join(',')).join(' ')
   )
 
+  let resourceMarkerCoordinates = $derived.by(() => {
+    if (geojsonRoute?.markers.length && resourceSize && svgSize) {
+      return geojsonRoute.markers.flatMap((marker) => {
+        if (!isGeojsonPoint(marker.geometry)) {
+          return []
+        }
+
+        const resourcePoint = transformer.transformToResource(
+          marker.geometry.coordinates as Point
+        )
+
+        return [svgCoordinates(resourceSize, svgSize, resourcePoint)]
+      })
+    }
+  })
+
   let svgPositionCoordinates = $derived.by(() => {
     if (resourceSize && svgSize && resourcePositionCoordinates) {
       return svgCoordinates(resourceSize, svgSize, resourcePositionCoordinates)
@@ -147,7 +164,7 @@
             height={width * devicePixelRatio}
           />
         </div>
-        {#if svgSize && svgPositionCoordinates}
+        {#if svgSize && (svgPositionCoordinates || resourceRouteCoordinates || resourceMarkerCoordinates?.length)}
           <div
             class="group absolute top-0 w-full h-full flex items-center justify-center"
           >
@@ -170,22 +187,38 @@
                   stroke-width="0.6"
                 />
               {/if}
-              <g
-                class="opacity-90 delay-300 transition-opacity group-hover:opacity-0"
-              >
+              {#each resourceMarkerCoordinates || [] as markerCoordinates}
                 <circle
-                  cx={svgPositionCoordinates[0]}
-                  cy={svgPositionCoordinates[1]}
+                  cx={markerCoordinates[0]}
+                  cy={markerCoordinates[1]}
                   r={pinRadius}
                   fill="white"
                 />
                 <circle
-                  cx={svgPositionCoordinates[0]}
-                  cy={svgPositionCoordinates[1]}
+                  cx={markerCoordinates[0]}
+                  cy={markerCoordinates[1]}
                   r={pinRadius * 0.5}
-                  fill={pink}
+                  fill={red}
                 />
-              </g>
+              {/each}
+              {#if svgPositionCoordinates}
+                <g
+                  class="opacity-90 delay-300 transition-opacity group-hover:opacity-0"
+                >
+                  <circle
+                    cx={svgPositionCoordinates[0]}
+                    cy={svgPositionCoordinates[1]}
+                    r={pinRadius}
+                    fill="white"
+                  />
+                  <circle
+                    cx={svgPositionCoordinates[0]}
+                    cy={svgPositionCoordinates[1]}
+                    r={pinRadius * 0.5}
+                    fill={pink}
+                  />
+                </g>
+              {/if}
             </svg>
             {#if pinOriginPosition}
               <div


### PR DESCRIPTION
This pull request improves how GeoJSON routes and markers are handled and displayed in the `Here.svelte`, `Route.svelte`, and `Thumbnail.svelte` components. The main focus is on better distinguishing between routes and points of interest (POIs), improving UI clarity, and ensuring that only valid GeoJSON points are processed for markers.

**GeoJSON Route and Marker Handling:**

* Updated the logic in `Here.svelte` to only process and display route geometry if it exists, and to clear the route feature if missing. Marker features are now generated only for valid GeoJSON points, using `flatMap` to filter out invalid entries. [[1]](diffhunk://#diff-06e376b295fed9eed0a3d5e29db6225fd2b310ee7c1914c704388c120611b3b1L242-R245) [[2]](diffhunk://#diff-06e376b295fed9eed0a3d5e29db6225fd2b310ee7c1914c704388c120611b3b1R255-L260) [[3]](diffhunk://#diff-06e376b295fed9eed0a3d5e29db6225fd2b310ee7c1914c704388c120611b3b1L301-R312)

**UI and Label Improvements:**

* In `Route.svelte`, replaced the previous route summary with a new derived label (`currentGeojsonLabel`) that reports the number of POIs and route length more flexibly, depending on the loaded GeoJSON data. [[1]](diffhunk://#diff-71813c5c077e74c3ba8b72d7fda788b10a3dd4cb1975d74983fccda77a7b57acR56-R75) [[2]](diffhunk://#diff-71813c5c077e74c3ba8b72d7fda788b10a3dd4cb1975d74983fccda77a7b57acL88-R108)
* Updated the help text to clarify that the GeoJSON file can contain Point and/or LineString features, or a single Point or LineString feature.

**Thumbnail Marker Rendering:**

* In `Thumbnail.svelte`, added logic to project and render POI markers as SVG circles on the thumbnail, only for valid GeoJSON points. The SVG overlay now displays markers along with the route and position. [[1]](diffhunk://#diff-b49cf70181f778bda08a06493e28d3ede790ed6453a25b5e5d3579360376c3d0R92-R107) [[2]](diffhunk://#diff-b49cf70181f778bda08a06493e28d3ede790ed6453a25b5e5d3579360376c3d0L150-R167) [[3]](diffhunk://#diff-b49cf70181f778bda08a06493e28d3ede790ed6453a25b5e5d3579360376c3d0R190-R204) [[4]](diffhunk://#diff-b49cf70181f778bda08a06493e28d3ede790ed6453a25b5e5d3579360376c3d0R221)

**Code Quality:**

* Added missing import of `isGeojsonPoint` in `Thumbnail.svelte` to support marker validation.