### PR TITLE
added requestedtilesloading event, improved return type when adding multiple maps, improved error handling

### DIFF
--- a/packages/leaflet/src/WarpedMapLayer.ts
+++ b/packages/leaflet/src/WarpedMapLayer.ts
@@ -16,7 +16,9 @@ import {
   AnimationOptions,
   BaseRenderOptions,
   Sprite,
-  WarpedMapListOptions
+  WarpedMapListOptions,
+  BatchMapResult,
+  BatchOptions
 } from '@allmaps/render'
 import {
   rectangleToSize,
@@ -431,13 +433,15 @@ export class WarpedMapLayer
    */
   addGeoreferenceAnnotation(
     annotation: unknown,
-    mapOptions?: Partial<WebGL2WarpedMapOptions>
-  ): (string | Error)[] {
+    mapOptions?: Partial<WebGL2WarpedMapOptions>,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     BaseWarpedMapLayer.assertRenderer(this.renderer)
 
     const results = this.renderer.addGeoreferenceAnnotation(
       annotation,
-      mapOptions
+      mapOptions,
+      batchOptions
     )
     this.nativeUpdate()
 
@@ -450,11 +454,16 @@ export class WarpedMapLayer
    * @param annotation - Georeference Annotation
    * @returns Map IDs of the maps that were removed, or an error per map
    */
-  removeGeoreferenceAnnotation(annotation: unknown): (string | Error)[] {
+  removeGeoreferenceAnnotation(
+    annotation: unknown,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     BaseWarpedMapLayer.assertRenderer(this.renderer)
 
-    const results =
-      this.renderer.warpedMapList.removeGeoreferenceAnnotation(annotation)
+    const results = this.renderer.warpedMapList.removeGeoreferenceAnnotation(
+      annotation,
+      batchOptions
+    )
     this.nativeUpdate()
 
     return results
@@ -469,13 +478,14 @@ export class WarpedMapLayer
    */
   async addGeoreferenceAnnotationByUrl(
     annotationUrl: string,
-    mapOptions?: Partial<WebGL2WarpedMapOptions>
-  ): Promise<(string | Error)[]> {
+    mapOptions?: Partial<WebGL2WarpedMapOptions>,
+    batchOptions?: Partial<BatchOptions>
+  ): Promise<BatchMapResult[]> {
     const annotation = await fetch(annotationUrl).then((response) =>
       response.json()
     )
 
-    return this.addGeoreferenceAnnotation(annotation, mapOptions)
+    return this.addGeoreferenceAnnotation(annotation, mapOptions, batchOptions)
   }
 
   /**
@@ -485,12 +495,13 @@ export class WarpedMapLayer
    * @returns Map IDs of the maps that were removed, or an error per map
    */
   async removeGeoreferenceAnnotationByUrl(
-    annotationUrl: string
-  ): Promise<(string | Error)[]> {
+    annotationUrl: string,
+    batchOptions?: Partial<BatchOptions>
+  ): Promise<BatchMapResult[]> {
     const annotation = await fetch(annotationUrl).then((response) =>
       response.json()
     )
-    return this.removeGeoreferenceAnnotation(annotation)
+    return this.removeGeoreferenceAnnotation(annotation, batchOptions)
   }
 
   /**
@@ -1444,6 +1455,11 @@ export class WarpedMapLayer
       this.nativePassWarpedMapEvent.bind(this)
     )
 
+    this.renderer.tileCache.addEventListener(
+      WarpedMapEventType.TILEFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
     this.renderer.spritesTileCache.addEventListener(
       WarpedMapEventType.MAPTILESLOADEDFROMSPRITES,
       this.nativePassWarpedMapEvent.bind(this)
@@ -1456,6 +1472,11 @@ export class WarpedMapLayer
 
     this.renderer.tileCache.addEventListener(
       WarpedMapEventType.FIRSTMAPTILELOADED,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.tileCache.addEventListener(
+      WarpedMapEventType.REQUESTEDTILESLOADING,
       this.nativePassWarpedMapEvent.bind(this)
     )
 
@@ -1540,6 +1561,11 @@ export class WarpedMapLayer
       this.nativePassWarpedMapEvent.bind(this)
     )
 
+    this.renderer.tileCache.removeEventListener(
+      WarpedMapEventType.TILEFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
     this.renderer.spritesTileCache.removeEventListener(
       WarpedMapEventType.MAPTILESLOADEDFROMSPRITES,
       this.nativePassWarpedMapEvent.bind(this)
@@ -1552,6 +1578,11 @@ export class WarpedMapLayer
 
     this.renderer.tileCache.removeEventListener(
       WarpedMapEventType.FIRSTMAPTILELOADED,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.tileCache.removeEventListener(
+      WarpedMapEventType.REQUESTEDTILESLOADING,
       this.nativePassWarpedMapEvent.bind(this)
     )
 

--- a/packages/openlayers/src/WarpedMapLayer.ts
+++ b/packages/openlayers/src/WarpedMapLayer.ts
@@ -19,7 +19,9 @@ import type {
   AnimationOptions,
   WarpedMapList,
   Sprite,
-  WarpedMapListOptions
+  WarpedMapListOptions,
+  BatchMapResult,
+  BatchOptions
 } from '@allmaps/render'
 import type {
   WebGL2RenderOptions,
@@ -307,13 +309,15 @@ export class WarpedMapLayer
    */
   addGeoreferenceAnnotation(
     annotation: unknown,
-    mapOptions?: Partial<WebGL2WarpedMapOptions>
-  ): (string | Error)[] {
+    mapOptions?: Partial<WebGL2WarpedMapOptions>,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     BaseWarpedMapLayer.assertRenderer(this.renderer)
 
     const results = this.renderer.addGeoreferenceAnnotation(
       annotation,
-      mapOptions
+      mapOptions,
+      batchOptions
     )
     this.nativeUpdate()
 
@@ -326,11 +330,16 @@ export class WarpedMapLayer
    * @param annotation - Georeference Annotation
    * @returns Map IDs of the maps that were removed, or an error per map
    */
-  removeGeoreferenceAnnotation(annotation: unknown): (string | Error)[] {
+  removeGeoreferenceAnnotation(
+    annotation: unknown,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     BaseWarpedMapLayer.assertRenderer(this.renderer)
 
-    const results =
-      this.renderer.warpedMapList.removeGeoreferenceAnnotation(annotation)
+    const results = this.renderer.warpedMapList.removeGeoreferenceAnnotation(
+      annotation,
+      batchOptions
+    )
     this.nativeUpdate()
 
     return results
@@ -345,13 +354,14 @@ export class WarpedMapLayer
    */
   async addGeoreferenceAnnotationByUrl(
     annotationUrl: string,
-    mapOptions?: Partial<WebGL2WarpedMapOptions>
-  ): Promise<(string | Error)[]> {
+    mapOptions?: Partial<WebGL2WarpedMapOptions>,
+    batchOptions?: Partial<BatchOptions>
+  ): Promise<BatchMapResult[]> {
     const annotation = await fetch(annotationUrl).then((response) =>
       response.json()
     )
 
-    return this.addGeoreferenceAnnotation(annotation, mapOptions)
+    return this.addGeoreferenceAnnotation(annotation, mapOptions, batchOptions)
   }
 
   /**
@@ -361,12 +371,13 @@ export class WarpedMapLayer
    * @returns Map IDs of the maps that were removed, or an error per map
    */
   async removeGeoreferenceAnnotationByUrl(
-    annotationUrl: string
-  ): Promise<(string | Error)[]> {
+    annotationUrl: string,
+    batchOptions?: Partial<BatchOptions>
+  ): Promise<BatchMapResult[]> {
     const annotation = await fetch(annotationUrl).then((response) =>
       response.json()
     )
-    return this.removeGeoreferenceAnnotation(annotation)
+    return this.removeGeoreferenceAnnotation(annotation, batchOptions)
   }
 
   /**
@@ -1320,6 +1331,11 @@ export class WarpedMapLayer
       this.nativePassWarpedMapEvent.bind(this)
     )
 
+    this.renderer.tileCache.addEventListener(
+      WarpedMapEventType.TILEFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
     this.renderer.spritesTileCache.addEventListener(
       WarpedMapEventType.MAPTILESLOADEDFROMSPRITES,
       this.nativePassWarpedMapEvent.bind(this)
@@ -1332,6 +1348,11 @@ export class WarpedMapLayer
 
     this.renderer.tileCache.addEventListener(
       WarpedMapEventType.FIRSTMAPTILELOADED,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.tileCache.addEventListener(
+      WarpedMapEventType.REQUESTEDTILESLOADING,
       this.nativePassWarpedMapEvent.bind(this)
     )
 
@@ -1416,6 +1437,11 @@ export class WarpedMapLayer
       this.nativePassWarpedMapEvent.bind(this)
     )
 
+    this.renderer.tileCache.removeEventListener(
+      WarpedMapEventType.TILEFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
     this.renderer.spritesTileCache.removeEventListener(
       WarpedMapEventType.MAPTILESLOADEDFROMSPRITES,
       this.nativePassWarpedMapEvent.bind(this)
@@ -1428,6 +1454,11 @@ export class WarpedMapLayer
 
     this.renderer.tileCache.removeEventListener(
       WarpedMapEventType.FIRSTMAPTILELOADED,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.tileCache.removeEventListener(
+      WarpedMapEventType.REQUESTEDTILESLOADING,
       this.nativePassWarpedMapEvent.bind(this)
     )
 

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -38,6 +38,7 @@
     "watch": "vite build --watch",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "NODE_ENV=test vitest run",
     "lint": "prettier --ignore-path ../../.gitignore --check src && eslint src --ext .js,.ts",
     "types": "tsc --noEmit",
     "format": "prettier --ignore-path ../../.gitignore --write src",
@@ -80,6 +81,7 @@
     "remark-cli": "^12.0.1",
     "typescript": "catalog:",
     "vite": "catalog:",
+    "vitest": "^4.0.4",
     "vite-plugin-dts": "^3.8.3",
     "vite-plugin-glsl": "^1.3.0",
     "vite-plugin-no-bundle": "^4.0.0"

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -27,6 +27,11 @@ export type {
   MaskOptions,
   ProjectionOptions,
   TransformationOptions,
+  BatchFailureMode,
+  BatchOptions,
+  BatchMapSuccess,
+  BatchMapError,
+  BatchMapResult,
   Sprite,
   SpritesInfo
 } from './shared/types.js'

--- a/packages/render/src/maps/WarpedMapList.ts
+++ b/packages/render/src/maps/WarpedMapList.ts
@@ -40,6 +40,8 @@ import type { Ring, Bbox, Point } from '@allmaps/types'
 import type { Projection } from '@allmaps/project'
 
 import type {
+  BatchMapResult,
+  BatchOptions,
   GetWarpedMapOptions,
   ProjectionOptions,
   SelectionOptions,
@@ -116,7 +118,8 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
         'distortionMeasure'
       ],
       projection: webMercatorProjection,
-      warpedMapFactory: createWarpedMapFactory<W>()
+      warpedMapFactory: createWarpedMapFactory<W>(),
+      batchFailureMode: 'best-effort'
     }
 
     this.warpedMapsById = new Map()
@@ -171,7 +174,8 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
 
   addGeoreferencedMaps(
     georeferencedMaps: unknown,
-    mapOptions?: Partial<GetWarpedMapOptions<W>>
+    mapOptions?: Partial<GetWarpedMapOptions<W>>,
+    batchOptions?: Partial<BatchOptions>
   ) {
     const validatedGeoreferencedMapOrMaps =
       validateGeoreferencedMap(georeferencedMaps)
@@ -184,7 +188,8 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
 
     const results = this.#addGeoreferencedMapsInternal(
       validatedGeoreferencedMaps,
-      mapOptions
+      mapOptions,
+      batchOptions
     )
 
     this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.CHANGED))
@@ -215,7 +220,10 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
     return results
   }
 
-  removeGeoreferencedMaps(georeferencedMaps: unknown): (string | Error)[] {
+  removeGeoreferencedMaps(
+    georeferencedMaps: unknown,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     const validatedGeoreferencedMapOrMaps =
       validateGeoreferencedMap(georeferencedMaps)
 
@@ -226,7 +234,8 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
       : [validatedGeoreferencedMapOrMaps]
 
     const results = this.#removeGeoreferencedMapsInternal(
-      validatedGeoreferencedMaps
+      validatedGeoreferencedMaps,
+      batchOptions
     )
 
     this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.CHANGED))
@@ -254,10 +263,15 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
    */
   addGeoreferenceAnnotation(
     annotation: unknown,
-    mapOptions?: Partial<GetWarpedMapOptions<W>>
+    mapOptions?: Partial<GetWarpedMapOptions<W>>,
+    batchOptions?: Partial<BatchOptions>
   ) {
     const maps = parseAnnotation(annotation)
-    const results = this.#addGeoreferencedMapsInternal(maps, mapOptions)
+    const results = this.#addGeoreferencedMapsInternal(
+      maps,
+      mapOptions,
+      batchOptions
+    )
     this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.CHANGED))
     return results
   }
@@ -268,9 +282,12 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
    * @param annotation
    * @returns Map IDs of the maps that were removed, or an error per map
    */
-  removeGeoreferenceAnnotation(annotation: unknown): (string | Error)[] {
+  removeGeoreferenceAnnotation(
+    annotation: unknown,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     const maps = parseAnnotation(annotation)
-    const results = this.#removeGeoreferencedMapsInternal(maps)
+    const results = this.#removeGeoreferencedMapsInternal(maps, batchOptions)
     this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.CHANGED))
     return results
   }
@@ -287,30 +304,57 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
    * It is import to do this after the event listeners on the warpedmaplist
    * are added to the renderer, so the WARPEDMAPADDED event is passed.
    */
-  updateWarpedMapsUsingFactory() {
-    for (const warpedMap of this.warpedMapsById.values()) {
-      const updatedWarpedMap = this.options.warpedMapFactory(
-        warpedMap.mapId,
-        warpedMap.georeferencedMap,
-        this.options,
-        warpedMap.mapOptions as Partial<GetWarpedMapOptions<W>>
-      )
+  updateWarpedMapsUsingFactory(
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
+    const results: BatchMapResult[] = []
 
-      this.warpedMapsById.set(warpedMap.mapId, updatedWarpedMap)
+    for (const [index, warpedMap] of Array.from(
+      this.warpedMapsById.values()
+    ).entries()) {
+      try {
+        const updatedWarpedMap = this.options.warpedMapFactory(
+          warpedMap.mapId,
+          warpedMap.georeferencedMap,
+          this.options,
+          warpedMap.mapOptions as Partial<GetWarpedMapOptions<W>>
+        )
 
-      // Note: zIndices don't have to be updated since they only use mapId
-      // Note: RTree doesn't have to be updated since they only use mapId and geoMask
+        this.warpedMapsById.set(warpedMap.mapId, updatedWarpedMap)
+        this.#removeEventListenersFromWarpedMap(warpedMap)
+        warpedMap.destroy()
 
-      this.#addEventListenersToWarpedMap(updatedWarpedMap)
+        // Note: zIndices don't have to be updated since they only use mapId
+        // Note: RTree doesn't have to be updated since they only use mapId and geoMask
 
-      this.dispatchEvent(
-        new WarpedMapEvent(WarpedMapEventType.WARPEDMAPADDED, {
-          mapIds: [warpedMap.mapId]
+        this.#addEventListenersToWarpedMap(updatedWarpedMap)
+
+        this.dispatchEvent(
+          new WarpedMapEvent(WarpedMapEventType.WARPEDMAPADDED, {
+            mapIds: [warpedMap.mapId]
+          })
+        )
+
+        results.push({ ok: true, mapId: warpedMap.mapId, index })
+      } catch (error) {
+        const batchError = ensureError(error)
+
+        if (this.#getBatchFailureMode(batchOptions) === 'fail-fast') {
+          throw batchError
+        }
+
+        this.#removeGeoreferencedMapByIdInternal(warpedMap.mapId)
+        this.#dispatchBatchError(batchError, warpedMap.mapId)
+        results.push({
+          ok: false,
+          error: batchError,
+          index,
+          mapId: warpedMap.mapId
         })
-      )
+      }
     }
 
-    return this
+    return results
   }
 
   /**
@@ -1168,18 +1212,27 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
 
   #addGeoreferencedMapsInternal(
     georeferencedMaps: GeoreferencedMap[],
-    mapOptions?: Partial<GetWarpedMapOptions<W>>
-  ) {
-    const results: (string | Error)[] = []
-    for (const georeferencedMap of georeferencedMaps) {
+    mapOptions?: Partial<GetWarpedMapOptions<W>>,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
+    const results: BatchMapResult[] = []
+    for (const [index, georeferencedMap] of georeferencedMaps.entries()) {
+      const mapId = this.#getOrComputeMapId(georeferencedMap)
       try {
-        const mapId = this.#addGeoreferencedMapInternal(
+        const addedMapId = this.#addGeoreferencedMapInternal(
           georeferencedMap,
           mapOptions
         )
-        results.push(mapId)
+        results.push({ ok: true, mapId: addedMapId, index })
       } catch (error) {
-        results.push(ensureError(error))
+        const batchError = ensureError(error)
+
+        if (this.#getBatchFailureMode(batchOptions) === 'fail-fast') {
+          throw batchError
+        }
+
+        this.#dispatchBatchError(batchError, mapId)
+        results.push({ ok: false, error: batchError, index, mapId })
       }
     }
 
@@ -1205,6 +1258,7 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
       this.#removeZIndexHoles()
       this.dispatchEvent(new WarpedMapEvent(WarpedMapEventType.CHANGED))
 
+      this.#removeEventListenersFromWarpedMap(warpedMap)
       warpedMap.destroy()
     } else {
       throw new Error(`No map found with ID ${mapId}`)
@@ -1213,20 +1267,44 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
   }
 
   #removeGeoreferencedMapsInternal(
-    georeferencedMaps: GeoreferencedMap[]
-  ): (string | Error)[] {
-    const results: (string | Error)[] = []
+    georeferencedMaps: GeoreferencedMap[],
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
+    const results: BatchMapResult[] = []
 
-    for (const georeferencedMap of georeferencedMaps) {
+    for (const [index, georeferencedMap] of georeferencedMaps.entries()) {
+      let mapId: string | undefined
       try {
-        const mapId = this.#removeGeoreferencedMapInternal(georeferencedMap)
-        results.push(mapId)
+        mapId = this.#getOrComputeMapId(georeferencedMap)
+        this.#removeGeoreferencedMapByIdInternal(mapId)
+        results.push({ ok: true, mapId, index })
       } catch (error) {
-        results.push(ensureError(error))
+        const batchError = ensureError(error)
+
+        if (this.#getBatchFailureMode(batchOptions) === 'fail-fast') {
+          throw batchError
+        }
+
+        this.#dispatchBatchError(batchError, mapId)
+        results.push({ ok: false, error: batchError, index, mapId })
       }
     }
 
     return results
+  }
+
+  #getBatchFailureMode(batchOptions?: Partial<BatchOptions>) {
+    return batchOptions?.failureMode ?? this.options.batchFailureMode
+  }
+
+  #dispatchBatchError(error: Error, mapId?: string): void {
+    this.dispatchEvent(
+      new WarpedMapErrorEvent(
+        error,
+        mapId ? { mapIds: [mapId] } : undefined,
+        WarpedMapEventType.ERROR
+      )
+    )
   }
 
   #getOrComputeMapId(georeferencedMap: GeoreferencedMap): string {
@@ -1512,10 +1590,7 @@ export class WarpedMapList<W extends WarpedMap> extends EventTarget {
       boundImageInfoFetchError
     )
 
-    warpedMap.addEventListener(
-      WarpedMapEventType.IMAGELOADED,
-      boundImageLoaded
-    )
+    warpedMap.addEventListener(WarpedMapEventType.IMAGELOADED, boundImageLoaded)
     warpedMap.addEventListener(
       WarpedMapEventType.IMAGEINFOFETCHERROR,
       boundImageInfoFetchError

--- a/packages/render/src/renderers/BaseRenderer.ts
+++ b/packages/render/src/renderers/BaseRenderer.ts
@@ -41,7 +41,9 @@ import type {
   SpritesInfo,
   Sprite,
   WarpedMapListOptions,
-  WebGL2WarpedMapOptions
+  WebGL2WarpedMapOptions,
+  BatchMapResult,
+  BatchOptions
 } from '../shared/types.js'
 
 /**
@@ -68,6 +70,7 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
   #boundMapTileDeleted = this.mapTileDeleted.bind(this)
   #boundImageLoaded = this.imageLoaded.bind(this)
   #boundImageInfoFetchError = this.imageInfoFetchError.bind(this)
+  #boundError = this.error.bind(this)
   #boundWarpedMapAdded = this.warpedMapAdded.bind(this)
   #boundWarpedMapRemoved = this.warpedMapRemoved.bind(this)
   #boundPrepareChange = this.prepareChange.bind(this)
@@ -131,9 +134,14 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
    */
   addGeoreferenceAnnotation(
     annotation: unknown,
-    mapOptions?: Partial<GetWarpedMapOptions<W>>
+    mapOptions?: Partial<GetWarpedMapOptions<W>>,
+    batchOptions?: Partial<BatchOptions>
   ) {
-    return this.warpedMapList.addGeoreferenceAnnotation(annotation, mapOptions)
+    return this.warpedMapList.addGeoreferenceAnnotation(
+      annotation,
+      mapOptions,
+      batchOptions
+    )
   }
 
   /**
@@ -147,6 +155,18 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
     mapOptions?: Partial<GetWarpedMapOptions<W>>
   ) {
     return this.warpedMapList.addGeoreferencedMap(georeferencedMap, mapOptions)
+  }
+
+  addGeoreferencedMaps(
+    georeferencedMaps: unknown,
+    mapOptions?: Partial<GetWarpedMapOptions<W>>,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
+    return this.warpedMapList.addGeoreferencedMaps(
+      georeferencedMaps,
+      mapOptions,
+      batchOptions
+    )
   }
 
   async addSprites(sprites: Sprite[], imageUrl: string, imageSize: Size) {
@@ -1214,6 +1234,18 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   protected imageInfoFetchError(event: Event): void {}
 
+  protected error(event: Event): void {
+    if (event instanceof WarpedMapErrorEvent) {
+      this.dispatchEvent(
+        new WarpedMapErrorEvent(
+          event.error,
+          event.data,
+          WarpedMapEventType.ERROR
+        )
+      )
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
   protected warpedMapAdded(event: Event): void {}
 
@@ -1241,6 +1273,10 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
     this.warpedMapList.addEventListener(
       WarpedMapEventType.IMAGELOADED,
       this.#boundImageLoaded
+    )
+    this.warpedMapList.addEventListener(
+      WarpedMapEventType.ERROR,
+      this.#boundError
     )
     this.warpedMapList.addEventListener(
       WarpedMapEventType.IMAGEINFOFETCHERROR,
@@ -1284,6 +1320,10 @@ export abstract class BaseRenderer<W extends WarpedMap, D> extends EventTarget {
     this.warpedMapList.removeEventListener(
       WarpedMapEventType.IMAGEINFOFETCHERROR,
       this.#boundImageInfoFetchError
+    )
+    this.warpedMapList.removeEventListener(
+      WarpedMapEventType.ERROR,
+      this.#boundError
     )
     this.warpedMapList.removeEventListener(
       WarpedMapEventType.WARPEDMAPADDED,

--- a/packages/render/src/shared/events.ts
+++ b/packages/render/src/shared/events.ts
@@ -26,6 +26,7 @@ export const WarpedMapEventType = {
   MAPTILESLOADEDFROMSPRITES: 'maptilesloadedfromsprites',
   MAPTILEDELETED: 'maptiledeleted',
   FIRSTMAPTILELOADED: 'firstmaptileloaded',
+  REQUESTEDTILESLOADING: 'requestedtilesloading',
   ALLREQUESTEDTILESLOADED: 'allrequestedtilesloaded',
 
   // WebGL2WarpedMap > WebGL2Renderer

--- a/packages/render/src/shared/types.ts
+++ b/packages/render/src/shared/types.ts
@@ -47,6 +47,27 @@ export type TransformationOptions = {
   options?: unknown
 }
 
+export type BatchFailureMode = 'fail-fast' | 'best-effort'
+
+export type BatchOptions = {
+  failureMode: BatchFailureMode
+}
+
+export type BatchMapSuccess = {
+  ok: true
+  mapId: string
+  index: number
+}
+
+export type BatchMapError = {
+  ok: false
+  error: Error
+  index: number
+  mapId?: string
+}
+
+export type BatchMapResult = BatchMapSuccess | BatchMapError
+
 export type GeoreferencedMapOptions = {
   gcps: Gcp[]
   resourceMask: Ring
@@ -154,6 +175,7 @@ export type SpecificWarpedMapListOptions<W extends WarpedMap> = {
   animatedOptions: Array<keyof WebGL2WarpedMapOptions>
   projection: Projection
   warpedMapFactory: WarpedMapFactory<W>
+  batchFailureMode: BatchFailureMode
 }
 export type WarpedMapListOptions<W extends WarpedMap> =
   SpecificWarpedMapListOptions<W> & Partial<WebGL2WarpedMapOptions>

--- a/packages/render/src/tilecache/CacheableImageBitmapTile.ts
+++ b/packages/render/src/tilecache/CacheableImageBitmapTile.ts
@@ -2,7 +2,6 @@ import { fetchUrl } from '@allmaps/stdlib'
 
 import { FetchableTile } from './FetchableTile.js'
 import { CacheableTile } from './CacheableTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
 
 import type { FetchFn } from '@allmaps/types'
 
@@ -33,21 +32,13 @@ export class CacheableImageBitmapTile extends CacheableTile<ImageBitmap> {
         this.fetchableTile.tile.tileZoomLevel.height
       )
 
-      this.dispatchEvent(
-        new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
-          tileUrl: this.fetchableTile.tileUrl
-        })
-      )
+      this.dispatchTileFetched()
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (this.isAbortError(err)) {
         // fetchImage was aborted because viewport was moved and tile
         // is no longer needed. This error can be ignored, nothing to do.
       } else {
-        this.dispatchEvent(
-          new WarpedMapEvent(WarpedMapEventType.TILEFETCHERROR, {
-            tileUrl: this.fetchableTile.tileUrl
-          })
-        )
+        this.dispatchTileFetchError(err)
       }
     }
 

--- a/packages/render/src/tilecache/CacheableImageDataTile.ts
+++ b/packages/render/src/tilecache/CacheableImageDataTile.ts
@@ -2,7 +2,6 @@ import { fetchUrl } from '@allmaps/stdlib'
 
 import { FetchableTile } from './FetchableTile.js'
 import { CacheableTile } from './CacheableTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
 
 import type { FetchFn } from '@allmaps/types'
 
@@ -40,21 +39,13 @@ export class CacheableImageDataTile extends CacheableTile<ImageData> {
       context.drawImage(bitmap, 0, 0)
       this.data = context.getImageData(0, 0, width, height)
 
-      this.dispatchEvent(
-        new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
-          tileUrl: this.fetchableTile.tileUrl
-        })
-      )
+      this.dispatchTileFetched()
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (this.isAbortError(err)) {
         // fetchImage was aborted because viewport was moved and tile
         // is no longer needed. This error can be ignored, nothing to do.
       } else {
-        this.dispatchEvent(
-          new WarpedMapEvent(WarpedMapEventType.TILEFETCHERROR, {
-            tileUrl: this.fetchableTile.tileUrl
-          })
-        )
+        this.dispatchTileFetchError(err)
       }
     }
 

--- a/packages/render/src/tilecache/CacheableIntArrayTile.ts
+++ b/packages/render/src/tilecache/CacheableIntArrayTile.ts
@@ -2,7 +2,6 @@ import { fetchUrl } from '@allmaps/stdlib'
 
 import { FetchableTile } from './FetchableTile.js'
 import { CacheableTile } from './CacheableTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
 
 import type { FetchFn } from '@allmaps/types'
 
@@ -42,21 +41,13 @@ export class CacheableIntArrayTile<D> extends CacheableTile<D> {
       const arrayBuffer = await response.arrayBuffer()
       this.data = this.getImageData(new Uint8ClampedArray(arrayBuffer))
 
-      this.dispatchEvent(
-        new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
-          tileUrl: this.fetchableTile.tileUrl
-        })
-      )
+      this.dispatchTileFetched()
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (this.isAbortError(err)) {
         // fetchImage was aborted because viewport was moved and tile
         // is no longer needed. This error can be ignored, nothing to do.
       } else {
-        this.dispatchEvent(
-          new WarpedMapEvent(WarpedMapEventType.TILEFETCHERROR, {
-            tileUrl: this.fetchableTile.tileUrl
-          })
-        )
+        this.dispatchTileFetchError(err)
       }
     }
 

--- a/packages/render/src/tilecache/CacheableRawJpegTile.ts
+++ b/packages/render/src/tilecache/CacheableRawJpegTile.ts
@@ -2,7 +2,6 @@ import { fetchUrl } from '@allmaps/stdlib'
 
 import { FetchableTile } from './FetchableTile.js'
 import { CacheableTile } from './CacheableTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
 
 import type { FetchFn } from '@allmaps/types'
 
@@ -64,21 +63,13 @@ export class CacheableRawJpegTile extends CacheableTile<RawJpegData> {
         height
       }
 
-      this.dispatchEvent(
-        new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
-          tileUrl: this.fetchableTile.tileUrl
-        })
-      )
+      this.dispatchTileFetched()
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (this.isAbortError(err)) {
         // fetchImage was aborted because viewport was moved and tile
         // is no longer needed. This error can be ignored, nothing to do.
       } else {
-        this.dispatchEvent(
-          new WarpedMapEvent(WarpedMapEventType.TILEFETCHERROR, {
-            tileUrl: this.fetchableTile.tileUrl
-          })
-        )
+        this.dispatchTileFetchError(err)
       }
     }
 

--- a/packages/render/src/tilecache/CacheableTile.ts
+++ b/packages/render/src/tilecache/CacheableTile.ts
@@ -1,8 +1,17 @@
 import { FetchableTile } from './FetchableTile.js'
 
-import { bufferBboxByRatio, doBboxesIntersect } from '@allmaps/stdlib'
+import {
+  ResourceFetchError,
+  bufferBboxByRatio,
+  doBboxesIntersect
+} from '@allmaps/stdlib'
 
 import { computeBboxTile } from '../shared/tiles.js'
+import {
+  WarpedMapErrorEvent,
+  WarpedMapEvent,
+  WarpedMapEventType
+} from '../shared/events.js'
 
 import type { FetchFn } from '@allmaps/types'
 
@@ -76,6 +85,55 @@ export abstract class CacheableTile<D> extends EventTarget {
     if (!this.abortController.signal.aborted) {
       this.abortController.abort()
     }
+  }
+
+  protected isAbortError(error: unknown) {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      error.name === 'AbortError'
+    )
+  }
+
+  protected dispatchTileFetched() {
+    this.dispatchEvent(
+      new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
+        mapIds: [this.fetchableTile.mapId],
+        tileUrl: this.fetchableTile.tileUrl
+      })
+    )
+  }
+
+  protected dispatchTileFetchError(error: unknown) {
+    const normalizedError =
+      error instanceof Error ? error : new Error(String(error))
+    const resourceFetchError =
+      normalizedError instanceof ResourceFetchError ? normalizedError : undefined
+    const errorLike = normalizedError as Partial<ResourceFetchError>
+    const errorKind =
+      resourceFetchError?.kind ??
+      (typeof errorLike.kind === 'string' ? errorLike.kind : 'unknown')
+    const corsLikely =
+      resourceFetchError?.corsLikely ??
+      (typeof errorLike.corsLikely === 'boolean' ? errorLike.corsLikely : false)
+    const status =
+      resourceFetchError?.status ??
+      (typeof errorLike.status === 'number' ? errorLike.status : undefined)
+
+    this.dispatchEvent(
+      new WarpedMapErrorEvent(
+        normalizedError,
+        {
+          mapIds: [this.fetchableTile.mapId],
+          tileUrl: this.fetchableTile.tileUrl,
+          errorKind,
+          corsLikely,
+          status
+        },
+        WarpedMapEventType.TILEFETCHERROR
+      )
+    )
   }
 
   shouldPrune(

--- a/packages/render/src/tilecache/CacheableWorkerImageBitmapTile.ts
+++ b/packages/render/src/tilecache/CacheableWorkerImageBitmapTile.ts
@@ -2,7 +2,6 @@ import { proxy as comlinkProxy, wrap as comlinkWrap } from 'comlink'
 
 import { FetchableTile } from './FetchableTile.js'
 import { CacheableTile } from './CacheableTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
 
 import type { FetchFn } from '@allmaps/types'
 import type { FetchAndGetImageBitmapWorkerType } from '../workers/fetch-and-get-image-bitmap.js'
@@ -30,32 +29,21 @@ export class CacheableWorkerImageBitmapTile extends CacheableTile<ImageBitmap> {
       const wrappedWorker = comlinkWrap<FetchAndGetImageBitmapWorkerType>(
         this.#worker
       )
-      wrappedWorker
-        .getImageBitmap(
-          this.fetchableTile.tileUrl,
-          comlinkProxy(this.abortController.signal),
-          this.fetchFn,
-          this.fetchableTile.tile.tileZoomLevel.width,
-          this.fetchableTile.tile.tileZoomLevel.height
-        )
-        .then((response) => {
-          this.data = response
-          this.dispatchEvent(
-            new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
-              tileUrl: this.fetchableTile.tileUrl
-            })
-          )
-        })
+      this.data = await wrappedWorker.getImageBitmap(
+        this.fetchableTile.tileUrl,
+        comlinkProxy(this.abortController.signal),
+        this.fetchFn,
+        this.fetchableTile.tile.tileZoomLevel.width,
+        this.fetchableTile.tile.tileZoomLevel.height
+      )
+
+      this.dispatchTileFetched()
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (this.isAbortError(err)) {
         // fetchImage was aborted because viewport was moved and tile
         // is no longer needed. This error can be ignored, nothing to do.
       } else {
-        this.dispatchEvent(
-          new WarpedMapEvent(WarpedMapEventType.TILEFETCHERROR, {
-            tileUrl: this.fetchableTile.tileUrl
-          })
-        )
+        this.dispatchTileFetchError(err)
       }
     }
 

--- a/packages/render/src/tilecache/CacheableWorkerImageDataTile.ts
+++ b/packages/render/src/tilecache/CacheableWorkerImageDataTile.ts
@@ -36,39 +36,21 @@ export class CacheableWorkerImageDataTile extends CacheableTile<ImageData> {
    */
   async fetch() {
     try {
-      this.#worker
-        .getImageData(
-          this.fetchableTile.tileUrl,
-          comlinkProxy(() => this.abortController.abort()),
-          this.fetchFn,
-          this.fetchableTile.tile.tileZoomLevel.width,
-          this.fetchableTile.tile.tileZoomLevel.height
-        )
-        .then((response) => {
-          this.data = response
-          this.dispatchEvent(
-            new WarpedMapEvent(WarpedMapEventType.TILEFETCHED, {
-              tileUrl: this.fetchableTile.tileUrl
-            })
-          )
-        })
-        .catch((err) => {
-          if (err instanceof Error && err.name === 'AbortError') {
-            console.log('Fetch aborted') // Handle the abort error
-          } else {
-            console.error(err) // Handle other errors
-          }
-        })
+      this.data = await this.#worker.getImageData(
+        this.fetchableTile.tileUrl,
+        comlinkProxy(() => this.abortController.abort()),
+        this.fetchFn,
+        this.fetchableTile.tile.tileZoomLevel.width,
+        this.fetchableTile.tile.tileZoomLevel.height
+      )
+
+      this.dispatchTileFetched()
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (this.isAbortError(err)) {
         // fetchImage was aborted because viewport was moved and tile
         // is no longer needed. This error can be ignored, nothing to do.
       } else {
-        this.dispatchEvent(
-          new WarpedMapEvent(WarpedMapEventType.TILEFETCHERROR, {
-            tileUrl: this.fetchableTile.tileUrl
-          })
-        )
+        this.dispatchTileFetchError(err)
       }
     }
 

--- a/packages/render/src/tilecache/TileCache.ts
+++ b/packages/render/src/tilecache/TileCache.ts
@@ -1,7 +1,11 @@
 import { equalSet } from '@allmaps/stdlib'
 
 import { CacheableTile, CachedTile } from './CacheableTile.js'
-import { WarpedMapEvent, WarpedMapEventType } from '../shared/events.js'
+import {
+  WarpedMapErrorEvent,
+  WarpedMapEvent,
+  WarpedMapEventType
+} from '../shared/events.js'
 
 import { FetchableTile } from './FetchableTile.js'
 
@@ -440,6 +444,25 @@ export class TileCache<D> extends EventTarget {
       if (this.tilesByTileUrl.has(tileUrl)) {
         this.updateTilesFetchingCount(-1)
       }
+
+      const mapIds = [
+        ...new Set([
+          ...(event.data.mapIds ?? []),
+          ...(this.mapIdsByTileUrl.get(tileUrl) ?? [])
+        ])
+      ]
+
+      this.dispatchEvent(
+        new WarpedMapErrorEvent(
+          event.error ?? new Error(`Failed to fetch tile: ${tileUrl}`),
+          {
+            ...event.data,
+            mapIds,
+            tileUrl
+          },
+          WarpedMapEventType.TILEFETCHERROR
+        )
+      )
     }
   }
 
@@ -558,7 +581,14 @@ export class TileCache<D> extends EventTarget {
   }
 
   protected updateTilesFetchingCount(delta: number) {
+    const previousTilesFetchingCount = this.tilesFetchingCount
     this.tilesFetchingCount += delta
+
+    if (previousTilesFetchingCount === 0 && this.tilesFetchingCount > 0) {
+      this.dispatchEvent(
+        new WarpedMapEvent(WarpedMapEventType.REQUESTEDTILESLOADING)
+      )
+    }
 
     if (this.tilesFetchingCount === 0) {
       this.dispatchEvent(

--- a/packages/render/test/warped-map-list.test.ts
+++ b/packages/render/test/warped-map-list.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'vitest'
+
+import { WarpedMapList } from '../src/maps/WarpedMapList.js'
+import { WarpedMap } from '../src/maps/WarpedMap.js'
+import {
+  WarpedMapErrorEvent,
+  WarpedMapEventType
+} from '../src/shared/events.js'
+
+import type { GeoreferencedMap } from '@allmaps/annotation'
+import type {
+  GetWarpedMapOptions,
+  WarpedMapFactory,
+  WarpedMapListOptions
+} from '../src/shared/types.js'
+
+const GOOD_MAP_ID_1 = 'https://example.com/maps/good-1'
+const BAD_MAP_ID = 'https://example.com/maps/bad'
+const GOOD_MAP_ID_2 = 'https://example.com/maps/good-2'
+
+function createGeoreferencedMap(id: string): unknown {
+  return {
+    version: 1,
+    id,
+    gcps: [
+      {
+        image: [0, 0],
+        world: [0, 0]
+      },
+      {
+        image: [100, 0],
+        world: [1, 0]
+      },
+      {
+        image: [100, 100],
+        world: [1, 1]
+      },
+      {
+        image: [0, 100],
+        world: [0, 1]
+      }
+    ],
+    image: {
+      uri: `${id}/info.json`,
+      type: 'ImageService3',
+      width: 100,
+      height: 100
+    },
+    pixelMask: [
+      [0, 0],
+      [100, 0],
+      [100, 100],
+      [0, 100]
+    ]
+  }
+}
+
+function createWarpedMapFactory(
+  failingMapId: string
+): WarpedMapFactory<WarpedMap> {
+  return (
+    mapId: string,
+    georeferencedMap: GeoreferencedMap,
+    listOptions?: Partial<WarpedMapListOptions<WarpedMap>>,
+    mapOptions?: Partial<GetWarpedMapOptions<WarpedMap>>
+  ) => {
+    if (mapId === failingMapId) {
+      throw new Error(`Failed map ${mapId}`)
+    }
+
+    return new WarpedMap(mapId, georeferencedMap, listOptions, mapOptions)
+  }
+}
+
+describe('WarpedMapList batch failures', () => {
+  test('addGeoreferencedMaps collects errors by default', () => {
+    const warpedMapList = new WarpedMapList({
+      warpedMapFactory: createWarpedMapFactory(BAD_MAP_ID)
+    })
+
+    const results = warpedMapList.addGeoreferencedMaps([
+      createGeoreferencedMap(GOOD_MAP_ID_1),
+      createGeoreferencedMap(BAD_MAP_ID),
+      createGeoreferencedMap(GOOD_MAP_ID_2)
+    ])
+
+    expect(results).toMatchObject([
+      { ok: true, mapId: GOOD_MAP_ID_1, index: 0 },
+      { ok: false, mapId: BAD_MAP_ID, index: 1 },
+      { ok: true, mapId: GOOD_MAP_ID_2, index: 2 }
+    ])
+    expect(warpedMapList.getMapIds()).to.deep.equal([
+      GOOD_MAP_ID_1,
+      GOOD_MAP_ID_2
+    ])
+  })
+
+  test('addGeoreferencedMaps can fail fast', () => {
+    const warpedMapList = new WarpedMapList({
+      warpedMapFactory: createWarpedMapFactory(BAD_MAP_ID)
+    })
+
+    expect(() =>
+      warpedMapList.addGeoreferencedMaps(
+        [
+          createGeoreferencedMap(GOOD_MAP_ID_1),
+          createGeoreferencedMap(BAD_MAP_ID),
+          createGeoreferencedMap(GOOD_MAP_ID_2)
+        ],
+        undefined,
+        { failureMode: 'fail-fast' }
+      )
+    ).to.throw(`Failed map ${BAD_MAP_ID}`)
+    expect(warpedMapList.getMapIds()).to.deep.equal([GOOD_MAP_ID_1])
+  })
+
+  test('updateWarpedMapsUsingFactory removes failed maps and continues', () => {
+    const warpedMapList = new WarpedMapList()
+    const errors: WarpedMapErrorEvent[] = []
+
+    warpedMapList.addGeoreferencedMaps([
+      createGeoreferencedMap(GOOD_MAP_ID_1),
+      createGeoreferencedMap(BAD_MAP_ID),
+      createGeoreferencedMap(GOOD_MAP_ID_2)
+    ])
+    warpedMapList.setOptions({
+      warpedMapFactory: createWarpedMapFactory(BAD_MAP_ID)
+    })
+    warpedMapList.addEventListener(WarpedMapEventType.ERROR, (event) => {
+      if (event instanceof WarpedMapErrorEvent) {
+        errors.push(event)
+      }
+    })
+
+    const results = warpedMapList.updateWarpedMapsUsingFactory()
+
+    expect(results).toMatchObject([
+      { ok: true, mapId: GOOD_MAP_ID_1, index: 0 },
+      { ok: false, mapId: BAD_MAP_ID, index: 1 },
+      { ok: true, mapId: GOOD_MAP_ID_2, index: 2 }
+    ])
+    expect(warpedMapList.getMapIds()).to.deep.equal([
+      GOOD_MAP_ID_1,
+      GOOD_MAP_ID_2
+    ])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].data?.mapIds).to.deep.equal([BAD_MAP_ID])
+  })
+})

--- a/packages/stdlib/src/api.ts
+++ b/packages/stdlib/src/api.ts
@@ -1,81 +1,54 @@
+import { generateId } from '@allmaps/id'
+
 import type {
   Image,
   EmbeddedImage,
   Manifest,
-  Collection,
-  EmbeddedCollection
+  Collection
 } from '@allmaps/iiif-parser'
 
-import { fetchJson } from './fetch.js'
+type Hash = string
 
-function fetchAnnotationsByIiifUrl(url: string) {
+type AllmapsId = `manifests/${Hash}` | `images/${Hash}`
+
+function fetchAnnotationsByAllmapsId(
+  restBaseUrl: string,
+  allmapsId: AllmapsId,
+  fetch = globalThis.fetch
+) {
   // TODO: move base URLs to env/config file
-  return fetchJson(`https://annotations.allmaps.org/?url=${url}`)
+  return fetch(`${restBaseUrl}/${allmapsId}`).then((response) =>
+    response.json()
+  )
 }
 
 async function fetchAnnotationsForImage(
-  parsedImage: Image | EmbeddedImage
-): Promise<unknown[]> {
-  try {
-    const annotations = await fetchAnnotationsByIiifUrl(
-      `${parsedImage.uri}/info.json`
-    )
-    return [annotations]
-  } catch (err) {
-    return []
-  }
+  restBaseUrl: string,
+  parsedImage: Image | EmbeddedImage,
+  fetch?: typeof globalThis.fetch
+) {
+  const allmapsId: AllmapsId = `images/${await generateId(parsedImage.uri)}`
+  return fetchAnnotationsByAllmapsId(restBaseUrl, allmapsId, fetch)
 }
 
 async function fetchAnnotationsForManifest(
-  parsedManifest: Manifest
-): Promise<unknown[]> {
-  try {
-    const annotations = await fetchAnnotationsByIiifUrl(parsedManifest.uri)
-    return [annotations]
-  } catch (err) {
-    const annotations: unknown[] = []
-    for (const canvas of parsedManifest.canvases) {
-      const imageAnnotations = await fetchAnnotationsForImage(canvas.image)
-      annotations.push(...imageAnnotations)
-    }
-
-    return annotations
-  }
-}
-
-async function fetchAnnotationsForCollection(
-  parsedCollection: Collection | EmbeddedCollection
-): Promise<unknown[]> {
-  try {
-    const annotations = await fetchAnnotationsByIiifUrl(parsedCollection.uri)
-    return [annotations]
-  } catch (err) {
-    const annotations: unknown[] = []
-    if ('items' in parsedCollection) {
-      for (const item of parsedCollection.items) {
-        if (item.type === 'collection') {
-          const itemAnnotations = await fetchAnnotationsForCollection(item)
-          annotations.push(...itemAnnotations)
-        } else if (item.type === 'manifest' && 'canvases' in item) {
-          const itemAnnotations = await fetchAnnotationsForManifest(item)
-          annotations.push(...itemAnnotations)
-        }
-      }
-    }
-
-    return annotations
-  }
+  restBaseUrl: string,
+  parsedManifest: Manifest,
+  fetch?: typeof globalThis.fetch
+) {
+  const allmapsId: AllmapsId = `manifests/${await generateId(parsedManifest.uri)}`
+  return fetchAnnotationsByAllmapsId(restBaseUrl, allmapsId, fetch)
 }
 
 export function fetchAnnotationsFromApi(
-  parsedIiif: Image | Manifest | Collection
+  restBaseUrl: string,
+  parsedIiif: Image | Manifest | Collection,
+  fetch?: typeof globalThis.fetch
 ) {
   if (parsedIiif.type === 'image') {
-    return fetchAnnotationsForImage(parsedIiif)
+    return fetchAnnotationsForImage(restBaseUrl, parsedIiif, fetch)
   } else if (parsedIiif.type === 'manifest') {
-    return fetchAnnotationsForManifest(parsedIiif)
-  } else if (parsedIiif.type === 'collection') {
-    return fetchAnnotationsForCollection(parsedIiif)
+    return fetchAnnotationsForManifest(restBaseUrl, parsedIiif, fetch)
   } else {
     throw new Error('Unsupported IIIF resource')
   }

--- a/packages/stdlib/src/color.ts
+++ b/packages/stdlib/src/color.ts
@@ -8,8 +8,8 @@ import type { Color, ColorWithTransparancy } from '@allmaps/types'
  * @param rgb - RGB color array, e.g. [0, 51, 255]
  * @returns HEX string, e.g. '#0033ff'
  */
-export function rgbToHex(color: Color): string {
-  return '#' + rgbHex(...color)
+export function rgbToHex(rgb: Color): string {
+  return '#' + rgbHex(...rgb)
 }
 
 /**
@@ -17,8 +17,8 @@ export function rgbToHex(color: Color): string {
  * @param rgb - RGBA color array, e.g. [0, 51, 255, 255]
  * @returns HEX string, e.g. '#0033ffff'
  */
-export function rgbaToHex(color: ColorWithTransparancy): string {
-  return '#' + rgbHex(...color)
+export function rgbaToHex(rgba: ColorWithTransparancy): string {
+  return '#' + rgbHex(...rgba)
 }
 
 /**

--- a/packages/stdlib/src/fetch.ts
+++ b/packages/stdlib/src/fetch.ts
@@ -1,5 +1,97 @@
 import type { FetchFn } from '@allmaps/types'
 
+export type ResourceFetchErrorKind = 'network-or-cors' | 'http'
+
+type ResourceFetchErrorOptions = {
+  cause?: unknown
+  corsLikely?: boolean
+  message?: string
+  status?: number
+  statusText?: string
+}
+
+export class ResourceFetchError extends Error {
+  kind: ResourceFetchErrorKind
+  input: RequestInfo | URL
+  url: string
+  status?: number
+  statusText?: string
+  corsLikely: boolean
+  cause?: unknown
+
+  constructor(
+    kind: ResourceFetchErrorKind,
+    input: RequestInfo | URL,
+    options: ResourceFetchErrorOptions = {}
+  ) {
+    super(options.message ?? getDefaultFetchErrorMessage(kind, input, options))
+
+    this.name = 'ResourceFetchError'
+    this.kind = kind
+    this.input = input
+    this.url = getInputUrl(input)
+    this.status = options.status
+    this.statusText = options.statusText
+    this.corsLikely = options.corsLikely ?? false
+    this.cause = options.cause
+  }
+}
+
+function getInputUrl(input: RequestInfo | URL) {
+  if (typeof input === 'string') {
+    return input
+  } else if (input instanceof URL) {
+    return input.href
+  } else {
+    return input.url
+  }
+}
+
+function getDefaultFetchErrorMessage(
+  kind: ResourceFetchErrorKind,
+  input: RequestInfo | URL,
+  options: ResourceFetchErrorOptions
+) {
+  const url = getInputUrl(input)
+
+  if (kind === 'network-or-cors') {
+    return `Failed to fetch: ${url}`
+  }
+
+  if (options.status === 404) {
+    return `Not found: ${url} (404)`
+  } else if (options.status === 500) {
+    return 'Internal server error (500)'
+  } else if (options.statusText) {
+    return options.statusText
+  } else {
+    return `Failed to fetch: ${url} (${options.status})`
+  }
+}
+
+function isAbortError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'AbortError'
+  )
+}
+
+function isCorsLikely(input: RequestInfo | URL) {
+  const location = globalThis.location
+  if (!location) {
+    return false
+  }
+
+  try {
+    const url = new URL(getInputUrl(input), location.href)
+    return url.origin !== location.origin
+  } catch {
+    return false
+  }
+}
+
 export async function fetchUrl(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -7,25 +99,44 @@ export async function fetchUrl(
 ): Promise<Response> {
   let response: Response
 
-  if (typeof fetchFn === 'function') {
-    response = await fetchFn(input, init)
-  } else {
-    response = await fetch(input, init)
+  try {
+    if (typeof fetchFn === 'function') {
+      response = await fetchFn(input, init)
+    } else {
+      response = await fetch(input, init)
+    }
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+
+    throw new ResourceFetchError('network-or-cors', input, {
+      cause: error,
+      corsLikely: isCorsLikely(input)
+    })
   }
 
   if (!response.ok) {
-    const json = await response.json()
-    if (json && json.error) {
-      throw new Error(json.error)
-    } else if (response.statusText) {
-      throw new Error(response.statusText)
-    } else if (response.status === 404) {
-      throw new Error(`Not found: ${input} (404)`)
-    } else if (response.status === 500) {
-      throw new Error('Internal server error (500)')
-    } else {
-      throw new Error(`Failed to fetch: ${input} (${response.status})`)
+    let message: string | undefined
+
+    try {
+      const json = await response.clone().json()
+      if (json && typeof json.error === 'string') {
+        message = json.error
+      }
+    } catch {
+      // Ignore invalid JSON error bodies and use the response status instead.
     }
+
+    if (!message && response.statusText) {
+      message = response.statusText
+    }
+
+    throw new ResourceFetchError('http', input, {
+      message,
+      status: response.status,
+      statusText: response.statusText
+    })
   }
 
   return response

--- a/packages/stdlib/src/geometry.ts
+++ b/packages/stdlib/src/geometry.ts
@@ -357,8 +357,13 @@ export function isClosed(input: Point[]): boolean {
 }
 
 export function isEqualPoint(point0: Point, point1: Point): boolean {
-  if (point0 === point1) return true
-  if (point0 === null || point1 === null) return false
+  if (point0 === point1) {
+    return true
+  }
+
+  if (point0 === null || point1 === null) {
+    return false
+  }
 
   return point0[0] === point1[0] && point0[1] === point1[1]
 }

--- a/packages/stdlib/src/index.ts
+++ b/packages/stdlib/src/index.ts
@@ -64,11 +64,14 @@ export {
 } from './color.js'
 
 export {
+  ResourceFetchError,
   fetchUrl,
   fetchJson,
   fetchImageInfo,
   fetchImageBitmap
 } from './fetch.js'
+
+export type { ResourceFetchErrorKind } from './fetch.js'
 
 export {
   isGeojsonPoint,

--- a/packages/stdlib/src/self-intersect.ts
+++ b/packages/stdlib/src/self-intersect.ts
@@ -82,7 +82,11 @@ export function linesIntersectionPoint(
 
   const intersectionPoint = prolongedLinesIntersectionPoint(line0, line1)
 
-  if (intersectionPoint === undefined) return undefined // discard parallels and coincidence
+  // discard parallels and coincidence
+  if (intersectionPoint === undefined) {
+    return
+  }
+
   let frac0, frac1
   if (line0[1][0] != line0[0][0]) {
     frac0 = (intersectionPoint[0] - line0[0][0]) / (line0[1][0] - line0[0][0])
@@ -98,7 +102,7 @@ export function linesIntersectionPoint(
   // There are roughly three cases we need to deal with.
   // 1. If at least one of the fracs lies outside [0,1], there is no intersection.
   if (isOutside(frac0, options.epsilon) || isOutside(frac1, options.epsilon)) {
-    return undefined
+    return
   }
 
   // 2. If both are either exactly 0 or exactly 1, this is not an intersection but just
@@ -132,7 +136,10 @@ export function prolongedLinesIntersectionPoint(
   const denom =
     (line0[0][0] - line0[1][0]) * (line1[0][1] - line1[1][1]) -
     (line0[0][1] - line0[1][1]) * (line1[0][0] - line1[1][0])
-  if (denom === 0) return undefined
+
+  if (denom === 0) {
+    return
+  }
 
   const x =
     ((line0[0][0] * line0[1][1] - line0[0][1] * line0[1][0]) *

--- a/packages/warpedmaplayer/README.md
+++ b/packages/warpedmaplayer/README.md
@@ -48,6 +48,7 @@ The following events are emitted by the native map object to inform you of the s
 | `maptileloaded`                 | A tile has been loaded to the tile cache for a map                                                                                   |
 | `maptiledeleted`                | A tile has been deleted from the tile cache for a map                                                                                |
 | `firstmaptileloaded`            | The cache loaded a first tile of a map                                                                                               |
+| `requestedtilesloading`         | New tiles requested for the current viewport started loading                                                                         |
 | `allrequestedtilesloaded`       | All tiles requested for the current viewport have been loaded                                                                        |
 | `cleared`                       | The warped map list has been cleared                                                                                                 |
 | `preparechange`                 | An upcoming options change has been prepared for a specific map (by mixing previous and new properties if the animation was ongoing) |

--- a/packages/warpedmaplayer/src/WarpedMapLayer.ts
+++ b/packages/warpedmaplayer/src/WarpedMapLayer.ts
@@ -8,7 +8,9 @@ import type {
   ProjectionOptions,
   BaseRenderOptions,
   Sprite,
-  WarpedMapListOptions
+  WarpedMapListOptions,
+  BatchMapResult,
+  BatchOptions
 } from '@allmaps/render'
 import type { Point, Bbox, Ring, Gcp, Size } from '@allmaps/types'
 import type { TransformationType } from '@allmaps/transform'
@@ -77,13 +79,15 @@ export abstract class BaseWarpedMapLayer<
    */
   addGeoreferenceAnnotation(
     annotation: unknown,
-    mapOptions?: Partial<WebGL2WarpedMapOptions>
-  ): (string | Error)[] {
+    mapOptions?: Partial<WebGL2WarpedMapOptions>,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     BaseWarpedMapLayer.assertRenderer(this.renderer)
 
     const results = this.renderer.addGeoreferenceAnnotation(
       annotation,
-      mapOptions
+      mapOptions,
+      batchOptions
     )
     this.nativeUpdate()
 
@@ -96,11 +100,16 @@ export abstract class BaseWarpedMapLayer<
    * @param annotation - Georeference Annotation
    * @returns Map IDs of the maps that were removed, or an error per map
    */
-  removeGeoreferenceAnnotation(annotation: unknown): (string | Error)[] {
+  removeGeoreferenceAnnotation(
+    annotation: unknown,
+    batchOptions?: Partial<BatchOptions>
+  ): BatchMapResult[] {
     BaseWarpedMapLayer.assertRenderer(this.renderer)
 
-    const results =
-      this.renderer.warpedMapList.removeGeoreferenceAnnotation(annotation)
+    const results = this.renderer.warpedMapList.removeGeoreferenceAnnotation(
+      annotation,
+      batchOptions
+    )
     this.nativeUpdate()
 
     return results
@@ -115,13 +124,14 @@ export abstract class BaseWarpedMapLayer<
    */
   async addGeoreferenceAnnotationByUrl(
     annotationUrl: string,
-    mapOptions?: Partial<WebGL2WarpedMapOptions>
-  ): Promise<(string | Error)[]> {
+    mapOptions?: Partial<WebGL2WarpedMapOptions>,
+    batchOptions?: Partial<BatchOptions>
+  ): Promise<BatchMapResult[]> {
     const annotation = await fetch(annotationUrl).then((response) =>
       response.json()
     )
 
-    return this.addGeoreferenceAnnotation(annotation, mapOptions)
+    return this.addGeoreferenceAnnotation(annotation, mapOptions, batchOptions)
   }
 
   /**
@@ -131,12 +141,13 @@ export abstract class BaseWarpedMapLayer<
    * @returns Map IDs of the maps that were removed, or an error per map
    */
   async removeGeoreferenceAnnotationByUrl(
-    annotationUrl: string
-  ): Promise<(string | Error)[]> {
+    annotationUrl: string,
+    batchOptions?: Partial<BatchOptions>
+  ): Promise<BatchMapResult[]> {
     const annotation = await fetch(annotationUrl).then((response) =>
       response.json()
     )
-    return this.removeGeoreferenceAnnotation(annotation)
+    return this.removeGeoreferenceAnnotation(annotation, batchOptions)
   }
 
   /**
@@ -1090,6 +1101,11 @@ export abstract class BaseWarpedMapLayer<
       this.nativePassWarpedMapEvent.bind(this)
     )
 
+    this.renderer.tileCache.addEventListener(
+      WarpedMapEventType.TILEFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
     this.renderer.spritesTileCache.addEventListener(
       WarpedMapEventType.MAPTILESLOADEDFROMSPRITES,
       this.nativePassWarpedMapEvent.bind(this)
@@ -1102,6 +1118,11 @@ export abstract class BaseWarpedMapLayer<
 
     this.renderer.tileCache.addEventListener(
       WarpedMapEventType.FIRSTMAPTILELOADED,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.tileCache.addEventListener(
+      WarpedMapEventType.REQUESTEDTILESLOADING,
       this.nativePassWarpedMapEvent.bind(this)
     )
 
@@ -1186,6 +1207,11 @@ export abstract class BaseWarpedMapLayer<
       this.nativePassWarpedMapEvent.bind(this)
     )
 
+    this.renderer.tileCache.removeEventListener(
+      WarpedMapEventType.TILEFETCHERROR,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
     this.renderer.spritesTileCache.removeEventListener(
       WarpedMapEventType.MAPTILESLOADEDFROMSPRITES,
       this.nativePassWarpedMapEvent.bind(this)
@@ -1198,6 +1224,11 @@ export abstract class BaseWarpedMapLayer<
 
     this.renderer.tileCache.removeEventListener(
       WarpedMapEventType.FIRSTMAPTILELOADED,
+      this.nativePassWarpedMapEvent.bind(this)
+    )
+
+    this.renderer.tileCache.removeEventListener(
+      WarpedMapEventType.REQUESTEDTILESLOADING,
       this.nativePassWarpedMapEvent.bind(this)
     )
 


### PR DESCRIPTION
This pull request introduces improved batch processing capabilities for georeference annotation management in both the Leaflet and OpenLayers map layers, as well as in the core render package. It updates relevant APIs to support batch options and result types, enhances event handling for tile loading and errors, and adds new types and test tooling to the render package.

**Batch processing and API improvements:**

* Updated `WarpedMapLayer` methods in both `leaflet` and `openlayers` packages (`addGeoreferenceAnnotation`, `removeGeoreferenceAnnotation`, and their `ByUrl` variants) to accept an optional `batchOptions` parameter and return detailed `BatchMapResult[]` results, enabling more granular control and feedback during batch operations. [[1]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43L434-R444) [[2]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43L453-R466) [[3]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43L472-R488) [[4]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43L488-R504) [[5]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962L310-R320) [[6]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962L329-R342) [[7]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962L348-R364) [[8]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962L364-R380)

* Refactored `WarpedMapList` in the `render` package to support batch options and results for all relevant methods, including annotation and map management, and updated the default batch failure mode. [[1]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L174-R178) [[2]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L187-R192) [[3]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L218-R226) [[4]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L229-R238) [[5]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L257-R274) [[6]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L271-R290) [[7]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L290-R315) [[8]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R324-R325) [[9]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3L119-R122)

**Type and import enhancements:**

* Added new batch-related types (`BatchMapResult`, `BatchOptions`, etc.) to the public API and updated imports across relevant files to support the new batch processing features. [[1]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43L19-R21) [[2]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962L22-R24) [[3]](diffhunk://#diff-104392d44d03827023061628fd34a8f88f1917ef87eb3da7ecdac1bf3eec0833R30-R34) [[4]](diffhunk://#diff-0c2407e84af6bfa071c70356fc08bf058f0661e568c66442022a9f76e5c8e7a3R43-R44)

**Event handling improvements:**

* Added event listeners and corresponding removals for new tile loading and error events (`TILEFETCHERROR`, `REQUESTEDTILESLOADING`) in both `leaflet` and `openlayers` `WarpedMapLayer` implementations to improve error reporting and loading state management. [[1]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43R1458-R1462) [[2]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43R1478-R1482) [[3]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43R1564-R1568) [[4]](diffhunk://#diff-0caddd2938bd1195d4c5919a97a32137789bad676daec008d761a37d28f8ec43R1584-R1588) [[5]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962R1334-R1338) [[6]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962R1354-R1358) [[7]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962R1440-R1444) [[8]](diffhunk://#diff-95a3635d8dbb3e720103e3fb9891a69f6880127561c1676c457bb2b464d15962R1460-R1464)

**Tooling and testing:**

* Added `vitest` as a dev dependency and a `test` script to the `render` package for improved testing support. [[1]](diffhunk://#diff-0410bccd829eb8af59dead354217b8cbf28ee896dd8b7b98cbc0789caa39df16R41) [[2]](diffhunk://#diff-0410bccd829eb8af59dead354217b8cbf28ee896dd8b7b98cbc0789caa39df16R84)

These changes collectively make batch operations more robust and observable, improve error handling, and lay the groundwork for better test coverage.