### PR TITLE
background color functions are now in separate module

### DIFF
--- a/packages/stdlib/src/background-color.ts
+++ b/packages/stdlib/src/background-color.ts
@@ -1,108 +1,108 @@
-import type { Point } from '@allmaps/types'
+// import type { Point } from '@allmaps/types'
 
-type Color = [number, number, number]
+// type Color = [number, number, number]
 
-type ColorCount = {
-  count: number
-  color: Color
-}
+// type ColorCount = {
+//   count: number
+//   color: Color
+// }
 
-type Histogram = {
-  [bin: string]: ColorCount
-}
+// type Histogram = {
+//   [bin: string]: ColorCount
+// }
 
-const DEFAULT_BIN_SIZE = 5
-const DEFAULT_RESOLUTION = 2
+// const DEFAULT_BIN_SIZE = 5
+// const DEFAULT_RESOLUTION = 2
 
-export function getImageData(imageBitmap: ImageBitmap, mask?: Point[]) {
-  const canvas = new OffscreenCanvas(imageBitmap.width, imageBitmap.height)
-  const context = canvas.getContext('2d')
+// export function getImageData(imageBitmap: ImageBitmap, mask?: Point[]) {
+//   const canvas = new OffscreenCanvas(imageBitmap.width, imageBitmap.height)
+//   const context = canvas.getContext('2d')
 
-  if (!context) {
-    throw new Error('Could not create OffscreenCanvas context')
-  }
+//   if (!context) {
+//     throw new Error('Could not create OffscreenCanvas context')
+//   }
 
-  if (mask) {
-    context.fillStyle = 'rgba(0, 0, 0, 0)'
-    context.fillRect(0, 0, imageBitmap.width, imageBitmap.height)
+//   if (mask) {
+//     context.fillStyle = 'rgba(0, 0, 0, 0)'
+//     context.fillRect(0, 0, imageBitmap.width, imageBitmap.height)
 
-    context.beginPath()
-    context.moveTo(mask[0][0], mask[0][1])
-    mask.slice(1).forEach((point) => context.lineTo(point[0], point[1]))
-    context.closePath()
-    context.clip()
-  }
+//     context.beginPath()
+//     context.moveTo(mask[0][0], mask[0][1])
+//     mask.slice(1).forEach((point) => context.lineTo(point[0], point[1]))
+//     context.closePath()
+//     context.clip()
+//   }
 
-  context.drawImage(imageBitmap, 0, 0)
-  return context.getImageData(0, 0, imageBitmap.width, imageBitmap.height)
-}
+//   context.drawImage(imageBitmap, 0, 0)
+//   return context.getImageData(0, 0, imageBitmap.width, imageBitmap.height)
+// }
 
-export function getColorsArray(
-  imageData: ImageData,
-  resolution = DEFAULT_RESOLUTION
-) {
-  const colors = []
-  for (let x = 0; x < imageData.width; x += resolution) {
-    for (let y = 0; y < imageData.height; y += resolution) {
-      const startIndex = (x + y * imageData.width) * 4
+// export function getColorsArray(
+//   imageData: ImageData,
+//   resolution = DEFAULT_RESOLUTION
+// ) {
+//   const colors = []
+//   for (let x = 0; x < imageData.width; x += resolution) {
+//     for (let y = 0; y < imageData.height; y += resolution) {
+//       const startIndex = (x + y * imageData.width) * 4
 
-      const opacity = imageData.data[startIndex + 3]
+//       const opacity = imageData.data[startIndex + 3]
 
-      if (opacity > 0) {
-        const color: Color = [
-          imageData.data[startIndex],
-          imageData.data[startIndex + 1],
-          imageData.data[startIndex + 2]
-        ]
+//       if (opacity > 0) {
+//         const color: Color = [
+//           imageData.data[startIndex],
+//           imageData.data[startIndex + 1],
+//           imageData.data[startIndex + 2]
+//         ]
 
-        colors.push(color)
-      }
-    }
-  }
+//         colors.push(color)
+//       }
+//     }
+//   }
 
-  return colors
-}
+//   return colors
+// }
 
-export function getColorHistogram(colors: Color[], binSize = DEFAULT_BIN_SIZE) {
-  const histogram: Histogram = {}
+// export function getColorHistogram(colors: Color[], binSize = DEFAULT_BIN_SIZE) {
+//   const histogram: Histogram = {}
 
-  for (const color of colors) {
-    const bin = createColorBin(color, binSize)
+//   for (const color of colors) {
+//     const bin = createColorBin(color, binSize)
 
-    if (!histogram[bin]) {
-      histogram[bin] = {
-        count: 0,
-        color
-      }
-    }
+//     if (!histogram[bin]) {
+//       histogram[bin] = {
+//         count: 0,
+//         color
+//       }
+//     }
 
-    histogram[bin].count += 1
-  }
+//     histogram[bin].count += 1
+//   }
 
-  return histogram
-}
+//   return histogram
+// }
 
-export function getMaxOccurringColor(histogram: Histogram): ColorCount {
-  let max = Number.NEGATIVE_INFINITY
-  let maxOccurringColor
+// export function getMaxOccurringColor(histogram: Histogram): ColorCount {
+//   let max = Number.NEGATIVE_INFINITY
+//   let maxOccurringColor
 
-  for (const { count, color } of Object.values(histogram)) {
-    if (count > max) {
-      max = count
-      maxOccurringColor = color
-    }
-  }
+//   for (const { count, color } of Object.values(histogram)) {
+//     if (count > max) {
+//       max = count
+//       maxOccurringColor = color
+//     }
+//   }
 
-  if (!maxOccurringColor) {
-    throw new Error('Histogram is empty')
-  }
+//   if (!maxOccurringColor) {
+//     throw new Error('Histogram is empty')
+//   }
 
-  return {
-    count: max,
-    color: maxOccurringColor
-  }
-}
+//   return {
+//     count: max,
+//     color: maxOccurringColor
+//   }
+// }
 
-function createColorBin(color: Color, binSize: number) {
-  return color.map((c) => Math.round(c / binSize)).toString()
-}
+// function createColorBin(color: Color, binSize: number) {
+//   return color.map((c) => Math.round(c / binSize)).toString()
+// }

--- a/packages/stdlib/src/index.ts
+++ b/packages/stdlib/src/index.ts
@@ -1,11 +1,11 @@
 export { fetchAnnotationsFromApi } from './api.js'
 
-export {
-  getImageData,
-  getColorsArray,
-  getColorHistogram,
-  getMaxOccurringColor
-} from './background-color.js'
+// export {
+//   getImageData,
+//   getColorsArray,
+//   getColorHistogram,
+//   getMaxOccurringColor
+// } from './background-color.js'
 
 export {
   computeMinMax,


### PR DESCRIPTION
This pull request comments out (disables) the background color analysis utilities in the codebase. The main effect is that all functions and types related to computing the dominant color from images are no longer available for import or use.

The most important changes are:

### Disabling background color analysis

* All functions and types in `background-color.ts` (such as `getImageData`, `getColorsArray`, `getColorHistogram`, and `getMaxOccurringColor`) have been commented out, effectively disabling this module.
* The export block for these functions in `index.ts` has also been commented out, so they are no longer exported from the package.