### PR TITLE
add coderabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,48 @@
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - develop
+    ignore_title_keywords:
+      - WIP
+      - '[skip review]'
+    ignore_usernames:
+      - github-actions[bot]
+
+  path_instructions:
+    - path: 'apps/**'
+      instructions: |
+        Review Svelte/SvelteKit UI changes for accessibility, state ownership,
+        responsive layout, and consistency with nearby app patterns.
+    - path: 'packages/**'
+      instructions: |
+        Treat package APIs as public. Watch for type/export changes, backwards
+        compatibility, deterministic tests, and workspace dependency edges.
+    - path: 'apis/**'
+      instructions: |
+        Focus on authentication, validation, SQL/query cost, Cloudflare Workers
+        compatibility, and error semantics.
+    - path: 'workers/**'
+      instructions: |
+        Review for Cloudflare Workers runtime compatibility, binding usage,
+        retry/error behavior, and edge-safe dependency choices.
+
+chat:
+  auto_reply: false
+  allow_non_org_members: false
+
+knowledge_base:
+  code_guidelines:
+    enabled: true


### PR DESCRIPTION
Adds a root CodeRabbit configuration for the Allmaps monorepo. The config enables automatic reviews for PRs targeting develop, adds path-specific guidance for apps, packages, APIs, and workers, and restricts CodeRabbit chat replies to organization members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review and automation settings for repository changes.
  * Added clearer guidance for different areas of the project, including app, package, API, and worker code.
  * Improved review output preferences to provide higher-level summaries and a cleaner review experience.
  * Refined which pull requests and automated reviews are ignored by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->