### PR TITLE
iiif-parser now fully supports embedded annotations

### DIFF
--- a/packages/iiif-parser/src/lib/types.ts
+++ b/packages/iiif-parser/src/lib/types.ts
@@ -96,7 +96,7 @@ export type Provider = Agent[]
 export type Annotations = {
   id: string
   type: 'AnnotationPage'
-  // items?: object[]
+  items?: unknown[]
 }[]
 
 export type ConstructorOptions = {

--- a/packages/iiif-parser/test/parse.test.ts
+++ b/packages/iiif-parser/test/parse.test.ts
@@ -72,6 +72,51 @@ fs.readdirSync(inputDir)
   })
   .forEach(runTests)
 
+describe('Parsing georeference annotation pages in Presentation 3 manifests', () => {
+  test('should preserve embedded and linked canvas annotation pages', () => {
+    const embeddedManifest = IIIF.parse(
+      readJSONFile(
+        path.join(
+          inputDir,
+          'manifest.3.pica-toegankelijke-kaartcollectie-embedded-annotations.json'
+        )
+      )
+    )
+    const linkedManifest = IIIF.parse(
+      readJSONFile(
+        path.join(inputDir, 'manifest.3.pica-toegankelijke-kaartcollectie.json')
+      )
+    )
+
+    if (embeddedManifest.type !== 'manifest') {
+      throw new Error('Expected embedded fixture to parse as manifest')
+    }
+
+    if (linkedManifest.type !== 'manifest') {
+      throw new Error('Expected linked fixture to parse as manifest')
+    }
+
+    expect(
+      embeddedManifest.canvases.every((canvas) =>
+        canvas.annotations?.some(
+          (annotationPage) => annotationPage.items?.length
+        )
+      )
+    ).toBe(true)
+
+    expect(
+      linkedManifest.canvases.every((canvas) =>
+        canvas.annotations?.some(
+          (annotationPage) =>
+            annotationPage.id &&
+            annotationPage.type === 'AnnotationPage' &&
+            !annotationPage.items
+        )
+      )
+    ).toBe(true)
+  })
+})
+
 export function readJSONFile(filename: string) {
   try {
     return JSON.parse(fs.readFileSync(filename, 'utf-8'))


### PR DESCRIPTION
This pull request makes a minor update to the IIIF parser to better support annotation pages in Presentation 3 manifests. The main changes include relaxing the type of the `items` field in annotation pages and adding a test to verify correct handling of embedded and linked annotation pages.

**Type improvements:**

* Changed the `items` field in the `Annotations` type from a commented-out property to an optional property of type `unknown[]`, allowing for more flexible annotation page structures.

**Test enhancements:**

* Added a test to ensure that both embedded and linked canvas annotation pages are correctly preserved during parsing, improving test coverage for Presentation 3 manifests.