### PR TITLE
ignore .svelte-kit when searching in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "search.exclude": {
+    "**/.svelte-kit": true
+  }
+}


### PR DESCRIPTION
This pull request adds a new workspace setting to exclude the `.svelte-kit` directory from search results in VS Code. This helps reduce noise from build artifacts when searching the codebase.

VS Code configuration:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R5): Added a `search.exclude` rule to hide the `.svelte-kit` directory from search results.