### PR TITLE
more test routes in test iiif server

### DIFF
--- a/test/server/README.md
+++ b/test/server/README.md
@@ -43,6 +43,10 @@ GET /cors/iiif/:version/:level/:imageId/:region/:size/:rotation/:quality.:format
 GET /cors/annotations/images/:imageId.json
 GET /cors/annotations/images/:version/:level/:imageId.json
 GET /cors/annotations/combined/iiif{2|3}-level{0|1|2}.json
+GET /cors/annotations/combined/image-500-iiif3-level2.json
+GET /cors/annotations/combined/slow-iiif3-level2.json
+GET /cors/annotations/combined/mixed-slow-iiif3-level2.json
+GET /cors/annotations/combined/mixed-partof-hierarchy-iiif3-level2.json
 GET /cors/annotations/combined/mixed-iiif2-level0-level2.json
 GET /cors/annotations/combined/mixed-iiif3-level0-level2.json
 GET /cors/annotations/combined/mixed-iiif2-level0-iiif3-level2.json
@@ -52,8 +56,12 @@ GET /cors/errors/annotations/images/:imageId/bad-resource-size.json
 GET /cors/errors/annotations/images/:version/:level/:imageId/:variant.json
 GET /cors/manifests/2/:imageId.json
 GET /cors/manifests/2/:level/:imageId.json
+GET /cors/manifests/2/:imageId.json/canvas/1
+GET /cors/manifests/2/:level/:imageId.json/canvas/1
 GET /cors/manifests/3/:imageId.json
 GET /cors/manifests/3/:version/:level/:imageId.json
+GET /cors/manifests/3/:imageId.json/canvas/1
+GET /cors/manifests/3/:version/:level/:imageId.json/canvas/1
 GET /cors/manifests/3/:imageId/embedded-annotation.json
 GET /cors/manifests/3/:imageId/linked-annotation.json
 GET /cors/manifests/3/:version/:level/:imageId/embedded-annotation.json
@@ -78,6 +86,8 @@ GET /cors/manifests/3/combined/embedded-annotations.json
 GET /cors/manifests/3/combined/linked-annotations.json
 GET /cors/manifests/3/combined/image-services-iiif{2|3}-level{0|1|2}-embedded-annotations.json
 GET /cors/manifests/3/combined/image-services-iiif{2|3}-level{0|1|2}-linked-annotations.json
+GET /cors/manifests/3/combined/manifest-embedded-annotations.json
+GET /cors/manifests/3/combined/partial-manifest-embedded-annotations.json
 GET /cors/manifests/3/combined/partial-embedded-annotations.json
 GET /cors/manifests/3/combined/partial-linked-annotations.json
 GET /cors/manifests/3/combined/mixed-embedded-annotation-errors.json
@@ -86,16 +96,17 @@ GET /cors/manifests/3/combined/image-services-iiif2-level0-level2.json
 GET /cors/manifests/3/combined/image-services-iiif3-level0-level2.json
 GET /cors/manifests/3/combined/image-services-iiif2-level0-iiif3-level2.json
 GET /cors/manifests/3/combined/image-services-iiif2-level2-iiif3-level0.json
+GET /cors/manifests/3/combined/:variant.json/canvas/:canvasIndex
 GET /cors/annotations/manifests/3/combined/:variant/canvas/:canvasIndex.json
 ```
 
 The image endpoint supports IIIF Image API 2.1 and 3.0 `level0`, `level1`, and
-`level2` URLs. Level 0 serves JPEG full-image requests for dimensions listed in
-the `sizes` array, including the full image size, and JPEG tile requests
-declared by the `tiles` array in `info.json`. Higher levels support `full`,
-pixel, and percentage regions; `full`, `max`, `w,`, `,h`, `w,h`, `!w,h`, and
-`pct:n` sizes; rotation `0`; qualities `default` and `color`; and output
-formats `jpg`, `jpeg`, `png`, and `webp`.
+`level2` URLs. Level 0 omits the `sizes` array and serves only JPEG `full/full`
+or `full/max` full-image requests plus JPEG tile requests declared by the
+`tiles` array in `info.json`. Higher levels support `full`, pixel, and
+percentage regions; `full`, `max`, `w,`, `,h`, `w,h`, `!w,h`, and `pct:n`
+sizes; rotation `0`; qualities `default` and `color`; and output formats `jpg`,
+`jpeg`, `png`, and `webp`.
 
 The root catalog lists only `level0` and `level2` resources to keep the fixture
 overview compact; `level1` routes remain available for direct requests.

--- a/test/server/src/lib/components/Root.svelte
+++ b/test/server/src/lib/components/Root.svelte
@@ -528,6 +528,29 @@
                 link.label === 'All linked annotations' &&
                 isIiif3Level2(link)
             )
+          ),
+          createCombinedScenario(
+            'manifest-level-annotations',
+            'Manifest with manifest-level annotations',
+            'The combined annotation page is embedded in the top-level manifest annotations property.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
+                link.label === 'Manifest-level annotation page'
+            )
+          ),
+          createCombinedScenario(
+            'partial-manifest-level-annotations',
+            'Manifest with manifest-level and canvas-level annotations',
+            'Some georeference annotations are embedded at the manifest level, while others are embedded on their canvas.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
+                link.label ===
+                  'Some manifest-level, some canvas-level annotations'
+            )
           )
         ].filter((scenario) => scenario !== undefined)
       },
@@ -574,6 +597,47 @@
         ].filter((scenario) => scenario !== undefined)
       },
       {
+        key: 'loading-behavior',
+        label: 'Loading Behavior',
+        description:
+          'Variants for testing successful metadata fetches with failing or slow follow-up resources.',
+        scenarios: [
+          createCombinedScenario(
+            'image-requests-return-500',
+            'Info.jsons load, image requests return 500',
+            'The annotation page and image service info.jsons load, but every image request fails with a 500 response.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'All info.jsons load, image requests return 500'
+            )
+          ),
+          createCombinedScenario(
+            'slow-manifest-and-resources',
+            'Slow manifest and resources',
+            'The manifest, linked annotation pages, image service info.jsons, and image requests all respond slowly.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
+                link.label === 'Slow manifest and resources'
+            )
+          ),
+          createCombinedScenario(
+            'some-slow-some-fast-images',
+            'Some slow, some fast images',
+            'The annotation page loads normally, but some image services respond slowly while others stay fast.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'Some slow, some fast images'
+            )
+          )
+        ].filter((scenario) => scenario !== undefined)
+      },
+      {
         key: 'mixed-structure',
         label: 'Partial And Mixed Structure',
         description:
@@ -588,6 +652,17 @@
               (link) =>
                 link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
                 link.label === 'Some embedded, some linked annotations'
+            )
+          ),
+          createCombinedScenario(
+            'mixed-partof-hierarchy',
+            'All annotations with mixed hierarchy',
+            'Some annotation targets include manifest and canvas hierarchy, some omit the manifest, and some omit the canvas hierarchy.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'All annotations, mixed partOf hierarchy'
             )
           ),
           createCombinedScenario(

--- a/test/server/src/lib/paths.ts
+++ b/test/server/src/lib/paths.ts
@@ -16,9 +16,10 @@ export function getImageServiceId(
   corsMode: CorsMode,
   version: IiifVersion,
   complianceLevel: ImageComplianceLevel,
-  imageId: string
+  imageId: string,
+  suffix?: string
 ) {
-  return `${getBaseUrl(request, corsMode)}/iiif/${version}/${complianceLevel}/${imageId}`
+  return `${getBaseUrl(request, corsMode)}/iiif/${version}/${complianceLevel}/${imageId}${suffix ? `/${suffix}` : ''}`
 }
 
 export function parseCorsMode(corsMode: string): CorsMode {

--- a/test/server/src/lib/server.ts
+++ b/test/server/src/lib/server.ts
@@ -57,10 +57,17 @@ type ImageApiService = {
   complianceLevel: ImageComplianceLevel
 }
 
+type ImageServiceBehavior = 'image-500' | 'slow'
+
+type ImageApiServiceReference = ImageApiService & {
+  behavior?: ImageServiceBehavior
+}
+
 const navPlaceContext = 'http://iiif.io/api/extension/navplace/context.json'
 const presentation3Context = 'http://iiif.io/api/presentation/3/context.json'
 
 const imageDefinitions = loadImageDefinitions()
+const slowResourceDelayMs = 4_000
 
 const images = new Map(imageDefinitions.map((image) => [image.id, image]))
 const originalManifests = new Map(
@@ -487,6 +494,50 @@ function parseCombinedImageServiceManifestVariant(variant: string):
   }
 }
 
+function parseImageServiceBehavior(
+  behavior: string | undefined
+): ImageServiceBehavior | undefined {
+  if (!behavior) {
+    return undefined
+  }
+
+  if (behavior === 'image-500' || behavior === 'slow') {
+    return behavior
+  }
+
+  throw new Error(`Unknown image service behavior: ${behavior}`)
+}
+
+function getCombinedImageServiceBehavior(
+  variant: string
+): ImageServiceBehavior | undefined {
+  if (variant === 'image-500-iiif3-level2') {
+    return 'image-500'
+  }
+
+  if (variant === 'slow-iiif3-level2') {
+    return 'slow'
+  }
+
+  return undefined
+}
+
+function isSlowCombinedVariant(variant: string) {
+  return getCombinedImageServiceBehavior(variant) === 'slow'
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function delaySlowResource(variantOrBehavior: string | undefined) {
+  if (variantOrBehavior === 'slow') {
+    await delay(slowResourceDelayMs)
+  }
+}
+
 function getCombinedAnnotationVariants(baseUrl: string) {
   return [
     ...catalogImageApiServices.map((service) =>
@@ -514,6 +565,30 @@ function getCombinedAnnotationVariants(baseUrl: string) {
       'level2',
       'Mixed CORS modes, correct and incorrect annotations',
       `${baseUrl}/annotations/combined/mixed-cors-errors-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'All info.jsons load, image requests return 500',
+      `${baseUrl}/annotations/combined/image-500-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Slow annotation page and image services',
+      `${baseUrl}/annotations/combined/slow-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Some slow, some fast images',
+      `${baseUrl}/annotations/combined/mixed-slow-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'All annotations, mixed partOf hierarchy',
+      `${baseUrl}/annotations/combined/mixed-partof-hierarchy-iiif3-level2.json`
     ),
     createCombinedImageServiceLink(
       'Annotation page',
@@ -573,6 +648,18 @@ function getCombinedManifestVariants(baseUrl: string) {
     createImageApiLink(
       '3',
       'level2',
+      'Manifest-level annotation page',
+      `${baseUrl}/manifests/3/combined/manifest-embedded-annotations.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Some manifest-level, some canvas-level annotations',
+      `${baseUrl}/manifests/3/combined/partial-manifest-embedded-annotations.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
       'Mixed correct/incorrect embedded annotations',
       `${baseUrl}/manifests/3/combined/mixed-embedded-annotation-errors.json`
     ),
@@ -581,6 +668,18 @@ function getCombinedManifestVariants(baseUrl: string) {
       'level2',
       'Mixed correct/incorrect linked annotations',
       `${baseUrl}/manifests/3/combined/mixed-linked-annotation-errors.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Image requests return 500',
+      `${baseUrl}/manifests/3/combined/image-500-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Slow manifest and resources',
+      `${baseUrl}/manifests/3/combined/slow-iiif3-level2.json`
     ),
     createCombinedImageServiceLink(
       'IIIF Presentation 3.0 manifest',
@@ -615,10 +714,14 @@ function isCombinedIiif3ManifestVariant(variant: string) {
     [
       'embedded-annotations',
       'linked-annotations',
+      'manifest-embedded-annotations',
+      'partial-manifest-embedded-annotations',
       'partial-embedded-annotations',
       'partial-linked-annotations',
       'mixed-embedded-annotation-errors',
       'mixed-linked-annotation-errors',
+      'image-500-iiif3-level2',
+      'slow-iiif3-level2',
       'image-services-iiif2-level0-level1',
       'image-services-iiif3-level0-level1',
       'image-services-iiif2-level0-iiif3-level1',
@@ -646,6 +749,14 @@ function getCombinedManifestLabel(variant: string) {
     return 'Combined fixture images with linked annotations'
   }
 
+  if (variant === 'manifest-embedded-annotations') {
+    return 'Combined fixture images with annotations on the manifest'
+  }
+
+  if (variant === 'partial-manifest-embedded-annotations') {
+    return 'Combined fixture images with annotations on the manifest and on canvases'
+  }
+
   if (variant === 'partial-embedded-annotations') {
     return 'Combined fixture images with some embedded and some linked annotations'
   }
@@ -660,6 +771,14 @@ function getCombinedManifestLabel(variant: string) {
 
   if (variant === 'mixed-linked-annotation-errors') {
     return 'Combined fixture images with mixed correct/incorrect linked annotations'
+  }
+
+  if (variant === 'image-500-iiif3-level2') {
+    return 'Combined fixture images whose info.json files load but image requests return 500'
+  }
+
+  if (variant === 'slow-iiif3-level2') {
+    return 'Combined fixture images whose resources load slowly'
   }
 
   if (variant === 'image-services-iiif2-level0-level1') {
@@ -707,6 +826,18 @@ function getCombinedCanvasManifestVariant(variant: string, index: number) {
   }
 
   if (variant === 'linked-annotations') {
+    return 'linked-annotation'
+  }
+
+  if (variant === 'manifest-embedded-annotations') {
+    return 'default'
+  }
+
+  if (variant === 'partial-manifest-embedded-annotations') {
+    return index % 2 === 0 ? 'default' : 'embedded-annotation'
+  }
+
+  if (variant === 'image-500-iiif3-level2' || variant === 'slow-iiif3-level2') {
     return 'linked-annotation'
   }
 
@@ -828,7 +959,7 @@ function getCombinedTargetCorsMode(
 function getCombinedAnnotationImageService(
   variant: string,
   index: number
-): { version: IiifVersion; complianceLevel: ImageComplianceLevel } | undefined {
+): ImageApiServiceReference | undefined {
   const imageServiceVariant = parseImageApiServiceVariant(variant)
 
   if (imageServiceVariant) {
@@ -890,11 +1021,23 @@ function getCombinedAnnotationImageService(
   if (
     variant === 'mixed-cors-iiif3-level2' ||
     variant === 'mixed-errors-iiif3-level2' ||
-    variant === 'mixed-cors-errors-iiif3-level2'
+    variant === 'mixed-cors-errors-iiif3-level2' ||
+    variant === 'mixed-partof-hierarchy-iiif3-level2' ||
+    variant === 'image-500-iiif3-level2' ||
+    variant === 'slow-iiif3-level2'
   ) {
     return {
       version: '3',
-      complianceLevel: 'level2'
+      complianceLevel: 'level2',
+      behavior: getCombinedImageServiceBehavior(variant)
+    }
+  }
+
+  if (variant === 'mixed-slow-iiif3-level2') {
+    return {
+      version: '3',
+      complianceLevel: 'level2',
+      behavior: index % 2 === 0 ? undefined : 'slow'
     }
   }
 
@@ -905,9 +1048,7 @@ function applyAnnotationImageService(
   annotationPage: JsonObject,
   baseUrl: string,
   image: ImageFixture,
-  service:
-    | { version: IiifVersion; complianceLevel: ImageComplianceLevel }
-    | undefined
+  service: ImageApiServiceReference | undefined
 ) {
   if (!service || !Array.isArray(annotationPage.items)) {
     return annotationPage
@@ -918,7 +1059,13 @@ function applyAnnotationImageService(
       continue
     }
 
-    item.target.source.id = `${baseUrl}/iiif/${service.version}/${service.complianceLevel}/${image.id}`
+    item.target.source.id = getImageServiceBaseUrl(
+      baseUrl,
+      service.version,
+      service.complianceLevel,
+      image.id,
+      service.behavior
+    )
     item.target.source.type = getImageServiceType(service.version)
   }
 
@@ -973,10 +1120,86 @@ function shouldBreakCombinedAnnotation(variant: string, index: number) {
   )
 }
 
+function removeManifestPartOf(resource: JsonObject) {
+  if (!Array.isArray(resource.partOf)) {
+    return
+  }
+
+  const partOf = resource.partOf
+    .filter(
+      (parent) =>
+        typeof parent !== 'object' ||
+        parent === null ||
+        parent.type !== 'Manifest'
+    )
+    .map((parent) => {
+      if (typeof parent !== 'object' || parent === null) {
+        return parent
+      }
+
+      const parentResource = cloneJsonObject(parent)
+      removeManifestPartOf(parentResource)
+
+      return parentResource
+    })
+
+  if (partOf.length > 0) {
+    resource.partOf = partOf
+  } else {
+    delete resource.partOf
+  }
+}
+
+function removeCanvasPartOf(resource: JsonObject) {
+  if (!Array.isArray(resource.partOf)) {
+    return
+  }
+
+  const partOf = resource.partOf.filter(
+    (parent) =>
+      typeof parent !== 'object' || parent === null || parent.type !== 'Canvas'
+  )
+
+  if (partOf.length > 0) {
+    resource.partOf = partOf
+  } else {
+    delete resource.partOf
+  }
+}
+
+function applyMixedPartOfHierarchy(map: JsonObject, index: number) {
+  if (index % 3 === 0) {
+    return map
+  }
+
+  const target = map.target
+
+  if (
+    typeof target !== 'object' ||
+    target === null ||
+    typeof target.source !== 'object' ||
+    target.source === null
+  ) {
+    return map
+  }
+
+  const outputMap = cloneJsonObject(map)
+  const source = outputMap.target.source
+
+  if (index % 3 === 1) {
+    removeManifestPartOf(source)
+  } else {
+    removeCanvasPartOf(source)
+  }
+
+  return outputMap
+}
+
 function createCombinedAnnotation(
   request: Request,
   corsMode: CorsMode,
-  variant: string
+  variant: string,
+  includeImage: (image: ImageFixture, index: number) => boolean = () => true
 ) {
   if (
     parseImageApiServiceVariant(variant) === undefined &&
@@ -988,6 +1211,10 @@ function createCombinedAnnotation(
       'mixed-cors-iiif3-level2',
       'mixed-errors-iiif3-level2',
       'mixed-cors-errors-iiif3-level2',
+      'image-500-iiif3-level2',
+      'slow-iiif3-level2',
+      'mixed-slow-iiif3-level2',
+      'mixed-partof-hierarchy-iiif3-level2',
       'mixed-iiif2-level0-level1',
       'mixed-iiif3-level0-level1',
       'mixed-iiif2-level0-iiif3-level1',
@@ -1010,6 +1237,10 @@ function createCombinedAnnotation(
     id: `${baseUrl}/annotations/combined/${variant}.json`,
     type: 'AnnotationPage',
     items: getCombinedImages().flatMap((image, index) => {
+      if (!includeImage(image, index)) {
+        return []
+      }
+
       const targetCorsMode = getCombinedTargetCorsMode(corsMode, variant, index)
       const targetBaseUrl = `${url.origin}/${targetCorsMode}`
       const annotation = JSON.parse(readFileSync(image.annotationPath, 'utf8'))
@@ -1039,11 +1270,32 @@ function createCombinedAnnotation(
                     getCombinedAnnotationErrorVariant(currentAnnotationIndex)
                   )
                 : map
+              const hierarchyMap =
+                variant === 'mixed-partof-hierarchy-iiif3-level2'
+                  ? applyMixedPartOfHierarchy(outputMap, currentAnnotationIndex)
+                  : outputMap
 
-              return outputMap.id ? [outputMap] : []
+              return hierarchyMap.id ? [hierarchyMap] : []
             })
         : []
     })
+  }
+}
+
+function createManifestLevelCombinedAnnotationPage(
+  request: Request,
+  corsMode: CorsMode,
+  manifestId: string,
+  includeImage?: (image: ImageFixture, index: number) => boolean
+) {
+  return {
+    ...createCombinedAnnotation(
+      request,
+      corsMode,
+      'iiif3-level2',
+      includeImage
+    ),
+    id: `${manifestId}/annotation-page/1`
   }
 }
 
@@ -1096,7 +1348,8 @@ function createIiif3Canvas(
   index = 1,
   linkedAnnotationPageId?: string,
   imageApiVersion: IiifVersion = '3',
-  imageComplianceLevel: ImageComplianceLevel = 'level1'
+  imageComplianceLevel: ImageComplianceLevel = 'level1',
+  imageServiceBehavior?: ImageServiceBehavior
 ) {
   const canvasId = `${manifestId}/canvas/${index}`
   const annotationPageId = `${canvasId}/annotation-page/1`
@@ -1106,7 +1359,8 @@ function createIiif3Canvas(
     corsMode,
     imageApiVersion,
     imageComplianceLevel,
-    image.id
+    image.id,
+    imageServiceBehavior
   )
   const canvasLabel = image.imageLabel ?? image.label
   const imageBodyDimensions = getManifestImageBodyDimensions(image)
@@ -1196,7 +1450,7 @@ function createCombinedIiif3Manifest(
     none: [getCombinedManifestLabel(variant)]
   }
 
-  return {
+  const manifest: JsonObject = {
     '@context': presentation3Context,
     id: manifestId,
     type: 'Manifest',
@@ -1214,10 +1468,63 @@ function createCombinedIiif3Manifest(
         index + 1,
         getCombinedLinkedAnnotationPageId(baseUrl, variant, index),
         imageService.version,
-        imageService.complianceLevel
+        imageService.complianceLevel,
+        getCombinedImageServiceBehavior(variant)
       )
     })
   }
+
+  if (variant === 'manifest-embedded-annotations') {
+    manifest.annotations = [
+      createManifestLevelCombinedAnnotationPage(request, corsMode, manifestId)
+    ]
+  } else if (variant === 'partial-manifest-embedded-annotations') {
+    manifest.annotations = [
+      createManifestLevelCombinedAnnotationPage(
+        request,
+        corsMode,
+        manifestId,
+        (_image, index) => index % 2 === 0
+      )
+    ]
+  }
+
+  return manifest
+}
+
+function createCombinedIiif3CanvasResource(
+  request: Request,
+  corsMode: CorsMode,
+  variant: string,
+  canvasIndex: number
+) {
+  const baseUrl = getBaseUrl(request, corsMode)
+  const imageIndex = canvasIndex - 1
+  const image = getCombinedImages()[imageIndex]
+
+  if (!image) {
+    throw new Error(`Unknown combined manifest canvas: ${canvasIndex}`)
+  }
+
+  const manifestId = `${baseUrl}/manifests/3/combined/${variant}.json`
+  const label = {
+    none: [getCombinedManifestLabel(variant)]
+  }
+  const imageService = getCombinedCanvasImageService(variant, imageIndex)
+
+  return createIiif3Canvas(
+    request,
+    corsMode,
+    image,
+    manifestId,
+    label,
+    getCombinedCanvasManifestVariant(variant, imageIndex),
+    canvasIndex,
+    getCombinedLinkedAnnotationPageId(baseUrl, variant, imageIndex),
+    imageService.version,
+    imageService.complianceLevel,
+    getCombinedImageServiceBehavior(variant)
+  )
 }
 
 function createLinkedAnnotationPage(
@@ -1514,20 +1821,19 @@ function assertLevel0TileRequest(
     region.top === 0 &&
     region.width === image.width &&
     region.height === image.height
-  const outputDimensions = getOutputDimensions(region, size)
-  const isListedSize = getSizes(image).some(
-    (listedSize) =>
-      listedSize.width === outputDimensions.width &&
-      listedSize.height === outputDimensions.height
-  )
-
-  if (isFullRegion && !size?.fit && isListedSize) {
+  if (isFullRegion && !size) {
     return
   }
 
-  if (!size?.width || size.height || size.fit) {
+  if (isFullRegion) {
     throw new Error(
-      'Level 0 requests must use a listed full-image size or width-only tile size syntax'
+      'Level 0 only serves full/max full-image requests and tiles declared in info.json'
+    )
+  }
+
+  if (!size?.width || size.fit === 'inside') {
+    throw new Error(
+      'Level 0 requests must use full/max full-image syntax, width-only tile size syntax, or exact tile size syntax'
     )
   }
 
@@ -1535,10 +1841,12 @@ function assertLevel0TileRequest(
   const scaleFactor = Math.round(region.width / size.width)
   const expectedOutputWidth = Math.ceil(region.width / scaleFactor)
   const expectedOutputHeight = Math.ceil(region.height / scaleFactor)
+  const requestedOutputHeight = size.height ?? expectedOutputHeight
 
   if (
     !tile.scaleFactors.includes(scaleFactor) ||
     size.width !== expectedOutputWidth ||
+    requestedOutputHeight !== expectedOutputHeight ||
     expectedOutputWidth > tile.width ||
     expectedOutputHeight > tile.height ||
     region.left % (tile.width * scaleFactor) !== 0 ||
@@ -1549,7 +1857,7 @@ function assertLevel0TileRequest(
     region.top + region.height > image.height
   ) {
     throw new Error(
-      'Level 0 only serves listed full-image sizes and tiles declared in info.json'
+      'Level 0 only serves full/max full-image requests and tiles declared in info.json'
     )
   }
 }
@@ -1690,16 +1998,17 @@ function createInfoJson(
   corsMode: CorsMode,
   version: IiifVersion,
   complianceLevel: ImageComplianceLevel,
-  image: ImageFixture
+  image: ImageFixture,
+  behavior?: ImageServiceBehavior
 ) {
   const id = getImageServiceId(
     request,
     corsMode,
     version,
     complianceLevel,
-    image.id
+    image.id,
+    behavior
   )
-  const sizes = getSizes(image)
   const tiles = getTiles(image)
 
   if (version === '2') {
@@ -1740,7 +2049,7 @@ function createInfoJson(
       width: image.width,
       height: image.height,
       tiles,
-      sizes,
+      ...(complianceLevel === 'level0' ? {} : { sizes: getSizes(image) }),
       profile
     }
   }
@@ -1776,7 +2085,7 @@ function createInfoJson(
     width: image.width,
     height: image.height,
     tiles,
-    sizes,
+    ...(complianceLevel === 'level0' ? {} : { sizes: getSizes(image) }),
     profile: complianceLevel,
     ...level3Extras
   }
@@ -2110,9 +2419,10 @@ function getImageServiceBaseUrl(
   baseUrl: string,
   version: IiifVersion,
   complianceLevel: ImageComplianceLevel,
-  imageId: string
+  imageId: string,
+  behavior?: ImageServiceBehavior
 ) {
-  return `${baseUrl}/iiif/${version}/${complianceLevel}/${imageId}`
+  return `${baseUrl}/iiif/${version}/${complianceLevel}/${imageId}${behavior ? `/${behavior}` : ''}`
 }
 
 function getLevel0TileExample(image: ImageFixture, imageServiceUrl: string) {
@@ -2446,15 +2756,20 @@ async function routeFixtureRequest(
 
   if (
     segments[0] === 'iiif' &&
-    (segments.length === 3 || segments.length === 4)
+    (segments.length === 3 || segments.length === 4 || segments.length === 5) &&
+    segments.at(-1) !== 'info.json'
   ) {
     parseIiifVersion(segments[1])
 
-    if (segments.length === 4) {
+    if (segments.length >= 4) {
       parseImageComplianceLevel(segments[2])
       getImage(segments[3])
     } else {
       getImage(segments[2])
+    }
+
+    if (segments.length === 5) {
+      parseImageServiceBehavior(segments[4])
     }
 
     const url = new URL(request.url)
@@ -2465,42 +2780,67 @@ async function routeFixtureRequest(
 
   if (
     segments[0] === 'iiif' &&
-    (segments.length === 4 || segments.length === 5) &&
+    (segments.length === 4 || segments.length === 5 || segments.length === 6) &&
     segments.at(-1) === 'info.json'
   ) {
     const version = parseIiifVersion(segments[1])
-    const hasComplianceLevel = segments.length === 5
+    const hasBehavior = segments.length === 6
+    const hasComplianceLevel = segments.length >= 5
     const complianceLevel = hasComplianceLevel
       ? parseImageComplianceLevel(segments[2])
       : 'level1'
     const image = getImage(hasComplianceLevel ? segments[3] : segments[2])
+    const behavior = hasBehavior
+      ? parseImageServiceBehavior(segments[4])
+      : undefined
+
+    await delaySlowResource(behavior)
 
     return jsonResponse(
-      createInfoJson(request, corsMode, version, complianceLevel, image),
+      createInfoJson(
+        request,
+        corsMode,
+        version,
+        complianceLevel,
+        image,
+        behavior
+      ),
       corsMode
     )
   }
 
   if (
     segments[0] === 'iiif' &&
-    (segments.length === 7 || segments.length === 8)
+    (segments.length === 7 || segments.length === 8 || segments.length === 9)
   ) {
     parseIiifVersion(segments[1])
-    const hasComplianceLevel = segments.length === 8
+    const hasBehavior = segments.length === 9
+    const hasComplianceLevel = segments.length >= 8
     const complianceLevel = hasComplianceLevel
       ? parseImageComplianceLevel(segments[2])
       : 'level1'
     const offset = hasComplianceLevel ? 1 : 0
+    const requestOffset = offset + (hasBehavior ? 1 : 0)
+    const behavior = hasBehavior
+      ? parseImageServiceBehavior(segments[4])
+      : undefined
+    const image = getImage(segments[2 + offset])
+
+    await delaySlowResource(behavior)
+
+    if (behavior === 'image-500') {
+      return textResponse('Image request failed intentionally', corsMode, 500)
+    }
 
     return createImageRequestResponse(
       corsMode,
       complianceLevel,
-      getImage(segments[2 + offset]),
-      segments[3 + offset],
-      segments[4 + offset],
-      segments[5 + offset],
-      segments[6 + offset].replace(/\.(jpg|jpeg|png|webp)$/, ''),
-      segments[6 + offset]
+      image,
+      segments[3 + requestOffset],
+      segments[4 + requestOffset],
+      segments[5 + requestOffset],
+      segments[6 + requestOffset].replace(/\.(jpg|jpeg|png|webp)$/, ''),
+      segments[6 + requestOffset]
     )
   }
 
@@ -2541,12 +2881,14 @@ async function routeFixtureRequest(
   }
 
   if (segments[0] === 'annotations' && segments[1] === 'combined') {
+    const variant = parseJsonFilename(segments[2])
+
+    if (isSlowCombinedVariant(variant)) {
+      await delay(slowResourceDelayMs)
+    }
+
     return jsonResponse(
-      createCombinedAnnotation(
-        request,
-        corsMode,
-        parseJsonFilename(segments[2])
-      ),
+      createCombinedAnnotation(request, corsMode, variant),
       corsMode
     )
   }
@@ -2576,6 +2918,10 @@ async function routeFixtureRequest(
         !isLinkedAnnotationVariant(canvasVariant)
       ) {
         return textResponse('No linked annotation for canvas', corsMode, 404)
+      }
+
+      if (isSlowCombinedVariant(variant)) {
+        await delay(slowResourceDelayMs)
       }
 
       return jsonResponse(
@@ -2673,7 +3019,19 @@ async function routeFixtureRequest(
     const imageComplianceLevel = hasImageApiRoute
       ? parseImageComplianceLevel(segments[2])
       : 'level1'
-    const path = segments.slice(hasImageApiRoute ? 3 : 2).join('/')
+    const isCanvasRoute =
+      segments.length >= 5 && segments[segments.length - 2] === 'canvas'
+
+    if (
+      isCanvasRoute &&
+      parsePositiveNumber(segments[segments.length - 1], 'canvas index') !== 1
+    ) {
+      return textResponse('Unknown manifest canvas', corsMode, 404)
+    }
+
+    const path = segments
+      .slice(hasImageApiRoute ? 3 : 2, isCanvasRoute ? -2 : undefined)
+      .join('/')
     const { imageId, variant } = path.includes('/')
       ? parseVariantJsonFilename(path)
       : { imageId: parseJsonFilename(path), variant: 'default' }
@@ -2687,25 +3045,62 @@ async function routeFixtureRequest(
       return textResponse('Unknown manifest variant', corsMode, 404)
     }
 
+    const manifest = createIiif2Manifest(
+      request,
+      corsMode,
+      image,
+      variant,
+      imageComplianceLevel,
+      hasImageApiRoute
+    )
+
     return jsonResponse(
-      createIiif2Manifest(
-        request,
-        corsMode,
-        image,
-        variant,
-        imageComplianceLevel,
-        hasImageApiRoute
-      ),
+      isCanvasRoute ? manifest.sequences[0].canvases[0] : manifest,
       corsMode
     )
   }
 
   if (segments[0] === 'manifests' && segments[1] === '3') {
+    if (
+      segments[2] === 'combined' &&
+      segments.length === 6 &&
+      segments[4] === 'canvas'
+    ) {
+      const variant = parseJsonFilename(segments[3])
+      const canvasIndex = parsePositiveNumber(segments[5], 'canvas index')
+
+      if (!isCombinedIiif3ManifestVariant(variant)) {
+        return textResponse('Unknown manifest variant', corsMode, 404)
+      }
+
+      if (!getCombinedImages()[canvasIndex - 1]) {
+        return textResponse('Unknown manifest canvas', corsMode, 404)
+      }
+
+      if (isSlowCombinedVariant(variant)) {
+        await delay(slowResourceDelayMs)
+      }
+
+      return jsonResponse(
+        createCombinedIiif3CanvasResource(
+          request,
+          corsMode,
+          variant,
+          canvasIndex
+        ),
+        corsMode
+      )
+    }
+
     if (segments[2] === 'combined' && segments.length === 4) {
       const variant = parseJsonFilename(segments[3])
 
       if (!isCombinedIiif3ManifestVariant(variant)) {
         return textResponse('Unknown manifest variant', corsMode, 404)
+      }
+
+      if (isSlowCombinedVariant(variant)) {
+        await delay(slowResourceDelayMs)
       }
 
       return jsonResponse(
@@ -2724,7 +3119,19 @@ async function routeFixtureRequest(
     const imageComplianceLevel = hasImageApiRoute
       ? parseImageComplianceLevel(segments[3])
       : 'level1'
-    const imagePath = segments.slice(hasImageApiRoute ? 4 : 2).join('/')
+    const isCanvasRoute =
+      segments.length >= 5 && segments[segments.length - 2] === 'canvas'
+
+    if (
+      isCanvasRoute &&
+      parsePositiveNumber(segments[segments.length - 1], 'canvas index') !== 1
+    ) {
+      return textResponse('Unknown manifest canvas', corsMode, 404)
+    }
+
+    const imagePath = segments
+      .slice(hasImageApiRoute ? 4 : 2, isCanvasRoute ? -2 : undefined)
+      .join('/')
     const { imageId, variant } = imagePath.includes('/')
       ? parseVariantJsonFilename(imagePath)
       : { imageId: parseJsonFilename(imagePath), variant: 'default' }
@@ -2738,18 +3145,17 @@ async function routeFixtureRequest(
       return textResponse('Unknown manifest variant', corsMode, 404)
     }
 
-    return jsonResponse(
-      createIiif3Manifest(
-        request,
-        corsMode,
-        image,
-        variant,
-        imageApiVersion,
-        imageComplianceLevel,
-        hasImageApiRoute
-      ),
-      corsMode
+    const manifest = createIiif3Manifest(
+      request,
+      corsMode,
+      image,
+      variant,
+      imageApiVersion,
+      imageComplianceLevel,
+      hasImageApiRoute
     )
+
+    return jsonResponse(isCanvasRoute ? manifest.items[0] : manifest, corsMode)
   }
 
   return textResponse('Not found', corsMode, 404)


### PR DESCRIPTION
This pull request expands the test server's IIIF fixture coverage and scenario selection UI. It introduces new test routes for manifest-level and loading behavior variants, updates documentation to clarify IIIF Image API level support, and improves the flexibility of image service URL generation.

**New test scenarios and routes:**

* Added routes and UI scenarios for manifests with manifest-level annotations and for manifests mixing manifest-level and canvas-level annotations. [[1]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR89-R90) [[2]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR531-R553)
* Introduced a new "Loading Behavior" group with scenarios for error and slow-loading image requests, including partial failures and mixed-speed images. [[1]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR46-R49) [[2]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR599-R639)
* Added test routes and scenarios for annotation pages with mixed partOf hierarchies. [[1]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR46-R49) [[2]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR657-R667)

**Documentation updates:**

* Clarified the behavior of IIIF Image API level 0 endpoints in `test/server/README.md`, specifying that level 0 omits the `sizes` array and only serves full-image and tile requests.

**Test utility improvements:**

* Enhanced the `getImageServiceId` function to accept an optional `suffix`, allowing more flexible construction of image service URLs for test cases.

**Additional test routes:**

* Added new manifest canvas routes (e.g., `/canvas/1`) for both IIIF Presentation v2 and v3 manifests, and new combined annotation test routes. [[1]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR59-R64) [[2]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR46-R49)