### PR TITLE
added too many requests option. And improved manifest errors

### DIFF
--- a/test/server/README.md
+++ b/test/server/README.md
@@ -37,6 +37,8 @@ GET /cors/iiif/2/:level/:imageId
 GET /cors/iiif/3/:level/:imageId
 GET /cors/iiif/2/:level/:imageId/info.json
 GET /cors/iiif/3/:level/:imageId/info.json
+GET /cors/iiif/:version/:level/:imageId/too-many-requests-after-20s/info.json
+GET /cors/iiif/:version/:level/:imageId/too-many-requests-after-20s/:region/:size/:rotation/:quality.:format
 GET /cors/errors/iiif/:version/:level/:imageId/missing-dimensions/info.json
 GET /cors/errors/iiif/:version/:level/:imageId/bad-tiles/info.json
 GET /cors/iiif/:version/:level/:imageId/:region/:size/:rotation/:quality.:format
@@ -46,6 +48,8 @@ GET /cors/annotations/combined/iiif{2|3}-level{0|1|2}.json
 GET /cors/annotations/combined/image-500-iiif3-level2.json
 GET /cors/annotations/combined/slow-iiif3-level2.json
 GET /cors/annotations/combined/mixed-slow-iiif3-level2.json
+GET /cors/annotations/combined/too-many-requests-after-20s-iiif3-level2.json
+GET /cors/annotations/combined/mixed-too-many-requests-after-20s-iiif3-level2.json
 GET /cors/annotations/combined/mixed-partof-hierarchy-iiif3-level2.json
 GET /cors/annotations/combined/mixed-iiif2-level0-level2.json
 GET /cors/annotations/combined/mixed-iiif3-level0-level2.json
@@ -92,6 +96,8 @@ GET /cors/manifests/3/combined/partial-embedded-annotations.json
 GET /cors/manifests/3/combined/partial-linked-annotations.json
 GET /cors/manifests/3/combined/mixed-embedded-annotation-errors.json
 GET /cors/manifests/3/combined/mixed-linked-annotation-errors.json
+GET /cors/manifests/3/combined/too-many-requests-after-20s-iiif3-level2.json
+GET /cors/manifests/3/combined/mixed-too-many-requests-after-20s-iiif3-level2.json
 GET /cors/manifests/3/combined/image-services-iiif2-level0-level2.json
 GET /cors/manifests/3/combined/image-services-iiif3-level0-level2.json
 GET /cors/manifests/3/combined/image-services-iiif2-level0-iiif3-level2.json

--- a/test/server/src/lib/components/Root.svelte
+++ b/test/server/src/lib/components/Root.svelte
@@ -33,6 +33,7 @@
     }
     errors: {
       infoJsons: Link[]
+      imageServices: Link[]
       annotations: Link[]
       manifests: Link[]
     }
@@ -128,6 +129,7 @@
       manifests,
       errors: {
         infoJsons: image.errors.infoJsons.map(withMode),
+        imageServices: image.errors.imageServices.map(withMode),
         annotations: image.errors.annotations.map(withMode),
         manifests: image.errors.manifests.map(withMode)
       },
@@ -245,6 +247,11 @@
       key: 'info-jsons',
       label: 'Broken info.json',
       getLinks: (links) => links.errors.infoJsons
+    },
+    {
+      key: 'image-services',
+      label: 'Rate Limited Image Services',
+      getLinks: (links) => links.errors.imageServices
     },
     {
       key: 'annotations',
@@ -633,6 +640,28 @@
               (link) =>
                 link.resourceKind === 'Annotation page' &&
                 link.label === 'Some slow, some fast images'
+            )
+          ),
+          createCombinedScenario(
+            'image-services-rate-limited-after-20s',
+            'Image services return 429 after 20 seconds',
+            'The annotation page loads normally and points at image services that serve info.json and tiles for 20 seconds, then return 429 responses.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'Image services return 429 after 20 seconds'
+            )
+          ),
+          createCombinedScenario(
+            'some-image-services-rate-limited-after-20s',
+            'Some image services return 429 after 20 seconds',
+            'Only some image services in the annotation page become rate limited, while the others continue responding normally.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'Some image services return 429 after 20 seconds'
             )
           )
         ].filter((scenario) => scenario !== undefined)

--- a/test/server/src/lib/server.ts
+++ b/test/server/src/lib/server.ts
@@ -57,7 +57,7 @@ type ImageApiService = {
   complianceLevel: ImageComplianceLevel
 }
 
-type ImageServiceBehavior = 'image-500' | 'slow'
+type ImageServiceBehavior = 'image-500' | 'slow' | 'too-many-requests-after-20s'
 
 type ImageApiServiceReference = ImageApiService & {
   behavior?: ImageServiceBehavior
@@ -68,8 +68,10 @@ const presentation3Context = 'http://iiif.io/api/presentation/3/context.json'
 
 const imageDefinitions = loadImageDefinitions()
 const slowResourceDelayMs = 4_000
+const tooManyRequestsAfterMs = 20_000
 
 const images = new Map(imageDefinitions.map((image) => [image.id, image]))
+const imageServiceBehaviorStartedAt = new Map<string, number>()
 const originalManifests = new Map(
   imageDefinitions.flatMap((image) => {
     if (!image.originalManifestPath) {
@@ -148,6 +150,10 @@ function getImageServiceProfile(
 
 function getImageServiceType(version: IiifVersion) {
   return version === '2' ? 'ImageService2' : 'ImageService3'
+}
+
+function getWrongImageServiceType(version: IiifVersion) {
+  return version === '2' ? 'ImageService3' : 'ImageService2'
 }
 
 function isJsonObject(value: unknown): value is JsonObject {
@@ -501,7 +507,11 @@ function parseImageServiceBehavior(
     return undefined
   }
 
-  if (behavior === 'image-500' || behavior === 'slow') {
+  if (
+    behavior === 'image-500' ||
+    behavior === 'slow' ||
+    behavior === 'too-many-requests-after-20s'
+  ) {
     return behavior
   }
 
@@ -517,6 +527,10 @@ function getCombinedImageServiceBehavior(
 
   if (variant === 'slow-iiif3-level2') {
     return 'slow'
+  }
+
+  if (variant === 'too-many-requests-after-20s-iiif3-level2') {
+    return 'too-many-requests-after-20s'
   }
 
   return undefined
@@ -536,6 +550,51 @@ async function delaySlowResource(variantOrBehavior: string | undefined) {
   if (variantOrBehavior === 'slow') {
     await delay(slowResourceDelayMs)
   }
+}
+
+function getImageServiceBehaviorKey(
+  corsMode: CorsMode,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  imageId: string,
+  behavior: ImageServiceBehavior
+) {
+  return [corsMode, version, complianceLevel, imageId, behavior].join(':')
+}
+
+function shouldReturnTooManyRequests(
+  corsMode: CorsMode,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  imageId: string,
+  behavior: ImageServiceBehavior | undefined
+) {
+  if (behavior !== 'too-many-requests-after-20s') {
+    return false
+  }
+
+  const key = getImageServiceBehaviorKey(
+    corsMode,
+    version,
+    complianceLevel,
+    imageId,
+    behavior
+  )
+  const now = Date.now()
+  const startedAt = imageServiceBehaviorStartedAt.get(key) ?? now
+
+  if (!imageServiceBehaviorStartedAt.has(key)) {
+    imageServiceBehaviorStartedAt.set(key, startedAt)
+  }
+
+  return now - startedAt >= tooManyRequestsAfterMs
+}
+
+function tooManyRequestsResponse(corsMode: CorsMode) {
+  const response = textResponse('Too Many Requests', corsMode, 429)
+  response.headers.set('retry-after', '20')
+
+  return response
 }
 
 function getCombinedAnnotationVariants(baseUrl: string) {
@@ -583,6 +642,18 @@ function getCombinedAnnotationVariants(baseUrl: string) {
       'level2',
       'Some slow, some fast images',
       `${baseUrl}/annotations/combined/mixed-slow-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Image services return 429 after 20 seconds',
+      `${baseUrl}/annotations/combined/too-many-requests-after-20s-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Some image services return 429 after 20 seconds',
+      `${baseUrl}/annotations/combined/mixed-too-many-requests-after-20s-iiif3-level2.json`
     ),
     createImageApiLink(
       '3',
@@ -681,6 +752,18 @@ function getCombinedManifestVariants(baseUrl: string) {
       'Slow manifest and resources',
       `${baseUrl}/manifests/3/combined/slow-iiif3-level2.json`
     ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Image services return 429 after 20 seconds',
+      `${baseUrl}/manifests/3/combined/too-many-requests-after-20s-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Some image services return 429 after 20 seconds',
+      `${baseUrl}/manifests/3/combined/mixed-too-many-requests-after-20s-iiif3-level2.json`
+    ),
     createCombinedImageServiceLink(
       'IIIF Presentation 3.0 manifest',
       `${baseUrl}/manifests/3/combined/image-services-iiif2-level0-level2.json`,
@@ -722,6 +805,8 @@ function isCombinedIiif3ManifestVariant(variant: string) {
       'mixed-linked-annotation-errors',
       'image-500-iiif3-level2',
       'slow-iiif3-level2',
+      'too-many-requests-after-20s-iiif3-level2',
+      'mixed-too-many-requests-after-20s-iiif3-level2',
       'image-services-iiif2-level0-level1',
       'image-services-iiif3-level0-level1',
       'image-services-iiif2-level0-iiif3-level1',
@@ -781,6 +866,14 @@ function getCombinedManifestLabel(variant: string) {
     return 'Combined fixture images whose resources load slowly'
   }
 
+  if (variant === 'too-many-requests-after-20s-iiif3-level2') {
+    return 'Combined fixture images whose image services return 429 after 20 seconds'
+  }
+
+  if (variant === 'mixed-too-many-requests-after-20s-iiif3-level2') {
+    return 'Combined fixture images with some image services that return 429 after 20 seconds'
+  }
+
   if (variant === 'image-services-iiif2-level0-level1') {
     return 'Combined fixture images with IIIF 2.1 level 0 and level 1 images'
   }
@@ -837,7 +930,12 @@ function getCombinedCanvasManifestVariant(variant: string, index: number) {
     return index % 2 === 0 ? 'default' : 'embedded-annotation'
   }
 
-  if (variant === 'image-500-iiif3-level2' || variant === 'slow-iiif3-level2') {
+  if (
+    variant === 'image-500-iiif3-level2' ||
+    variant === 'slow-iiif3-level2' ||
+    variant === 'too-many-requests-after-20s-iiif3-level2' ||
+    variant === 'mixed-too-many-requests-after-20s-iiif3-level2'
+  ) {
     return 'linked-annotation'
   }
 
@@ -871,7 +969,7 @@ function getCombinedCanvasManifestVariant(variant: string, index: number) {
 function getCombinedCanvasImageService(
   variant: string,
   index: number
-): { version: IiifVersion; complianceLevel: ImageComplianceLevel } {
+): ImageApiServiceReference {
   const imageServiceVariant = parseCombinedImageServiceManifestVariant(variant)
 
   if (imageServiceVariant) {
@@ -931,6 +1029,22 @@ function getCombinedCanvasImageService(
     return index % 2 === 0
       ? { version: '2', complianceLevel: 'level2' }
       : { version: '3', complianceLevel: 'level0' }
+  }
+
+  if (variant === 'too-many-requests-after-20s-iiif3-level2') {
+    return {
+      version: '3',
+      complianceLevel: 'level2',
+      behavior: 'too-many-requests-after-20s'
+    }
+  }
+
+  if (variant === 'mixed-too-many-requests-after-20s-iiif3-level2') {
+    return {
+      version: '3',
+      complianceLevel: 'level2',
+      behavior: index % 2 === 0 ? undefined : 'too-many-requests-after-20s'
+    }
   }
 
   return {
@@ -1024,7 +1138,8 @@ function getCombinedAnnotationImageService(
     variant === 'mixed-cors-errors-iiif3-level2' ||
     variant === 'mixed-partof-hierarchy-iiif3-level2' ||
     variant === 'image-500-iiif3-level2' ||
-    variant === 'slow-iiif3-level2'
+    variant === 'slow-iiif3-level2' ||
+    variant === 'too-many-requests-after-20s-iiif3-level2'
   ) {
     return {
       version: '3',
@@ -1038,6 +1153,14 @@ function getCombinedAnnotationImageService(
       version: '3',
       complianceLevel: 'level2',
       behavior: index % 2 === 0 ? undefined : 'slow'
+    }
+  }
+
+  if (variant === 'mixed-too-many-requests-after-20s-iiif3-level2') {
+    return {
+      version: '3',
+      complianceLevel: 'level2',
+      behavior: index % 2 === 0 ? undefined : 'too-many-requests-after-20s'
     }
   }
 
@@ -1214,6 +1337,8 @@ function createCombinedAnnotation(
       'image-500-iiif3-level2',
       'slow-iiif3-level2',
       'mixed-slow-iiif3-level2',
+      'too-many-requests-after-20s-iiif3-level2',
+      'mixed-too-many-requests-after-20s-iiif3-level2',
       'mixed-partof-hierarchy-iiif3-level2',
       'mixed-iiif2-level0-level1',
       'mixed-iiif3-level0-level1',
@@ -1366,7 +1491,7 @@ function createIiif3Canvas(
   const imageBodyDimensions = getManifestImageBodyDimensions(image)
   const serviceType =
     variant === 'bad-service-type'
-      ? 'ImageService2'
+      ? getWrongImageServiceType(imageApiVersion)
       : getImageServiceType(imageApiVersion)
   const canvas: JsonObject = {
     id: canvasId,
@@ -1469,7 +1594,7 @@ function createCombinedIiif3Manifest(
         getCombinedLinkedAnnotationPageId(baseUrl, variant, index),
         imageService.version,
         imageService.complianceLevel,
-        getCombinedImageServiceBehavior(variant)
+        imageService.behavior ?? getCombinedImageServiceBehavior(variant)
       )
     })
   }
@@ -1523,7 +1648,7 @@ function createCombinedIiif3CanvasResource(
     getCombinedLinkedAnnotationPageId(baseUrl, variant, imageIndex),
     imageService.version,
     imageService.complianceLevel,
-    getCombinedImageServiceBehavior(variant)
+    imageService.behavior ?? getCombinedImageServiceBehavior(variant)
   )
 }
 
@@ -2293,6 +2418,24 @@ function createIiif2Manifest(
   }
 }
 
+function normalizeLabeledContentResources(
+  resources: JsonObject | JsonObject[] | undefined,
+  fallbackLabel: string
+) {
+  if (!resources) {
+    return undefined
+  }
+
+  const resourceItems = Array.isArray(resources) ? resources : [resources]
+
+  return resourceItems.map((resource) => ({
+    ...cloneJsonObject(resource),
+    label: resource.label ?? {
+      none: [fallbackLabel]
+    }
+  }))
+}
+
 function createIiif3Manifest(
   request: Request,
   corsMode: CorsMode,
@@ -2340,8 +2483,14 @@ function createIiif3Manifest(
     summary: parsedOriginalManifest?.summary,
     requiredStatement: parsedOriginalManifest?.requiredStatement,
     rights: parsedOriginalManifest?.rights,
-    homepage: parsedOriginalManifest?.homepage,
-    rendering: parsedOriginalManifest?.rendering,
+    homepage: normalizeLabeledContentResources(
+      parsedOriginalManifest?.homepage,
+      'Homepage'
+    ),
+    rendering: normalizeLabeledContentResources(
+      parsedOriginalManifest?.rendering,
+      'Rendering'
+    ),
     seeAlso: parsedOriginalManifest?.seeAlso,
     thumbnail: parsedOriginalManifest?.thumbnail,
     items: [canvas]
@@ -2516,6 +2665,33 @@ function getImageAnnotationErrorLinks(baseUrl: string, image: ImageFixture) {
   )
 }
 
+function getRateLimitedImageServiceLinks(baseUrl: string, image: ImageFixture) {
+  return catalogImageApiServices.flatMap(({ version, complianceLevel }) => {
+    const imageServiceUrl = getImageServiceBaseUrl(
+      baseUrl,
+      version,
+      complianceLevel,
+      image.id,
+      'too-many-requests-after-20s'
+    )
+
+    return [
+      createImageApiLink(
+        version,
+        complianceLevel,
+        '429 after 20s info.json',
+        `${imageServiceUrl}/info.json`
+      ),
+      createImageApiLink(
+        version,
+        complianceLevel,
+        '429 after 20s tile',
+        getLevel0TileExample(image, imageServiceUrl)
+      )
+    ]
+  })
+}
+
 function getManifestResourceLinks(baseUrl: string, image: ImageFixture) {
   if (!image.hasManifest) {
     return []
@@ -2685,6 +2861,7 @@ export function createCatalog(request: Request, corsMode: CorsMode) {
             )
           ]
         ),
+        imageServices: getRateLimitedImageServiceLinks(baseUrl, image),
         annotations: getImageAnnotationErrorLinks(baseUrl, image),
         manifests: getManifestErrorLinks(baseUrl, image)
       },
@@ -2796,6 +2973,18 @@ async function routeFixtureRequest(
 
     await delaySlowResource(behavior)
 
+    if (
+      shouldReturnTooManyRequests(
+        corsMode,
+        version,
+        complianceLevel,
+        image.id,
+        behavior
+      )
+    ) {
+      return tooManyRequestsResponse(corsMode)
+    }
+
     return jsonResponse(
       createInfoJson(
         request,
@@ -2813,7 +3002,7 @@ async function routeFixtureRequest(
     segments[0] === 'iiif' &&
     (segments.length === 7 || segments.length === 8 || segments.length === 9)
   ) {
-    parseIiifVersion(segments[1])
+    const version = parseIiifVersion(segments[1])
     const hasBehavior = segments.length === 9
     const hasComplianceLevel = segments.length >= 8
     const complianceLevel = hasComplianceLevel
@@ -2827,6 +3016,18 @@ async function routeFixtureRequest(
     const image = getImage(segments[2 + offset])
 
     await delaySlowResource(behavior)
+
+    if (
+      shouldReturnTooManyRequests(
+        corsMode,
+        version,
+        complianceLevel,
+        image.id,
+        behavior
+      )
+    ) {
+      return tooManyRequestsResponse(corsMode)
+    }
 
     if (behavior === 'image-500') {
       return textResponse('Image request failed intentionally', corsMode, 500)


### PR DESCRIPTION
This pull request adds support for simulating rate-limited IIIF image services in the test server, specifically services that return HTTP 429 ("Too Many Requests") responses after 20 seconds. It introduces new test scenarios and endpoints for these behaviors, updates the UI to display them, and refactors the code to support the new functionality and related labels.

**Support for rate-limited image services:**

* Added a new `ImageServiceBehavior` type, `'too-many-requests-after-20s'`, and logic to simulate image services that return 429 responses after 20 seconds (`tooManyRequestsAfterMs`), including tracking per-service state and generating appropriate responses. [[1]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26L60-R60) [[2]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R71-R74) [[3]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R555-R599)
* Implemented new endpoints and test data for annotation and manifest variants that include rate-limited image services, such as `/too-many-requests-after-20s/info.json` and `/mixed-too-many-requests-after-20s-iiif3-level2.json`. [[1]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR40-R41) [[2]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR51-R52) [[3]](diffhunk://#diff-214eaaa81a36efbee26156ed589b2905c461e6ec0a0d29baa095ee815eb99cdfR99-R100) [[4]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R646-R657) [[5]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R755-R766) [[6]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R808-R809) [[7]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R1340-R1341)
* Updated logic for manifest and annotation generation to handle these new variants, including correct assignment of behaviors to image services and appropriate labeling. [[1]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R1034-R1049) F322d9d0L969R969, [[2]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R1159-R1166) [[3]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R869-R876)

**UI and test scenario updates:**

* Updated the Svelte UI to display and allow navigation to the new rate-limited image service scenarios, including new error categories and scenario descriptions. [[1]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR36) [[2]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR132) [[3]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR251-R255) [[4]](diffhunk://#diff-6025a5dc6bee8bc154a2d194f7394316b41a072c2eb3dd5de773f5358446091bR644-R665)

**Other improvements and refactoring:**

* Added normalization for labeled content resources (such as `homepage` and `rendering`) in IIIF 3 manifests to ensure they always have a label, improving fixture consistency. [[1]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R2421-R2438) [[2]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26L2343-R2493)
* Fixed service type selection for intentionally "wrong" image service types in test fixtures. [[1]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26R155-R158) [[2]](diffhunk://#diff-3475de0fbf8b534d43591ee01377e0ef2843a3aab11ee770c95d43e976688e26L1369-R1494)

These changes enhance the test server's ability to simulate real-world error conditions for IIIF clients, especially around rate limiting and error handling.