### PR TITLE
added limit params to annotations routes

### DIFF
--- a/apis/annotations/src/routes/canvases.ts
+++ b/apis/annotations/src/routes/canvases.ts
@@ -1,42 +1,53 @@
 import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
-import { setCacheControl } from '@allmaps/api-shared'
+import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
-import { createElysia } from '../elysia.js'
+import { createElysia, createBetterAuthPlugin } from '../elysia.js'
+
+const querySchema = t.Object({
+  limit: t.Optional(t.Number())
+})
 
 export function createCanvasesRoutes(
   env: AnnotationsEnv,
   betterAuth: BetterAuthContext = createAuth(env)
 ) {
-  void betterAuth
-
-  return createElysia({ name: 'canvases' }).get(
-    '/canvases/:canvasId',
-    ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-medium')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        { canvasId: params.canvasId },
-        {
-          id: request.url,
-          format: 'annotation',
-          expectRows: true,
-          singular: false
+  return createElysia({ name: 'canvases' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      '/canvases/:canvasId',
+      async ({ request, env, db, params, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-medium' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          { canvasId: params.canvasId, limit: query.limit, userRole },
+          {
+            id: request.url,
+            format: 'annotation',
+            expectRows: true,
+            singular: false
+          }
+        )
+      },
+      {
+        params: t.Object({ canvasId: t.String() }),
+        query: querySchema,
+        detail: {
+          summary: 'Get Georeference Annotations for a single IIIF Canvas',
+          tags: ['Canvases']
         }
-      )
-    },
-    {
-      params: t.Object({ canvasId: t.String() }),
-      detail: {
-        summary: 'Get Georeference Annotations for a single IIIF Canvas',
-        tags: ['Canvases']
       }
-    }
-  )
+    )
 }

--- a/apis/annotations/src/routes/images.ts
+++ b/apis/annotations/src/routes/images.ts
@@ -1,11 +1,17 @@
+import { t } from 'elysia'
+
 import { queryMaps } from '@allmaps/api-shared/db'
-import { setCacheControl } from '@allmaps/api-shared'
+import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
-import { createElysia, RegExpRoute } from '../elysia.js'
+import { createElysia, createBetterAuthPlugin, RegExpRoute } from '../elysia.js'
+
+const querySchema = t.Object({
+  limit: t.Optional(t.Number())
+})
 
 // Matches: imageId  OR  imageId@imageChecksum  OR  imageId.geojson etc.
 const imageRoute = new RegExpRoute<{
@@ -21,31 +27,44 @@ export function createImagesRoutes(
   env: AnnotationsEnv,
   betterAuth: BetterAuthContext = createAuth(env)
 ) {
-  void betterAuth
-
-  return createElysia({ name: 'images' }).get(
-    `/images/${imageRoute.path}`,
-    ({ request, env, db, params, set }) => {
-      const { imageId, imageChecksum, ext } = imageRoute.parse(params)
-      setCacheControl(set, imageChecksum ? 'public-immutable' : 'public-medium')
-      const format = ext === 'geojson' ? 'geojson' : 'annotation'
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
-          imageId,
-          ...(imageChecksum ? { imageChecksum } : {})
-        },
-        { id: request.url, format, expectRows: true, singular: false }
-      )
-    },
-    {
-      params: imageRoute.params,
-      detail: {
-        summary:
-          'Get Georeference Annotations for a single IIIF Image (with optional version)',
-        tags: ['Images']
+  return createElysia({ name: 'images' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      `/images/${imageRoute.path}`,
+      async ({ request, env, db, params, query, set, getLimitRole }) => {
+        const { imageId, imageChecksum, ext } = imageRoute.parse(params)
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public'
+            ? imageChecksum
+              ? 'public-immutable'
+              : 'public-medium'
+            : 'private-no-store'
+        )
+        const format = ext === 'geojson' ? 'geojson' : 'annotation'
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            imageId,
+            ...(imageChecksum ? { imageChecksum } : {}),
+            limit: query.limit,
+            userRole
+          },
+          { id: request.url, format, expectRows: true, singular: false }
+        )
+      },
+      {
+        params: imageRoute.params,
+        query: querySchema,
+        detail: {
+          summary:
+            'Get Georeference Annotations for a single IIIF Image (with optional version)',
+          tags: ['Images']
+        }
       }
-    }
-  )
+    )
 }

--- a/apis/annotations/src/routes/manifests.ts
+++ b/apis/annotations/src/routes/manifests.ts
@@ -1,42 +1,53 @@
 import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
-import { setCacheControl } from '@allmaps/api-shared'
+import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
-import { createElysia } from '../elysia.js'
+import { createElysia, createBetterAuthPlugin } from '../elysia.js'
+
+const querySchema = t.Object({
+  limit: t.Optional(t.Number())
+})
 
 export function createManifestsRoutes(
   env: AnnotationsEnv,
   betterAuth: BetterAuthContext = createAuth(env)
 ) {
-  void betterAuth
-
-  return createElysia({ name: 'manifests' }).get(
-    '/manifests/:manifestId',
-    ({ request, env, db, params, set }) => {
-      setCacheControl(set, 'public-medium')
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        { manifestId: params.manifestId },
-        {
-          id: request.url,
-          format: 'annotation',
-          expectRows: true,
-          singular: false
+  return createElysia({ name: 'manifests' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      '/manifests/:manifestId',
+      async ({ request, env, db, params, query, set, getLimitRole }) => {
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getLimitRole()
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-medium' : 'private-no-store'
+        )
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          { manifestId: params.manifestId, limit: query.limit, userRole },
+          {
+            id: request.url,
+            format: 'annotation',
+            expectRows: true,
+            singular: false
+          }
+        )
+      },
+      {
+        params: t.Object({ manifestId: t.String() }),
+        query: querySchema,
+        detail: {
+          summary: 'Get Georeference Annotations for a single IIIF Manifest',
+          tags: ['Manifests']
         }
-      )
-    },
-    {
-      params: t.Object({ manifestId: t.String() }),
-      detail: {
-        summary: 'Get Georeference Annotations for a single IIIF Manifest',
-        tags: ['Manifests']
       }
-    }
-  )
+    )
 }

--- a/apis/annotations/src/routes/organizations.ts
+++ b/apis/annotations/src/routes/organizations.ts
@@ -1,11 +1,21 @@
-import { ResponseError, setCacheControl } from '@allmaps/api-shared'
+import { t } from 'elysia'
+
+import {
+  needsElevatedLimitRole,
+  ResponseError,
+  setCacheControl
+} from '@allmaps/api-shared'
 import { queryMaps, queryOrganizationBySlug } from '@allmaps/api-shared/db'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
-import { createElysia, RegExpRoute } from '../elysia.js'
+import { createElysia, createBetterAuthPlugin, RegExpRoute } from '../elysia.js'
+
+const querySchema = t.Object({
+  limit: t.Optional(t.Number())
+})
 
 const organizationRoute = new RegExpRoute<{
   organizationSlug: string
@@ -19,40 +29,57 @@ export function createOrganizationsRoutes(
   env: AnnotationsEnv,
   betterAuth: BetterAuthContext = createAuth(env)
 ) {
-  void betterAuth
-
-  return createElysia({ name: 'organizations' }).get(
-    `/organizations/${organizationRoute.path}`,
-    async ({ request, env, db, params, set }) => {
-      const { organizationSlug, ext } = organizationRoute.parse(params)
-      const organization = await queryOrganizationBySlug(
+  return createElysia({ name: 'organizations' })
+    .use(createBetterAuthPlugin(betterAuth))
+    .get(
+      `/organizations/${organizationRoute.path}`,
+      async ({
+        request,
+        env,
         db,
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        organizationSlug
-      )
-
-      if (!organization || !organization.plan) {
-        throw new ResponseError('Organization not found', 404)
-      }
-
-      setCacheControl(set, 'public-medium')
-
-      const format = ext === 'geojson' ? 'geojson' : 'annotation'
-      return queryMaps(
-        env.PUBLIC_ANNOTATIONS_BASE_URL,
-        db,
-        {
+        params,
+        query,
+        set,
+        getOrganizationLimitRole
+      }) => {
+        const { organizationSlug, ext } = organizationRoute.parse(params)
+        const organization = await queryOrganizationBySlug(
+          db,
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
           organizationSlug
-        },
-        { id: request.url, format, expectRows: true, singular: false }
-      )
-    },
-    {
-      params: organizationRoute.params,
-      detail: {
-        summary: 'Get Georeference Annotations for a single organization',
-        tags: ['Organizations']
+        )
+
+        if (!organization || !organization.plan) {
+          throw new ResponseError('Organization not found', 404)
+        }
+
+        const userRole = needsElevatedLimitRole(query.limit)
+          ? await getOrganizationLimitRole({ slug: organizationSlug })
+          : 'public'
+        setCacheControl(
+          set,
+          userRole === 'public' ? 'public-medium' : 'private-no-store'
+        )
+
+        const format = ext === 'geojson' ? 'geojson' : 'annotation'
+        return queryMaps(
+          env.PUBLIC_ANNOTATIONS_BASE_URL,
+          db,
+          {
+            organizationSlug,
+            limit: query.limit,
+            userRole
+          },
+          { id: request.url, format, expectRows: true, singular: false }
+        )
+      },
+      {
+        params: organizationRoute.params,
+        query: querySchema,
+        detail: {
+          summary: 'Get Georeference Annotations for a single organization',
+          tags: ['Organizations']
+        }
       }
-    }
-  )
+    )
 }


### PR DESCRIPTION
This pull request updates the annotations API routes to support per-request result limits and role-based access control for elevated limits. It introduces query parameter validation, integrates authentication plugins, and applies dynamic cache control headers based on user roles. The changes are applied consistently across the `canvases`, `images`, `manifests`, and `organizations` endpoints.

**Authentication and Role-Based Access Control:**
- All routes now use the `createBetterAuthPlugin` for authentication and role management. [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84L4-R35) [[2]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215R1-R14) [[3]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69L4-R35) [[4]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L1-R18)
- Endpoints determine if an elevated limit is requested using `needsElevatedLimitRole`, and fetch the appropriate user role accordingly. [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84L4-R35) [[2]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215R1-R14) [[3]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69L4-R35) [[4]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L38-R78)

**Query Parameter and Validation Enhancements:**
- All endpoints accept an optional `limit` query parameter, validated using a shared `querySchema` (`t.Object({ limit: t.Optional(t.Number()) })`). [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84R46) [[2]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215R1-R14) [[3]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215L24-R62) [[4]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69R46) [[5]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L1-R18) [[6]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L22-R44)
- The `limit` and `userRole` are passed to the database query functions for enforcement and auditing. [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84L4-R35) [[2]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215L24-R62) [[3]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69L4-R35) [[4]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L38-R78)

**Cache Control Improvements:**
- Cache control headers are now set dynamically: public cache for standard users, and private/no-store for elevated roles or when a higher limit is requested. [[1]](diffhunk://#diff-d9649a20c5169fe981b8c021605d2c5f55fe04d8683901ad8d469cc86445cb84L4-R35) [[2]](diffhunk://#diff-e21247f9124eb7e414a1d9c51c1263e179bde33c81012775530302723b749215L24-R62) [[3]](diffhunk://#diff-8fd863efb9d7ecfb35d9753b3f2acb4da7ea4254a60d02a5b6424dfc7d20ee69L4-R35) [[4]](diffhunk://#diff-4d61897c2c2dbcebeae2913a17746b71b32237394e7552bc05c7b40c8e7dd462L38-R78)

**Consistency and Refactoring:**
- The structure and logic for handling authentication, query parameters, and cache control are now consistent across all main annotation routes. (All change references above)