### PR TITLE
added-image-info-fetch-error

### DIFF
--- a/packages/leaflet/src/WarpedMapLayer.ts
+++ b/packages/leaflet/src/WarpedMapLayer.ts
@@ -1430,6 +1430,11 @@ export class WarpedMapLayer
     )
 
     this.renderer.addEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.addEventListener(
       WarpedMapEventType.ERROR,
       this.nativePassWarpedMapEvent.bind(this)
     )
@@ -1518,6 +1523,11 @@ export class WarpedMapLayer
     this.renderer.removeEventListener(
       WarpedMapEventType.IMAGELOADED,
       this.nativeUpdate.bind(this)
+    )
+
+    this.renderer.removeEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
     )
 
     this.renderer.removeEventListener(

--- a/packages/openlayers/src/WarpedMapLayer.ts
+++ b/packages/openlayers/src/WarpedMapLayer.ts
@@ -1306,6 +1306,11 @@ export class WarpedMapLayer
     )
 
     this.renderer.addEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.addEventListener(
       WarpedMapEventType.ERROR,
       this.nativePassWarpedMapEvent.bind(this)
     )
@@ -1394,6 +1399,11 @@ export class WarpedMapLayer
     this.renderer.removeEventListener(
       WarpedMapEventType.IMAGELOADED,
       this.nativeUpdate.bind(this)
+    )
+
+    this.renderer.removeEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
     )
 
     this.renderer.removeEventListener(

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -3,7 +3,11 @@ export { WarpedMapList } from './maps/WarpedMapList.js'
 export { WarpedMap } from './maps/WarpedMap.js'
 export { TriangulatedWarpedMap } from './maps/TriangulatedWarpedMap.js'
 
-export { WarpedMapEvent, WarpedMapEventType } from './shared/events.js'
+export {
+  WarpedMapErrorEvent,
+  WarpedMapEvent,
+  WarpedMapEventType
+} from './shared/events.js'
 
 export type {
   WarpedMapOptions,

--- a/packages/render/src/maps/WarpedMap.ts
+++ b/packages/render/src/maps/WarpedMap.ts
@@ -13,6 +13,7 @@ import {
   bboxToRectangle,
   rectanglesToScale,
   fetchImageInfo,
+  ResourceFetchError,
   getPropertyFromCacheOrComputation,
   getPropertyFromDoubleCacheOrComputation,
   mixLineStrings,
@@ -26,7 +27,11 @@ import {
 } from '@allmaps/stdlib'
 
 import { applyHomogeneousTransform } from '../shared/homogeneous-transform.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
+import {
+  WarpedMapErrorEvent,
+  WarpedMapEvent,
+  WarpedMapEventType
+} from '../shared/events.js'
 
 import type {
   Gcp,
@@ -83,6 +88,19 @@ const DEFAULT_SPECIFIC_PROJECTED_GCP_TRANSFORMER_OPTIONS = {
 const DEFAULT_PROJECTED_GCP_TRANSFORMER_OPTIONS = {
   ...DEFAULT_WARPED_MAP_OPTIONS,
   ...DEFAULT_SPECIFIC_PROJECTED_GCP_TRANSFORMER_OPTIONS
+}
+
+function ensureError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function isAbortError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'AbortError'
+  )
 }
 
 export function createWarpedMapFactory<W extends WarpedMap>() {
@@ -188,6 +206,7 @@ export class WarpedMap extends EventTarget {
   options!: WarpedMapOptions
 
   fetchingImageInfo: boolean
+  imageInfoError?: Error
   image?: Image
   tileSize?: Size
 
@@ -887,6 +906,12 @@ export class WarpedMap extends EventTarget {
    * @returns
    */
   async loadImage(imagesById?: Map<string, Image>): Promise<void> {
+    if (this.imageInfoError) {
+      throw this.imageInfoError
+    }
+
+    let imageInfoFetched = false
+
     try {
       const resourceId = this.georeferencedMap.resource.id
 
@@ -901,6 +926,7 @@ export class WarpedMap extends EventTarget {
           { signal },
           this.options.fetchFn
         )
+        imageInfoFetched = true
         this.abortController = undefined
         this.image = Image.parse(imageInfo)
         if (imagesById) {
@@ -912,11 +938,42 @@ export class WarpedMap extends EventTarget {
         Math.max(...this.image.tileZoomLevels.map((size) => size.height))
       ]
 
+      this.imageInfoError = undefined
       this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.IMAGELOADED))
     } catch (err) {
-      this.fetchingImageInfo = false
-      throw err
+      if (isAbortError(err)) {
+        throw err
+      }
+
+      const error = ensureError(err)
+      const resourceId = this.georeferencedMap.resource.id
+      const errorData =
+        error instanceof ResourceFetchError
+          ? {
+              errorKind: error.kind,
+              corsLikely: error.corsLikely,
+              status: error.status
+            }
+          : {
+              errorKind: imageInfoFetched ? 'parse' : 'unknown'
+            }
+
+      this.imageInfoError = error
+      this.dispatchEvent(
+        new WarpedMapErrorEvent(
+          error,
+          {
+            mapIds: [this.mapId],
+            imageId: resourceId,
+            imageInfoUrl: `${resourceId}/info.json`,
+            ...errorData
+          },
+          WarpedMapEventType.IMAGEINFOFETCHERROR
+        )
+      )
+      throw error
     } finally {
+      this.abortController = undefined
       this.fetchingImageInfo = false
     }
   }

--- a/packages/render/src/maps/WarpedMapList.ts
+++ b/packages/render/src/maps/WarpedMapList.ts
@@ -30,7 +30,11 @@ import {
   optionKeysToUndefinedOptions,
   pointInBbox
 } from '@allmaps/stdlib'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
+import {
+  WarpedMapErrorEvent,
+  WarpedMapEvent,
+  WarpedMapEventType
+} from '../shared/events.js'
 
 import type { Ring, Bbox, Point } from '@allmaps/types'
 import type { Projection } from '@allmaps/project'
@@ -83,6 +87,7 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
   options: WarpedMapListOptions<W>
 
   #boundImageLoadedByMapId: Map<string, EventListener>
+  #boundImageInfoFetchErrorByMapId: Map<string, EventListener>
 
   /**
    * Creates an instance of a WarpedMapList
@@ -118,6 +123,7 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
     this.zIndices = new Map()
     this.imagesById = new Map()
     this.#boundImageLoadedByMapId = new Map()
+    this.#boundImageInfoFetchErrorByMapId = new Map()
 
     this.options = mergeOptions(
       this.DEFAULT_WARPED_MAP_LIST_OPTIONS,
@@ -1479,18 +1485,62 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
     )
   }
 
-  #addEventListenersToWarpedMap(warpedMap: W) {
-    const bound = this.#imageLoaded.bind(this, warpedMap.mapId)
-    this.#boundImageLoadedByMapId.set(warpedMap.mapId, bound)
+  #imageInfoFetchError(mapId: string, event: Event) {
+    if (event instanceof WarpedMapEvent) {
+      this.dispatchEvent(
+        new WarpedMapErrorEvent(
+          ensureError(event.error),
+          {
+            ...event.data,
+            mapIds: [mapId]
+          },
+          WarpedMapEventType.IMAGEINFOFETCHERROR
+        )
+      )
+    }
+  }
 
-    warpedMap.addEventListener(WarpedMapEventType.IMAGELOADED, bound)
+  #addEventListenersToWarpedMap(warpedMap: W) {
+    const boundImageLoaded = this.#imageLoaded.bind(this, warpedMap.mapId)
+    const boundImageInfoFetchError = this.#imageInfoFetchError.bind(
+      this,
+      warpedMap.mapId
+    )
+    this.#boundImageLoadedByMapId.set(warpedMap.mapId, boundImageLoaded)
+    this.#boundImageInfoFetchErrorByMapId.set(
+      warpedMap.mapId,
+      boundImageInfoFetchError
+    )
+
+    warpedMap.addEventListener(
+      WarpedMapEventType.IMAGELOADED,
+      boundImageLoaded
+    )
+    warpedMap.addEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      boundImageInfoFetchError
+    )
   }
 
   #removeEventListenersFromWarpedMap(warpedMap: W) {
-    const bound = this.#boundImageLoadedByMapId.get(warpedMap.mapId)
-    if (bound) {
-      warpedMap.removeEventListener(WarpedMapEventType.IMAGELOADED, bound)
+    const boundImageLoaded = this.#boundImageLoadedByMapId.get(warpedMap.mapId)
+    if (boundImageLoaded) {
+      warpedMap.removeEventListener(
+        WarpedMapEventType.IMAGELOADED,
+        boundImageLoaded
+      )
       this.#boundImageLoadedByMapId.delete(warpedMap.mapId)
+    }
+
+    const boundImageInfoFetchError = this.#boundImageInfoFetchErrorByMapId.get(
+      warpedMap.mapId
+    )
+    if (boundImageInfoFetchError) {
+      warpedMap.removeEventListener(
+        WarpedMapEventType.IMAGEINFOFETCHERROR,
+        boundImageInfoFetchError
+      )
+      this.#boundImageInfoFetchErrorByMapId.delete(warpedMap.mapId)
     }
   }
 

--- a/packages/render/src/renderers/BaseRenderer.ts
+++ b/packages/render/src/renderers/BaseRenderer.ts
@@ -67,6 +67,7 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
   #boundMapTileLoaded = this.mapTileLoaded.bind(this)
   #boundMapTileDeleted = this.mapTileDeleted.bind(this)
   #boundImageLoaded = this.imageLoaded.bind(this)
+  #boundImageInfoFetchError = this.imageInfoFetchError.bind(this)
   #boundWarpedMapAdded = this.warpedMapAdded.bind(this)
   #boundWarpedMapRemoved = this.warpedMapRemoved.bind(this)
   #boundPrepareChange = this.prepareChange.bind(this)
@@ -566,7 +567,10 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
         applyMask: false
       })
       .filter(
-        (warpedMap) => !warpedMap.hasImage() && !warpedMap.fetchingImageInfo
+        (warpedMap) =>
+          !warpedMap.hasImage() &&
+          !warpedMap.fetchingImageInfo &&
+          !warpedMap.imageInfoError
       )
       .map((warpedMap) => warpedMap.loadImage(this.warpedMapList.imagesById))
   }
@@ -1208,6 +1212,9 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
   protected imageLoaded(event: Event): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  protected imageInfoFetchError(event: Event): void {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   protected warpedMapAdded(event: Event): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
@@ -1234,6 +1241,10 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
     this.warpedMapList.addEventListener(
       WarpedMapEventType.IMAGELOADED,
       this.#boundImageLoaded
+    )
+    this.warpedMapList.addEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.#boundImageInfoFetchError
     )
     this.warpedMapList.addEventListener(
       WarpedMapEventType.WARPEDMAPADDED,
@@ -1269,6 +1280,10 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
     this.warpedMapList.removeEventListener(
       WarpedMapEventType.IMAGELOADED,
       this.#boundImageLoaded
+    )
+    this.warpedMapList.removeEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.#boundImageInfoFetchError
     )
     this.warpedMapList.removeEventListener(
       WarpedMapEventType.WARPEDMAPADDED,

--- a/packages/render/src/renderers/WebGL2Renderer.ts
+++ b/packages/render/src/renderers/WebGL2Renderer.ts
@@ -18,7 +18,11 @@ import {
 } from '../maps/WebGL2WarpedMap.js'
 import { DEFAULT_ANIMATION_OPTIONS } from '../maps/WarpedMapList.js'
 import { CacheableWorkerImageDataTile } from '../tilecache/CacheableWorkerImageDataTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
+import {
+  WarpedMapErrorEvent,
+  WarpedMapEvent,
+  WarpedMapEventType
+} from '../shared/events.js'
 import {
   multiplyHomogeneousTransform,
   invertHomogeneousTransform,
@@ -325,7 +329,11 @@ export class WebGL2Renderer
       )
 
     // Not awaiting this, using events to trigger new render calls
-    this.loadMissingImagesInViewport()
+    this.loadMissingImagesInViewport().forEach((promise) => {
+      promise.catch(() => {
+        // Image-info failures are emitted as IMAGEINFOFETCHERROR events.
+      })
+    })
 
     // Don't fire throttled function unless it could result in something
     // Otherwise we have to wait for that cycle to finish before useful cycle can be started
@@ -1068,6 +1076,18 @@ export class WebGL2Renderer
     if (event instanceof WarpedMapEvent) {
       this.dispatchEvent(
         new WarpedMapEvent(WarpedMapEventType.IMAGELOADED, event.data)
+      )
+    }
+  }
+
+  protected imageInfoFetchError(event: Event) {
+    if (event instanceof WarpedMapEvent && event.error) {
+      this.dispatchEvent(
+        new WarpedMapErrorEvent(
+          event.error,
+          event.data,
+          WarpedMapEventType.IMAGEINFOFETCHERROR
+        )
       )
     }
   }

--- a/packages/render/src/shared/events.ts
+++ b/packages/render/src/shared/events.ts
@@ -12,6 +12,7 @@ export const WarpedMapEventType = {
 
   // WarpedMap > WarpedMapList > Renderer > ...
   IMAGELOADED: 'imageloaded',
+  IMAGEINFOFETCHERROR: 'imageinfofetcherror',
 
   // Tile > TileCache
   TILEFETCHED: 'tilefetched',
@@ -46,6 +47,11 @@ export type WarpedMapEventType =
 
 export type WarpedMapEventData = {
   mapIds: string[]
+  imageId: string
+  imageInfoUrl: string
+  errorKind: string
+  corsLikely: boolean
+  status: number
   tileUrl: string
   optionKeys: string[]
   animationOptions: Partial<AnimationOptions>
@@ -67,8 +73,12 @@ export class WarpedMapEvent extends Event {
 export class WarpedMapErrorEvent extends WarpedMapEvent {
   error: Error
 
-  constructor(error: Error, data?: Partial<WarpedMapEventData>) {
-    super(WarpedMapEventType.ERROR, data)
+  constructor(
+    error: Error,
+    data?: Partial<WarpedMapEventData>,
+    type: WarpedMapEventType = WarpedMapEventType.ERROR
+  ) {
+    super(type, data)
 
     this.error = error
   }

--- a/packages/warpedmaplayer/src/WarpedMapLayer.ts
+++ b/packages/warpedmaplayer/src/WarpedMapLayer.ts
@@ -1076,6 +1076,11 @@ export abstract class BaseWarpedMapLayer<
     )
 
     this.renderer.addEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.addEventListener(
       WarpedMapEventType.ERROR,
       this.nativePassWarpedMapEvent.bind(this)
     )
@@ -1164,6 +1169,11 @@ export abstract class BaseWarpedMapLayer<
     this.renderer.removeEventListener(
       WarpedMapEventType.IMAGELOADED,
       this.nativeUpdate.bind(this)
+    )
+
+    this.renderer.removeEventListener(
+      WarpedMapEventType.IMAGEINFOFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
     )
 
     this.renderer.removeEventListener(


### PR DESCRIPTION
This pull request introduces improved error handling for image info fetch failures throughout the WarpedMap rendering pipeline. The main change is the addition of a new event type, `IMAGEINFOFETCHERROR`, which allows errors encountered while fetching image metadata to propagate cleanly from the map level up through the renderer and layer abstractions. This enables more robust error reporting and handling in applications using these components.

**Error handling improvements:**

* Added the `IMAGEINFOFETCHERROR` event type to `WarpedMapEventType`, and extended `WarpedMapErrorEvent` to support custom event types. The event now carries additional metadata about the error, including error kind, CORS status, HTTP status, and related resource IDs. (`packages/render/src/shared/events.ts`) [[1]](diffhunk://#diff-bdc35f5c641149743be58eaacf16213b09057305d18dcf2c0a9e0f34ae0e9551R15) [[2]](diffhunk://#diff-bdc35f5c641149743be58eaacf16213b09057305d18dcf2c0a9e0f34ae0e9551R50-R54) [[3]](diffhunk://#diff-bdc35f5c641149743be58eaacf16213b09057305d18dcf2c0a9e0f34ae0e9551L70-R81)
* Updated `WarpedMap` to track image info fetch errors, emit `IMAGEINFOFETCHERROR` events with detailed error data, and prevent repeated fetch attempts on error. (`packages/render/src/maps/WarpedMap.ts`) [[1]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13R93-R105) [[2]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13R209) [[3]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13R909-R914) [[4]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13R929) [[5]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13R941-R976)

**Event propagation and listener management:**

* `WarpedMapList` now listens for `IMAGEINFOFETCHERROR` events from each map, rebroadcasts them, and manages event listeners for both image loaded and image info fetch error events. (`packages/render/src/maps/WarpedMapList.ts`) [[1]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L33-R37) [[2]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R90) [[3]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R126) [[4]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R1488-R1544)
* `BaseRenderer` and `WebGL2Renderer` now handle `IMAGEINFOFETCHERROR` events, propagate them, and ensure event listeners are correctly added and removed. (`packages/render/src/renderers/BaseRenderer.ts`, `packages/render/src/renderers/WebGL2Renderer.ts`) [[1]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19R70) [[2]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19L569-R573) [[3]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19R1214-R1216) [[4]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19R1245-R1248) [[5]](diffhunk://#diff-161694bdc7eb7d1f0f3bc63e9a79967a559a2178934d22547c7ed7c5ba088d19R1284-R1287) [[6]](diffhunk://#diff-2abfd4c097b38a015a16a012b43fb15360fccbace6d67d7296f68c4de32eecbcL21-R25) [[7]](diffhunk://#diff-2abfd4c097b38a015a16a012b43fb15360fccbace6d67d7296f68c4de32eecbcL328-R336) [[8]](diffhunk://#diff-2abfd4c097b38a015a16a012b43fb15360fccbace6d67d7296f68c4de32eecbcR1083-R1094)

**Integration with map layers:**

* Updated all WarpedMapLayer implementations (`leaflet`, `openlayers`, `warpedmaplayer`) to listen for and propagate `IMAGEINFOFETCHERROR` events, ensuring errors are surfaced at the layer level. (`packages/leaflet/src/WarpedMapLayer.ts`, `packages/openlayers/src/WarpedMapLayer.ts`, `packages/warpedmaplayer/src/WarpedMapLayer.ts`) [[1]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43R1432-R1436) [[2]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43R1528-R1532) [[3]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962R1308-R1312) [[4]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962R1404-R1408) [[5]](diffhunk://#diff-749773dbd734e9dae2b45b5fdb50f119044be3d1b8d4f1e8bc82961cd5c7b64aR1078-R1082) [[6]](diffhunk://#diff-749773dbd734e9dae2b45b5fdb50f119044be3d1b8d4f1e8bc82961cd5c7b64aR1174-R1178)

**Exports and imports:**

* Updated exports and imports to include the new event types and error event classes throughout the relevant modules. (`packages/render/src/index.ts`, `packages/render/src/maps/WarpedMap.ts`) [[1]](diffhunk://#diff-104392d44d03827023061628fd34a8f88f1917ef87eb3da7ecdac1bf3eec0833L6-R10) [[2]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13L29-R34) [[3]](diffhunk://#diff-429fcd5a0eefe4d0263749d1bbec248e0f4aaa8b8c6464558897dfc7319d1c13R16)

These changes together provide a consistent and extensible mechanism for handling and reporting image info fetch errors in the WarpedMap rendering system.