### PR TITLE
add generated IIIF fixture coverage

### DIFF
--- a/test/server/README.md
+++ b/test/server/README.md
@@ -46,6 +46,10 @@ GET /cors/annotations/images/:imageId.json
 GET /cors/annotations/images/:version/:level/:imageId.json
 GET /cors/annotations/combined/iiif{2|3}-level{0|1|2}.json
 GET /cors/annotations/combined/image-500-iiif3-level2.json
+GET /cors/annotations/combined/mixed-image-500-iiif3-level2.json
+GET /cors/annotations/combined/service-500-iiif3-level2.json
+GET /cors/annotations/combined/mixed-service-500-iiif3-level2.json
+GET /cors/annotations/combined/http-{401|403|404|429|500|503}.json
 GET /cors/annotations/combined/slow-iiif3-level2.json
 GET /cors/annotations/combined/mixed-slow-iiif3-level2.json
 GET /cors/annotations/combined/too-many-requests-after-20s-iiif3-level2.json
@@ -94,6 +98,7 @@ GET /cors/manifests/3/combined/manifest-embedded-annotations.json
 GET /cors/manifests/3/combined/partial-manifest-embedded-annotations.json
 GET /cors/manifests/3/combined/partial-embedded-annotations.json
 GET /cors/manifests/3/combined/partial-linked-annotations.json
+GET /cors/manifests/3/combined/all-embedded-annotations-mixed-errors.json
 GET /cors/manifests/3/combined/mixed-embedded-annotation-errors.json
 GET /cors/manifests/3/combined/mixed-linked-annotation-errors.json
 GET /cors/manifests/3/combined/too-many-requests-after-20s-iiif3-level2.json

--- a/test/server/package.json
+++ b/test/server/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "start": "node build",
     "import": "node scripts/import.ts",
+    "test": "vitest run",
     "types": "svelte-kit sync && tsc --noEmit",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -16,8 +17,8 @@
   },
   "dependencies": {
     "@allmaps/annotation": "workspace:^",
-    "@allmaps/iiif-parser": "workspace:^",
     "@allmaps/id": "workspace:^",
+    "@allmaps/iiif-parser": "workspace:^",
     "@allmaps/tailwind": "workspace:^",
     "@allmaps/transform": "workspace:^",
     "@allmaps/ui": "workspace:^",
@@ -44,6 +45,7 @@
     "tailwindcss": "^4.1.17",
     "typescript": "catalog:",
     "typescript-eslint": "^8.48.1",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/test/server/src/lib/components/Root.svelte
+++ b/test/server/src/lib/components/Root.svelte
@@ -600,6 +600,17 @@
                 link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
                 link.label === 'Mixed correct/incorrect embedded annotations'
             )
+          ),
+          createCombinedScenario(
+            'all-embedded-some-incorrect',
+            'Manifest with all maps embedded and some incorrect',
+            'Every canvas embeds its annotation page, while individual map annotations alternate between valid and intentionally broken.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
+                link.label === 'All embedded annotations, some incorrect'
+            )
           )
         ].filter((scenario) => scenario !== undefined)
       },
@@ -618,6 +629,53 @@
               (link) =>
                 link.resourceKind === 'Annotation page' &&
                 link.label === 'All info.jsons load, image requests return 500'
+            )
+          ),
+          createCombinedScenario(
+            'some-image-requests-return-500',
+            'Some image requests return 500',
+            'The annotation page loads normally, but only some referenced image requests fail with a 500 response.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'Some image requests return 500'
+            )
+          ),
+          createCombinedScenario(
+            'image-services-return-500',
+            'Annotation page loads, image services return 500',
+            'The annotation page loads normally, but every referenced image service info.json and image request fails with a 500 response.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label ===
+                  'Annotation page loads, image services return 500'
+            )
+          ),
+          createCombinedScenario(
+            'some-image-services-return-500',
+            'Some image services return 500',
+            'The annotation page loads normally, but only some referenced image service info.jsons and image requests fail with a 500 response.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'Annotation page' &&
+                link.label === 'Some image services return 500'
+            )
+          ),
+          ...[401, 403, 404, 429, 500, 503].map((status) =>
+            createCombinedScenario(
+              `annotation-page-http-${status}`,
+              `Annotation page returns ${status}`,
+              `The combined annotation page request itself fails with a ${status} response.`,
+              findCombinedLink(
+                'cors',
+                (link) =>
+                  link.resourceKind === 'Annotation page' &&
+                  link.label === `Annotation page returns ${status}`
+              )
             )
           ),
           createCombinedScenario(

--- a/test/server/src/lib/server.ts
+++ b/test/server/src/lib/server.ts
@@ -1,15 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 
-import { parseAnnotation } from '@allmaps/annotation'
-import { IIIF, Manifest } from '@allmaps/iiif-parser'
-import { GcpTransformer } from '@allmaps/transform'
-import sharp from 'sharp'
-
-import {
-  loadImageDefinitions,
-  type ImageFixtureDefinition
-} from './fixtures.ts'
 import {
   getBaseUrl,
   getImageServiceId,
@@ -23,295 +14,81 @@ import {
   parseVariantJsonFilename
 } from './paths.ts'
 import {
-  imageResponse,
   jsonResponse,
   redirectResponse,
   textResponse,
   withCors
 } from './responses.ts'
+import {
+  delay,
+  delaySlowResource,
+  getCombinedImageServiceBehavior,
+  isSlowCombinedVariant,
+  parseImageServiceBehavior,
+  shouldReturnTooManyRequests,
+  slowResourceDelayMs,
+  tooManyRequestsResponse
+} from './server/behaviors.ts'
+import {
+  createBrokenAnnotation,
+  createBrokenAnnotationMap,
+  getCombinedAnnotationErrorVariant,
+  getEmbeddedAnnotationErrorVariant,
+  getLinkedAnnotationErrorVariant,
+  isEmbeddedAnnotationVariant,
+  isLinkedAnnotationVariant,
+  shouldBreakCombinedAnnotation
+} from './server/annotations.ts'
+import {
+  catalogImageApiServices,
+  catalogImageComplianceLevels,
+  createBrokenInfoJson,
+  createImageApiLink,
+  createImageRequestResponse,
+  createInfoJson,
+  getIiif2Profile,
+  getImageApiVersionLabel,
+  getImageRequestExamples,
+  getImageServiceBaseUrl,
+  getImageServiceProfile,
+  getImageServiceType,
+  getLevel0TileExample,
+  getManifestImageBodyDimensions,
+  getManifestImageRequest,
+  getWrongImageServiceType,
+  isImageComplianceLevel,
+  parsePositiveNumber,
+  type ImageApiService,
+  type ImageApiServiceReference,
+  type ImageServiceBehavior
+} from './server/image-api.ts'
+import {
+  getFirstCanvas,
+  getFirstImageAnnotation,
+  getFirstImageResource,
+  getImage,
+  getImages,
+  getOriginalManifest,
+  hasMultipleMapAnnotations,
+  type ImageFixture
+} from './server/fixture-data.ts'
+import {
+  getIiif2Label,
+  getIiif2Rendering,
+  getIiif2Thumbnail
+} from './server/iiif2.ts'
+import { addNavPlaceContext, createNavPlace } from './server/navplace.ts'
 import type {
-  Bbox,
   CorsMode,
   IiifVersion,
   ImageComplianceLevel,
-  JsonObject,
-  Point,
-  Region,
-  Ring,
-  Size
+  JsonObject
 } from './types.ts'
 
-type ImageFixture = ImageFixtureDefinition
-type Link = {
-  label: string
-  href: string
-  version?: IiifVersion
-  versionLabel?: string
-  complianceLevel?: ImageComplianceLevel
-  complianceLabel?: string
-  group?: string
-}
-
-type ImageApiService = {
-  version: IiifVersion
-  complianceLevel: ImageComplianceLevel
-}
-
-type ImageServiceBehavior = 'image-500' | 'slow' | 'too-many-requests-after-20s'
-
-type ImageApiServiceReference = ImageApiService & {
-  behavior?: ImageServiceBehavior
-}
-
-const navPlaceContext = 'http://iiif.io/api/extension/navplace/context.json'
 const presentation3Context = 'http://iiif.io/api/presentation/3/context.json'
-
-const imageDefinitions = loadImageDefinitions()
-const slowResourceDelayMs = 4_000
-const tooManyRequestsAfterMs = 20_000
-
-const images = new Map(imageDefinitions.map((image) => [image.id, image]))
-const imageServiceBehaviorStartedAt = new Map<string, number>()
-const originalManifests = new Map(
-  imageDefinitions.flatMap((image) => {
-    if (!image.originalManifestPath) {
-      return []
-    }
-
-    const originalManifest = JSON.parse(
-      readFileSync(image.originalManifestPath, 'utf8')
-    )
-    const parsedManifest = IIIF.parse(originalManifest, {
-      keepSource: true
-    })
-
-    if (!(parsedManifest instanceof Manifest)) {
-      throw new Error(`${image.originalManifestPath} is not a IIIF manifest`)
-    }
-
-    return [
-      [
-        image.id,
-        {
-          parsedManifest,
-          source: originalManifest
-        }
-      ] as const
-    ]
-  })
-)
-
-const catalogImageComplianceLevels = ['level0', 'level2'] as const
-const catalogImageApiServices = (['2', '3'] as const).flatMap((version) =>
-  catalogImageComplianceLevels.map((complianceLevel) => ({
-    version,
-    complianceLevel
-  }))
-)
-
-function getImageApiVersionLabel(version: IiifVersion) {
-  return version === '2' ? '2.1' : '3.0'
-}
-
-function getImageApiLabel(version: IiifVersion) {
-  return `IIIF Image API ${getImageApiVersionLabel(version)}`
-}
-
-function createImageApiLink(
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  label: string,
-  href: string
-) {
-  return {
-    label,
-    href,
-    version,
-    versionLabel: getImageApiLabel(version),
-    complianceLevel,
-    complianceLabel: complianceLevel
-  }
-}
-
-function isImageComplianceLevel(value: string): value is ImageComplianceLevel {
-  return value === 'level0' || value === 'level1' || value === 'level2'
-}
-
-function getIiif2Profile(complianceLevel: ImageComplianceLevel) {
-  return `http://iiif.io/api/image/2/${complianceLevel}.json`
-}
-
-function getImageServiceProfile(
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel
-) {
-  return version === '2' ? getIiif2Profile(complianceLevel) : complianceLevel
-}
-
-function getImageServiceType(version: IiifVersion) {
-  return version === '2' ? 'ImageService2' : 'ImageService3'
-}
-
-function getWrongImageServiceType(version: IiifVersion) {
-  return version === '2' ? 'ImageService3' : 'ImageService2'
-}
 
 function isJsonObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
-}
-
-function getImage(imageId: string) {
-  const image = images.get(imageId)
-
-  if (!image) {
-    throw new Error(`Unknown image fixture: ${imageId}`)
-  }
-
-  return image
-}
-
-function getOriginalManifest(image: ImageFixture) {
-  return originalManifests.get(image.id)
-}
-
-function getGeoreferencedMap(image: ImageFixture) {
-  const annotation = JSON.parse(readFileSync(image.annotationPath, 'utf8'))
-  const maps = parseAnnotation(annotation)
-  const map = maps[0]
-
-  if (!map) {
-    throw new Error(`No georeferenced map found for ${image.id}`)
-  }
-
-  return map
-}
-
-function hasMultipleMapAnnotations(image: ImageFixture) {
-  const annotation = JSON.parse(readFileSync(image.annotationPath, 'utf8'))
-
-  return Array.isArray(annotation.items) && annotation.items.length > 1
-}
-
-function getFirstCanvas(sourceManifest: JsonObject) {
-  return cloneJsonObject(sourceManifest.sequences?.[0]?.canvases?.[0])
-}
-
-function getFirstImageAnnotation(sourceManifest: JsonObject) {
-  return cloneJsonObject(
-    sourceManifest.sequences?.[0]?.canvases?.[0]?.images?.[0]
-  )
-}
-
-function getFirstImageResource(sourceManifest: JsonObject) {
-  return cloneJsonObject(
-    sourceManifest.sequences?.[0]?.canvases?.[0]?.images?.[0]?.resource
-  )
-}
-
-function computeBbox(points: Ring): Bbox {
-  return [
-    Math.min(...points.map((point) => point[0])),
-    Math.min(...points.map((point) => point[1])),
-    Math.max(...points.map((point) => point[0])),
-    Math.max(...points.map((point) => point[1]))
-  ]
-}
-
-function bboxToCenter(bbox: Bbox): Point {
-  return [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2]
-}
-
-function bboxToRing(bbox: Bbox): Ring {
-  return [
-    [bbox[0], bbox[1]],
-    [bbox[2], bbox[1]],
-    [bbox[2], bbox[3]],
-    [bbox[0], bbox[3]],
-    [bbox[0], bbox[1]]
-  ]
-}
-
-function getGeoMask(image: ImageFixture): Ring {
-  const georeferencedMap = getGeoreferencedMap(image)
-  const transformer = GcpTransformer.fromGeoreferencedMap(georeferencedMap)
-  const resourceMask = georeferencedMap.resourceMask as unknown as Ring
-
-  return transformer.transformToGeo([resourceMask])[0] as unknown as Ring
-}
-
-function createGeoJsonFeatureCollection(
-  manifestId: string,
-  geometry:
-    | {
-        type: 'Point'
-        coordinates: Point
-      }
-    | {
-        type: 'Polygon'
-        coordinates: Ring[]
-      },
-  label: string
-) {
-  return {
-    id: `${manifestId}/navplace`,
-    type: 'FeatureCollection',
-    features: [
-      {
-        id: `${manifestId}/navplace/feature/1`,
-        type: 'Feature',
-        properties: {
-          label: {
-            none: [label]
-          }
-        },
-        geometry
-      }
-    ]
-  }
-}
-
-function addNavPlaceContext(manifest: JsonObject) {
-  const context = manifest['@context']
-
-  return {
-    ...manifest,
-    '@context': Array.isArray(context)
-      ? [navPlaceContext, ...context.filter((item) => item !== navPlaceContext)]
-      : [navPlaceContext, context ?? presentation3Context]
-  }
-}
-
-function createNavPlace(
-  manifestId: string,
-  image: ImageFixture,
-  variant: string
-) {
-  const geoMask = getGeoMask(image)
-  const geoMaskBbox = computeBbox(geoMask)
-
-  if (variant === 'navplace-midpoint') {
-    return createGeoJsonFeatureCollection(
-      manifestId,
-      {
-        type: 'Point',
-        coordinates: bboxToCenter(geoMaskBbox)
-      },
-      `${image.label} midpoint`
-    )
-  }
-
-  if (variant === 'navplace-bbox') {
-    return createGeoJsonFeatureCollection(
-      manifestId,
-      {
-        type: 'Polygon',
-        coordinates: [bboxToRing(geoMaskBbox)]
-      },
-      `${image.label} bounding box`
-    )
-  }
-
-  throw new Error(`Unknown navPlace variant: ${variant}`)
 }
 
 function createEmbeddedAnnotation(
@@ -375,52 +152,6 @@ function createEmbeddedAnnotation(
   }
 }
 
-function getEmbeddedAnnotationErrorVariant(variant: string) {
-  if (variant === 'embedded-annotation-missing-target') {
-    return 'missing-target'
-  }
-
-  if (variant === 'embedded-annotation-one-gcp') {
-    return 'one-gcp'
-  }
-
-  if (variant === 'embedded-annotation-mixed-errors') {
-    return 'mixed-errors'
-  }
-
-  return undefined
-}
-
-function getLinkedAnnotationErrorVariant(variant: string) {
-  if (variant === 'linked-annotation-missing-target') {
-    return 'missing-target'
-  }
-
-  if (variant === 'linked-annotation-one-gcp') {
-    return 'one-gcp'
-  }
-
-  if (variant === 'linked-annotation-mixed-errors') {
-    return 'mixed-errors'
-  }
-
-  return undefined
-}
-
-function isEmbeddedAnnotationVariant(variant: string) {
-  return (
-    variant === 'embedded-annotation' ||
-    getEmbeddedAnnotationErrorVariant(variant) !== undefined
-  )
-}
-
-function isLinkedAnnotationVariant(variant: string) {
-  return (
-    variant === 'linked-annotation' ||
-    getLinkedAnnotationErrorVariant(variant) !== undefined
-  )
-}
-
 function isIiif3ManifestVariant(variant: string) {
   return (
     variant === 'default' ||
@@ -433,7 +164,7 @@ function isIiif3ManifestVariant(variant: string) {
 }
 
 function getCombinedImages() {
-  return [...images.values()]
+  return getImages()
 }
 
 function createCombinedImageServiceLink(
@@ -500,101 +231,30 @@ function parseCombinedImageServiceManifestVariant(variant: string):
   }
 }
 
-function parseImageServiceBehavior(
-  behavior: string | undefined
-): ImageServiceBehavior | undefined {
-  if (!behavior) {
-    return undefined
+function getCombinedAnnotationHttpErrorStatus(variant: string) {
+  if (variant === 'http-401') {
+    return 401
   }
 
-  if (
-    behavior === 'image-500' ||
-    behavior === 'slow' ||
-    behavior === 'too-many-requests-after-20s'
-  ) {
-    return behavior
+  if (variant === 'http-403') {
+    return 403
   }
 
-  throw new Error(`Unknown image service behavior: ${behavior}`)
-}
-
-function getCombinedImageServiceBehavior(
-  variant: string
-): ImageServiceBehavior | undefined {
-  if (variant === 'image-500-iiif3-level2') {
-    return 'image-500'
+  if (variant === 'http-404') {
+    return 404
   }
 
-  if (variant === 'slow-iiif3-level2') {
-    return 'slow'
+  if (variant === 'http-429') {
+    return 429
   }
 
-  if (variant === 'too-many-requests-after-20s-iiif3-level2') {
-    return 'too-many-requests-after-20s'
+  if (variant === 'http-500') {
+    return 500
   }
 
-  return undefined
-}
-
-function isSlowCombinedVariant(variant: string) {
-  return getCombinedImageServiceBehavior(variant) === 'slow'
-}
-
-function delay(ms: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
-
-async function delaySlowResource(variantOrBehavior: string | undefined) {
-  if (variantOrBehavior === 'slow') {
-    await delay(slowResourceDelayMs)
+  if (variant === 'http-503') {
+    return 503
   }
-}
-
-function getImageServiceBehaviorKey(
-  corsMode: CorsMode,
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  imageId: string,
-  behavior: ImageServiceBehavior
-) {
-  return [corsMode, version, complianceLevel, imageId, behavior].join(':')
-}
-
-function shouldReturnTooManyRequests(
-  corsMode: CorsMode,
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  imageId: string,
-  behavior: ImageServiceBehavior | undefined
-) {
-  if (behavior !== 'too-many-requests-after-20s') {
-    return false
-  }
-
-  const key = getImageServiceBehaviorKey(
-    corsMode,
-    version,
-    complianceLevel,
-    imageId,
-    behavior
-  )
-  const now = Date.now()
-  const startedAt = imageServiceBehaviorStartedAt.get(key) ?? now
-
-  if (!imageServiceBehaviorStartedAt.has(key)) {
-    imageServiceBehaviorStartedAt.set(key, startedAt)
-  }
-
-  return now - startedAt >= tooManyRequestsAfterMs
-}
-
-function tooManyRequestsResponse(corsMode: CorsMode) {
-  const response = textResponse('Too Many Requests', corsMode, 429)
-  response.headers.set('retry-after', '20')
-
-  return response
 }
 
 function getCombinedAnnotationVariants(baseUrl: string) {
@@ -630,6 +290,60 @@ function getCombinedAnnotationVariants(baseUrl: string) {
       'level2',
       'All info.jsons load, image requests return 500',
       `${baseUrl}/annotations/combined/image-500-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Some image requests return 500',
+      `${baseUrl}/annotations/combined/mixed-image-500-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page loads, image services return 500',
+      `${baseUrl}/annotations/combined/service-500-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Some image services return 500',
+      `${baseUrl}/annotations/combined/mixed-service-500-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page returns 401',
+      `${baseUrl}/annotations/combined/http-401.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page returns 403',
+      `${baseUrl}/annotations/combined/http-403.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page returns 404',
+      `${baseUrl}/annotations/combined/http-404.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page returns 429',
+      `${baseUrl}/annotations/combined/http-429.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page returns 500',
+      `${baseUrl}/annotations/combined/http-500.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
+      'Annotation page returns 503',
+      `${baseUrl}/annotations/combined/http-503.json`
     ),
     createImageApiLink(
       '3',
@@ -737,6 +451,12 @@ function getCombinedManifestVariants(baseUrl: string) {
     createImageApiLink(
       '3',
       'level2',
+      'All embedded annotations, some incorrect',
+      `${baseUrl}/manifests/3/combined/all-embedded-annotations-mixed-errors.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
       'Mixed correct/incorrect linked annotations',
       `${baseUrl}/manifests/3/combined/mixed-linked-annotation-errors.json`
     ),
@@ -801,6 +521,7 @@ function isCombinedIiif3ManifestVariant(variant: string) {
       'partial-manifest-embedded-annotations',
       'partial-embedded-annotations',
       'partial-linked-annotations',
+      'all-embedded-annotations-mixed-errors',
       'mixed-embedded-annotation-errors',
       'mixed-linked-annotation-errors',
       'image-500-iiif3-level2',
@@ -852,6 +573,10 @@ function getCombinedManifestLabel(variant: string) {
 
   if (variant === 'mixed-embedded-annotation-errors') {
     return 'Combined fixture images with mixed correct/incorrect embedded annotations'
+  }
+
+  if (variant === 'all-embedded-annotations-mixed-errors') {
+    return 'Combined fixture images with all annotations embedded and some incorrect maps'
   }
 
   if (variant === 'mixed-linked-annotation-errors') {
@@ -945,6 +670,10 @@ function getCombinedCanvasManifestVariant(variant: string, index: number) {
 
   if (variant === 'partial-linked-annotations') {
     return index % 2 === 0 ? 'linked-annotation' : 'default'
+  }
+
+  if (variant === 'all-embedded-annotations-mixed-errors') {
+    return 'embedded-annotation'
   }
 
   if (variant === 'mixed-embedded-annotation-errors') {
@@ -1138,6 +867,7 @@ function getCombinedAnnotationImageService(
     variant === 'mixed-cors-errors-iiif3-level2' ||
     variant === 'mixed-partof-hierarchy-iiif3-level2' ||
     variant === 'image-500-iiif3-level2' ||
+    variant === 'service-500-iiif3-level2' ||
     variant === 'slow-iiif3-level2' ||
     variant === 'too-many-requests-after-20s-iiif3-level2'
   ) {
@@ -1145,6 +875,22 @@ function getCombinedAnnotationImageService(
       version: '3',
       complianceLevel: 'level2',
       behavior: getCombinedImageServiceBehavior(variant)
+    }
+  }
+
+  if (variant === 'mixed-image-500-iiif3-level2') {
+    return {
+      version: '3',
+      complianceLevel: 'level2',
+      behavior: index % 2 === 0 ? undefined : 'image-500'
+    }
+  }
+
+  if (variant === 'mixed-service-500-iiif3-level2') {
+    return {
+      version: '3',
+      complianceLevel: 'level2',
+      behavior: index % 2 === 0 ? undefined : 'service-500'
     }
   }
 
@@ -1227,20 +973,6 @@ function createImageAnnotation(
     ...annotation,
     id: getImageAnnotationId(baseUrl, image, service)
   }
-}
-
-function getCombinedAnnotationErrorVariant(index: number) {
-  return ['one-gcp', 'bad-resource-size', 'missing-target'][index % 3] as string
-}
-
-function shouldBreakCombinedAnnotation(variant: string, index: number) {
-  return (
-    (variant === 'mixed-errors' ||
-      variant === 'mixed-cors-errors' ||
-      variant === 'mixed-errors-iiif3-level2' ||
-      variant === 'mixed-cors-errors-iiif3-level2') &&
-    index % 2 === 1
-  )
 }
 
 function removeManifestPartOf(resource: JsonObject) {
@@ -1335,6 +1067,9 @@ function createCombinedAnnotation(
       'mixed-errors-iiif3-level2',
       'mixed-cors-errors-iiif3-level2',
       'image-500-iiif3-level2',
+      'mixed-image-500-iiif3-level2',
+      'service-500-iiif3-level2',
+      'mixed-service-500-iiif3-level2',
       'slow-iiif3-level2',
       'mixed-slow-iiif3-level2',
       'too-many-requests-after-20s-iiif3-level2',
@@ -1447,22 +1182,6 @@ function getCombinedLinkedAnnotationPageId(
   }.json`
 }
 
-function getManifestImageRequest(
-  imageServiceId: string,
-  imageApiVersion: IiifVersion
-) {
-  const imagePathSize = imageApiVersion === '2' ? 'full' : 'max'
-
-  return `${imageServiceId}/full/${imagePathSize}/0/default.jpg`
-}
-
-function getManifestImageBodyDimensions(image: ImageFixture) {
-  return {
-    width: image.width,
-    height: image.height
-  }
-}
-
 function createIiif3Canvas(
   request: Request,
   corsMode: CorsMode,
@@ -1564,6 +1283,44 @@ function createIiif3Canvas(
   return canvas
 }
 
+function getMapAnnotationCount(image: ImageFixture) {
+  const annotation = JSON.parse(readFileSync(image.annotationPath, 'utf8'))
+
+  return Array.isArray(annotation.items) ? annotation.items.length : 0
+}
+
+function getCombinedMapAnnotationOffset(imageIndex: number) {
+  return getCombinedImages()
+    .slice(0, imageIndex)
+    .reduce((total, image) => total + getMapAnnotationCount(image), 0)
+}
+
+function applyMixedEmbeddedAnnotationErrors(
+  canvas: JsonObject,
+  image: ImageFixture,
+  startIndex: number
+) {
+  const annotationPage = canvas.annotations?.[0]
+
+  if (!Array.isArray(annotationPage?.items)) {
+    return
+  }
+
+  annotationPage.items = annotationPage.items.map(
+    (annotation: JsonObject, index: number) => {
+      const annotationIndex = startIndex + index
+
+      return annotationIndex % 2 === 0
+        ? annotation
+        : createBrokenAnnotationMap(
+            cloneJsonObject(annotation),
+            image,
+            getCombinedAnnotationErrorVariant(annotationIndex)
+          )
+    }
+  )
+}
+
 function createCombinedIiif3Manifest(
   request: Request,
   corsMode: CorsMode,
@@ -1582,8 +1339,7 @@ function createCombinedIiif3Manifest(
     label,
     items: getCombinedImages().map((image, index) => {
       const imageService = getCombinedCanvasImageService(variant, index)
-
-      return createIiif3Canvas(
+      const canvas = createIiif3Canvas(
         request,
         corsMode,
         image,
@@ -1596,6 +1352,16 @@ function createCombinedIiif3Manifest(
         imageService.complianceLevel,
         imageService.behavior ?? getCombinedImageServiceBehavior(variant)
       )
+
+      if (variant === 'all-embedded-annotations-mixed-errors') {
+        applyMixedEmbeddedAnnotationErrors(
+          canvas,
+          image,
+          getCombinedMapAnnotationOffset(index)
+        )
+      }
+
+      return canvas
     })
   }
 
@@ -1637,7 +1403,7 @@ function createCombinedIiif3CanvasResource(
   }
   const imageService = getCombinedCanvasImageService(variant, imageIndex)
 
-  return createIiif3Canvas(
+  const canvas = createIiif3Canvas(
     request,
     corsMode,
     image,
@@ -1650,6 +1416,16 @@ function createCombinedIiif3CanvasResource(
     imageService.complianceLevel,
     imageService.behavior ?? getCombinedImageServiceBehavior(variant)
   )
+
+  if (variant === 'all-embedded-annotations-mixed-errors') {
+    applyMixedEmbeddedAnnotationErrors(
+      canvas,
+      image,
+      getCombinedMapAnnotationOffset(imageIndex)
+    )
+  }
+
+  return canvas
 }
 
 function createLinkedAnnotationPage(
@@ -1756,571 +1532,6 @@ function createCombinedIiif3LinkedAnnotationPage(
   )
 }
 
-function parseNumber(value: string, name: string) {
-  const number = Number(value)
-
-  if (!Number.isFinite(number)) {
-    throw new Error(`Invalid ${name}: ${value}`)
-  }
-
-  return number
-}
-
-function parsePositiveNumber(value: string, name: string) {
-  const number = parseNumber(value, name)
-
-  if (number <= 0) {
-    throw new Error(`Invalid ${name}: ${value}`)
-  }
-
-  return number
-}
-
-function parseRegion(regionParameter: string, image: ImageFixture): Region {
-  if (regionParameter === 'full') {
-    return {
-      left: 0,
-      top: 0,
-      width: image.width,
-      height: image.height
-    }
-  }
-
-  const isPercent = regionParameter.startsWith('pct:')
-  const values = (isPercent ? regionParameter.slice(4) : regionParameter)
-    .split(',')
-    .map((value) => parseNumber(value, 'region value'))
-
-  if (values.length !== 4) {
-    throw new Error(`Invalid region: ${regionParameter}`)
-  }
-
-  const [x, y, width, height] = values
-  const region = isPercent
-    ? {
-        left: Math.round((x / 100) * image.width),
-        top: Math.round((y / 100) * image.height),
-        width: Math.round((width / 100) * image.width),
-        height: Math.round((height / 100) * image.height)
-      }
-    : {
-        left: Math.round(x),
-        top: Math.round(y),
-        width: Math.round(width),
-        height: Math.round(height)
-      }
-
-  if (
-    region.left < 0 ||
-    region.top < 0 ||
-    region.width <= 0 ||
-    region.height <= 0 ||
-    region.left + region.width > image.width ||
-    region.top + region.height > image.height
-  ) {
-    throw new Error(`Region outside image bounds: ${regionParameter}`)
-  }
-
-  return region
-}
-
-function parseSize(sizeParameter: string, region: Region): Size | undefined {
-  if (sizeParameter === 'full' || sizeParameter === 'max') {
-    return undefined
-  }
-
-  if (sizeParameter.startsWith('pct:')) {
-    const percentage = parsePositiveNumber(sizeParameter.slice(4), 'percentage')
-
-    return {
-      width: Math.round((percentage / 100) * region.width)
-    }
-  }
-
-  const fit = sizeParameter.startsWith('!') ? 'inside' : 'fill'
-  const size = fit === 'inside' ? sizeParameter.slice(1) : sizeParameter
-  const [width, height] = size.split(',')
-
-  if (width && height) {
-    return {
-      width: Math.round(parsePositiveNumber(width, 'width')),
-      height: Math.round(parsePositiveNumber(height, 'height')),
-      fit
-    }
-  }
-
-  if (width) {
-    return {
-      width: Math.round(parsePositiveNumber(width, 'width'))
-    }
-  }
-
-  if (height) {
-    return {
-      height: Math.round(parsePositiveNumber(height, 'height'))
-    }
-  }
-
-  throw new Error(`Invalid size: ${sizeParameter}`)
-}
-
-function parseOutputFormat(format: string) {
-  if (format === 'jpg' || format === 'jpeg') {
-    return {
-      contentType: 'image/jpeg',
-      sharpFormat: 'jpeg' as const
-    }
-  }
-
-  if (format === 'png' || format === 'webp') {
-    return {
-      contentType: `image/${format}`,
-      sharpFormat: format as 'png' | 'webp'
-    }
-  }
-
-  throw new Error(`Unsupported format: ${format}`)
-}
-
-function getOutputDimensions(region: Region, size: Size | undefined) {
-  if (!size) {
-    return {
-      width: region.width,
-      height: region.height
-    }
-  }
-
-  if (size.width && size.height) {
-    if (size.fit === 'inside') {
-      const scale = Math.min(
-        size.width / region.width,
-        size.height / region.height
-      )
-
-      return {
-        width: Math.round(region.width * scale),
-        height: Math.round(region.height * scale)
-      }
-    }
-
-    return {
-      width: size.width,
-      height: size.height
-    }
-  }
-
-  if (size.width) {
-    return {
-      width: size.width,
-      height: Math.round((region.height / region.width) * size.width)
-    }
-  }
-
-  if (size.height) {
-    return {
-      width: Math.round((region.width / region.height) * size.height),
-      height: size.height
-    }
-  }
-
-  return {
-    width: region.width,
-    height: region.height
-  }
-}
-
-function assertLevel0TileRequest(
-  image: ImageFixture,
-  region: Region,
-  size: Size | undefined,
-  rotation: string,
-  quality: string,
-  format: string
-) {
-  if (rotation !== '0' || quality !== 'default' || format !== 'jpg') {
-    throw new Error('Level 0 only serves default JPEG requests')
-  }
-
-  const isFullRegion =
-    region.left === 0 &&
-    region.top === 0 &&
-    region.width === image.width &&
-    region.height === image.height
-  if (isFullRegion && !size) {
-    return
-  }
-
-  if (isFullRegion) {
-    throw new Error(
-      'Level 0 only serves full/max full-image requests and tiles declared in info.json'
-    )
-  }
-
-  if (!size?.width || size.fit === 'inside') {
-    throw new Error(
-      'Level 0 requests must use full/max full-image syntax, width-only tile size syntax, or exact tile size syntax'
-    )
-  }
-
-  const tile = getTiles(image)[0]
-  const scaleFactor = Math.round(region.width / size.width)
-  const expectedOutputWidth = Math.ceil(region.width / scaleFactor)
-  const expectedOutputHeight = Math.ceil(region.height / scaleFactor)
-  const requestedOutputHeight = size.height ?? expectedOutputHeight
-
-  if (
-    !tile.scaleFactors.includes(scaleFactor) ||
-    size.width !== expectedOutputWidth ||
-    requestedOutputHeight !== expectedOutputHeight ||
-    expectedOutputWidth > tile.width ||
-    expectedOutputHeight > tile.height ||
-    region.left % (tile.width * scaleFactor) !== 0 ||
-    region.top % (tile.height * scaleFactor) !== 0 ||
-    region.width > tile.width * scaleFactor ||
-    region.height > tile.height * scaleFactor ||
-    region.left + region.width > image.width ||
-    region.top + region.height > image.height
-  ) {
-    throw new Error(
-      'Level 0 only serves full/max full-image requests and tiles declared in info.json'
-    )
-  }
-}
-
-function createWatermark(output: { width: number; height: number }) {
-  const label =
-    output.width < 240 ? 'SCALED-DOWN COPY' : 'SCALED-DOWN COPY OF ORIGINAL'
-  const pixelSize = Math.max(1, Math.min(3, Math.floor(output.width / 260)))
-  const paddingX = Math.max(6, pixelSize * 5)
-  const paddingY = Math.max(5, pixelSize * 4)
-  const letterGap = pixelSize
-  const spaceWidth = pixelSize * 3
-  const glyphHeight = pixelSize * 7
-  const logoSize = Math.max(10, pixelSize * 9)
-  const contentHeight = Math.max(glyphHeight, logoSize)
-  const logoX = paddingX
-  const logoY = paddingY + Math.round((contentHeight - logoSize) / 2)
-  const glyphY = paddingY + Math.round((contentHeight - glyphHeight) / 2)
-  let cursorX = paddingX + logoSize + pixelSize * 4
-  const rects: string[] = []
-
-  for (const character of label) {
-    if (character === ' ') {
-      cursorX += spaceWidth
-      continue
-    }
-
-    const glyph = watermarkGlyphs[character]
-
-    if (!glyph) {
-      continue
-    }
-
-    for (const [rowIndex, row] of glyph.entries()) {
-      for (const [columnIndex, value] of [...row].entries()) {
-        if (value === '1') {
-          rects.push(
-            `<rect x="${cursorX + columnIndex * pixelSize}" y="${
-              glyphY + rowIndex * pixelSize
-            }" width="${pixelSize}" height="${pixelSize}"/>`
-          )
-        }
-      }
-    }
-
-    cursorX += glyph[0].length * pixelSize + letterGap
-  }
-
-  const width = Math.min(output.width, cursorX + paddingX - letterGap)
-  const height = contentHeight + paddingY * 2
-
-  return Buffer.from(`
-    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
-      <rect width="100%" height="100%" fill="black" fill-opacity="0.58"/>
-      <g fill="white" fill-opacity="0.92">
-        ${createWatermarkLogo(logoX, logoY, logoSize)}
-        ${rects.join('')}
-      </g>
-    </svg>
-  `)
-}
-
-function createWatermarkLogo(x: number, y: number, size: number) {
-  return `
-    <svg x="${x}" y="${y}" width="${size}" height="${size}" viewBox="0 0 1440 1440">
-      <polygon points="1275.2,1031.6 720,1359.5 164.9,1031.7 230.3,993 720,1282.2 1209.8,993"/>
-      <polygon points="1275.2,875.8 720,1203.7 164.8,875.8 230.2,837.2 720,1126.4 1209.8,837.2"/>
-      <polygon points="1275.2,720 720,1047.9 164.8,720 230.2,681.4 720,970.5 1209.8,681.4"/>
-      <polygon points="1275.1,564.2 1209.7,602.8 1143.2,642.1 720,892 296.7,642.1 230.2,602.8 164.8,564.2 230.2,525.5 720,814.7 1209.7,525.5"/>
-      <path d="M720,80.5L164.8,408.4L720,736.2l555.1-327.9L720,80.5z M676.6,639.9l-93.5-54l68.6-71.1L513.6,435l-122.7,39.8l-93.5-54l608-178.7l80.6,46.5L676.6,639.9z"/>
-      <polygon points="827.2,334.1 705.9,459.1 610.5,404"/>
-    </svg>
-  `
-}
-
-const watermarkGlyphs: Record<string, string[]> = {
-  A: ['01110', '10001', '10001', '11111', '10001', '10001', '10001'],
-  C: ['01111', '10000', '10000', '10000', '10000', '10000', '01111'],
-  D: ['11110', '10001', '10001', '10001', '10001', '10001', '11110'],
-  E: ['11111', '10000', '10000', '11110', '10000', '10000', '11111'],
-  F: ['11111', '10000', '10000', '11110', '10000', '10000', '10000'],
-  G: ['01111', '10000', '10000', '10011', '10001', '10001', '01111'],
-  I: ['11111', '00100', '00100', '00100', '00100', '00100', '11111'],
-  L: ['10000', '10000', '10000', '10000', '10000', '10000', '11111'],
-  N: ['10001', '11001', '10101', '10011', '10001', '10001', '10001'],
-  O: ['01110', '10001', '10001', '10001', '10001', '10001', '01110'],
-  P: ['11110', '10001', '10001', '11110', '10000', '10000', '10000'],
-  R: ['11110', '10001', '10001', '11110', '10100', '10010', '10001'],
-  S: ['01111', '10000', '10000', '01110', '00001', '00001', '11110'],
-  W: ['10001', '10001', '10001', '10101', '10101', '10101', '01010'],
-  Y: ['10001', '10001', '01010', '00100', '00100', '00100', '00100'],
-  '-': ['00000', '00000', '00000', '11111', '00000', '00000', '00000']
-}
-
-function getScaleFactors(image: ImageFixture) {
-  const scaleFactors = [1]
-  const largestDimension = Math.max(image.width, image.height)
-
-  while (512 * scaleFactors.at(-1)! < largestDimension) {
-    scaleFactors.push(scaleFactors.at(-1)! * 2)
-  }
-
-  return scaleFactors
-}
-
-function getSizes(image: ImageFixture) {
-  const sizes = [...getScaleFactors(image)].reverse().map((scaleFactor) => ({
-    width: Math.ceil(image.width / scaleFactor),
-    height: Math.ceil(image.height / scaleFactor)
-  }))
-  const hasFullSize = sizes.some(
-    (size) => size.width === image.width && size.height === image.height
-  )
-
-  return hasFullSize
-    ? sizes
-    : [
-        ...sizes,
-        {
-          width: image.width,
-          height: image.height
-        }
-      ]
-}
-
-function getTiles(image: ImageFixture) {
-  return [
-    {
-      width: 512,
-      height: 512,
-      scaleFactors: getScaleFactors(image)
-    }
-  ]
-}
-
-function createInfoJson(
-  request: Request,
-  corsMode: CorsMode,
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  image: ImageFixture,
-  behavior?: ImageServiceBehavior
-) {
-  const id = getImageServiceId(
-    request,
-    corsMode,
-    version,
-    complianceLevel,
-    image.id,
-    behavior
-  )
-  const tiles = getTiles(image)
-
-  if (version === '2') {
-    const profile: (JsonObject | string)[] =
-      complianceLevel === 'level0'
-        ? [`http://iiif.io/api/image/2/${complianceLevel}.json`]
-        : [
-            `http://iiif.io/api/image/2/${complianceLevel}.json`,
-            {
-              formats:
-                complianceLevel === 'level2'
-                  ? ['jpg', 'png', 'webp']
-                  : ['jpg', 'webp'],
-              qualities:
-                complianceLevel === 'level2'
-                  ? ['default', 'color']
-                  : ['default'],
-              supports:
-                complianceLevel === 'level2'
-                  ? [
-                      'regionByPx',
-                      'regionByPct',
-                      'sizeByW',
-                      'sizeByH',
-                      'sizeByWh',
-                      'sizeByPct',
-                      'sizeByConfinedWh',
-                      'cors'
-                    ]
-                  : ['regionByPx', 'sizeByW', 'sizeByH', 'sizeByPct', 'cors']
-            }
-          ]
-
-    return {
-      '@context': 'http://iiif.io/api/image/2/context.json',
-      '@id': id,
-      protocol: 'http://iiif.io/api/image',
-      width: image.width,
-      height: image.height,
-      tiles,
-      ...(complianceLevel === 'level0' ? {} : { sizes: getSizes(image) }),
-      profile
-    }
-  }
-
-  const level3Extras =
-    complianceLevel === 'level0'
-      ? {}
-      : complianceLevel === 'level1'
-        ? {
-            extraFormats: ['webp'],
-            extraFeatures: ['regionByPx', 'sizeByW', 'sizeByH', 'cors']
-          }
-        : {
-            extraFormats: ['png', 'webp'],
-            extraQualities: ['color'],
-            extraFeatures: [
-              'regionByPx',
-              'regionByPct',
-              'sizeByW',
-              'sizeByH',
-              'sizeByWh',
-              'sizeByPct',
-              'sizeByConfinedWh',
-              'cors'
-            ]
-          }
-
-  return {
-    '@context': 'http://iiif.io/api/image/3/context.json',
-    id,
-    type: 'ImageService3',
-    protocol: 'http://iiif.io/api/image',
-    width: image.width,
-    height: image.height,
-    tiles,
-    ...(complianceLevel === 'level0' ? {} : { sizes: getSizes(image) }),
-    profile: complianceLevel,
-    ...level3Extras
-  }
-}
-
-function createBrokenInfoJson(
-  request: Request,
-  corsMode: CorsMode,
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  image: ImageFixture,
-  variant: string
-) {
-  const infoJson = cloneJsonObject(
-    createInfoJson(request, corsMode, version, complianceLevel, image)
-  )
-
-  if (variant === 'missing-dimensions') {
-    delete infoJson.width
-    delete infoJson.height
-
-    return infoJson
-  }
-
-  if (variant === 'bad-tiles') {
-    return {
-      ...infoJson,
-      tiles: [
-        {
-          width: '512',
-          height: 0,
-          scaleFactors: ['one', 2, -4]
-        }
-      ]
-    }
-  }
-
-  throw new Error(`Unknown info.json error variant: ${variant}`)
-}
-
-function createBrokenAnnotation(
-  annotation: unknown,
-  baseUrl: string,
-  image: ImageFixture,
-  variant: string
-) {
-  const localizedAnnotation = localizeFixtureUrls(annotation, baseUrl)
-  const brokenAnnotation = cloneJsonObject(localizedAnnotation)
-  const maps = Array.isArray(brokenAnnotation.items)
-    ? brokenAnnotation.items.map((item) => cloneJsonObject(item))
-    : []
-
-  if (variant === 'mixed-errors') {
-    return {
-      ...brokenAnnotation,
-      items: maps.map((map, index) =>
-        index % 2 === 0
-          ? map
-          : createBrokenAnnotationMap(
-              map,
-              image,
-              getCombinedAnnotationErrorVariant(index)
-            )
-      )
-    }
-  }
-
-  const firstMap = maps[0] ?? {}
-
-  return {
-    ...brokenAnnotation,
-    items: [createBrokenAnnotationMap(firstMap, image, variant)]
-  }
-}
-
-function createBrokenAnnotationMap(
-  map: JsonObject,
-  image: ImageFixture,
-  variant: string
-) {
-  const brokenMap = cloneJsonObject(map)
-
-  if (variant === 'missing-target') {
-    delete brokenMap.target
-  } else if (variant === 'bad-resource-size') {
-    const target = cloneJsonObject(brokenMap.target)
-    const source = cloneJsonObject(target.source)
-
-    brokenMap.target = {
-      ...target,
-      source: {
-        ...source,
-        width: image.width * -1,
-        height: 'unknown'
-      }
-    }
-  } else if (variant === 'one-gcp') {
-    const body = cloneJsonObject(brokenMap.body)
-
-    brokenMap.body = {
-      ...body,
-      features: Array.isArray(body.features) ? body.features.slice(0, 1) : []
-    }
-  } else {
-    throw new Error(`Unknown annotation error variant: ${variant}`)
-  }
-
-  return brokenMap
-}
-
 function createIiif2Manifest(
   request: Request,
   corsMode: CorsMode,
@@ -2370,19 +1581,24 @@ function createIiif2Manifest(
     '@context': 'http://iiif.io/api/presentation/2/context.json',
     '@id': manifestId,
     '@type': 'sc:Manifest',
-    label: sourceManifest.label ?? manifestLabel,
+    label: getIiif2Label(sourceManifest.label, manifestLabel),
+    rendering: getIiif2Rendering(sourceManifest.rendering),
+    thumbnail: getIiif2Thumbnail(sourceManifest.thumbnail),
     sequences: [
       {
         ...cloneJsonObject(sourceManifest.sequences?.[0]),
         '@id': `${manifestId}/sequence/1`,
         '@type': 'sc:Sequence',
-        label: sourceManifest.sequences?.[0]?.label ?? manifestLabel,
+        label: getIiif2Label(
+          sourceManifest.sequences?.[0]?.label,
+          manifestLabel
+        ),
         canvases: [
           {
             ...sourceCanvas,
             '@id': canvasId,
             '@type': 'sc:Canvas',
-            label: sourceCanvas.label ?? canvasLabel,
+            label: getIiif2Label(sourceCanvas.label, canvasLabel),
             width: image.width,
             height: image.height,
             thumbnail: {
@@ -2506,134 +1722,6 @@ function createIiif3Manifest(
   return manifest
 }
 
-async function createImageRequestResponse(
-  corsMode: CorsMode,
-  complianceLevel: ImageComplianceLevel,
-  image: ImageFixture,
-  regionParameter: string,
-  sizeParameter: string,
-  rotation: string,
-  quality: string,
-  file: string
-) {
-  if (rotation !== '0') {
-    throw new Error('Only rotation 0 is supported')
-  }
-
-  if (quality !== 'default' && quality !== 'color') {
-    throw new Error('Only default and color quality are supported')
-  }
-
-  const fileMatch = file.match(/^(.+)\.(jpg|jpeg|png|webp)$/)
-
-  if (!fileMatch) {
-    throw new Error(`Invalid image request file: ${file}`)
-  }
-
-  const [, fileQuality, format] = fileMatch
-
-  if (fileQuality !== quality) {
-    throw new Error('Path quality and file quality do not match')
-  }
-
-  const region = parseRegion(regionParameter, image)
-  const size = parseSize(sizeParameter, region)
-  const outputFormat = parseOutputFormat(format)
-
-  if (complianceLevel === 'level0') {
-    assertLevel0TileRequest(image, region, size, rotation, quality, format)
-  }
-
-  const outputDimensions = getOutputDimensions(region, size)
-  let transformer = sharp(image.imagePath).extract(region)
-
-  if (size) {
-    transformer = transformer.resize(size)
-  }
-
-  const buffer = await transformer
-    .composite([
-      {
-        input: createWatermark(outputDimensions),
-        gravity: 'southeast'
-      }
-    ])
-    .toFormat(outputFormat.sharpFormat)
-    .toBuffer()
-
-  return imageResponse(buffer, corsMode, outputFormat.contentType)
-}
-
-function getImageServiceBaseUrl(
-  baseUrl: string,
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  imageId: string,
-  behavior?: ImageServiceBehavior
-) {
-  return `${baseUrl}/iiif/${version}/${complianceLevel}/${imageId}${behavior ? `/${behavior}` : ''}`
-}
-
-function getLevel0TileExample(image: ImageFixture, imageServiceUrl: string) {
-  const tile = getTiles(image)[0]
-  const width = Math.min(tile.width, image.width)
-  const height = Math.min(tile.height, image.height)
-
-  return `${imageServiceUrl}/0,0,${width},${height}/${width},/0/default.jpg`
-}
-
-function getImageRequestExamples(
-  image: ImageFixture,
-  version: IiifVersion,
-  complianceLevel: ImageComplianceLevel,
-  imageServiceUrl: string
-): Link[] {
-  if (complianceLevel === 'level0') {
-    return [
-      createImageApiLink(
-        version,
-        complianceLevel,
-        'Declared tile',
-        getLevel0TileExample(image, imageServiceUrl)
-      )
-    ]
-  }
-
-  const examples = [
-    createImageApiLink(
-      version,
-      complianceLevel,
-      'Full image, 600px wide',
-      `${imageServiceUrl}/full/600,/0/default.jpg`
-    ),
-    createImageApiLink(
-      version,
-      complianceLevel,
-      'Pixel region',
-      `${imageServiceUrl}/0,0,512,512/256,/0/default.jpg`
-    )
-  ]
-
-  if (complianceLevel === 'level2') {
-    examples.push(
-      createImageApiLink(
-        version,
-        complianceLevel,
-        'Percentage region',
-        `${imageServiceUrl}/pct:10,10,50,50/400,/0/default.jpg`
-      ),
-      createImageApiLink(
-        version,
-        complianceLevel,
-        'Confined WebP thumbnail',
-        `${imageServiceUrl}/full/!300,300/0/default.webp`
-      )
-    )
-  }
-
-  return examples
-}
-
 function getImageAnnotationLinks(baseUrl: string, image: ImageFixture) {
   return catalogImageApiServices.map(({ version, complianceLevel }) =>
     createImageApiLink(
@@ -2650,7 +1738,9 @@ function getImageAnnotationErrorLinks(baseUrl: string, image: ImageFixture) {
     ['Missing target', 'missing-target'],
     ['Invalid resource size', 'bad-resource-size'],
     ['Only 1 GCP', 'one-gcp'],
-    ['Mixed correct/incorrect maps', 'mixed-errors']
+    ...(hasMultipleMapAnnotations(image)
+      ? [['Mixed correct/incorrect maps', 'mixed-errors']]
+      : [])
   ] as const
 
   return catalogImageApiServices.flatMap(({ version, complianceLevel }) =>
@@ -2814,7 +1904,7 @@ export function createCatalog(request: Request, corsMode: CorsMode) {
       annotations: getCombinedAnnotationVariants(baseUrl),
       manifests: getCombinedManifestVariants(baseUrl)
     },
-    images: [...images.values()].map((image) => ({
+    images: getImages().map((image) => ({
       id: image.id,
       label: image.label,
       imageLabel: image.imageLabel,
@@ -2985,6 +2075,10 @@ async function routeFixtureRequest(
       return tooManyRequestsResponse(corsMode)
     }
 
+    if (behavior === 'service-500') {
+      return textResponse('Image service failed intentionally', corsMode, 500)
+    }
+
     return jsonResponse(
       createInfoJson(
         request,
@@ -3029,7 +2123,7 @@ async function routeFixtureRequest(
       return tooManyRequestsResponse(corsMode)
     }
 
-    if (behavior === 'image-500') {
+    if (behavior === 'image-500' || behavior === 'service-500') {
       return textResponse('Image request failed intentionally', corsMode, 500)
     }
 
@@ -3083,6 +2177,15 @@ async function routeFixtureRequest(
 
   if (segments[0] === 'annotations' && segments[1] === 'combined') {
     const variant = parseJsonFilename(segments[2])
+    const errorStatus = getCombinedAnnotationHttpErrorStatus(variant)
+
+    if (errorStatus) {
+      return textResponse(
+        `Combined annotation page returned ${errorStatus} intentionally`,
+        corsMode,
+        errorStatus
+      )
+    }
 
     if (isSlowCombinedVariant(variant)) {
       await delay(slowResourceDelayMs)

--- a/test/server/src/lib/server/annotations.ts
+++ b/test/server/src/lib/server/annotations.ts
@@ -1,0 +1,133 @@
+import { cloneJsonObject, localizeFixtureUrls } from '../paths.ts'
+import type { JsonObject } from '../types.ts'
+import type { ImageFixture } from './fixture-data.ts'
+
+export function getEmbeddedAnnotationErrorVariant(variant: string) {
+  if (variant === 'embedded-annotation-missing-target') {
+    return 'missing-target'
+  }
+
+  if (variant === 'embedded-annotation-one-gcp') {
+    return 'one-gcp'
+  }
+
+  if (variant === 'embedded-annotation-mixed-errors') {
+    return 'mixed-errors'
+  }
+
+  return undefined
+}
+
+export function getLinkedAnnotationErrorVariant(variant: string) {
+  if (variant === 'linked-annotation-missing-target') {
+    return 'missing-target'
+  }
+
+  if (variant === 'linked-annotation-one-gcp') {
+    return 'one-gcp'
+  }
+
+  if (variant === 'linked-annotation-mixed-errors') {
+    return 'mixed-errors'
+  }
+
+  return undefined
+}
+
+export function isEmbeddedAnnotationVariant(variant: string) {
+  return (
+    variant === 'embedded-annotation' ||
+    getEmbeddedAnnotationErrorVariant(variant) !== undefined
+  )
+}
+
+export function isLinkedAnnotationVariant(variant: string) {
+  return (
+    variant === 'linked-annotation' ||
+    getLinkedAnnotationErrorVariant(variant) !== undefined
+  )
+}
+
+export function getCombinedAnnotationErrorVariant(index: number) {
+  return ['one-gcp', 'bad-resource-size', 'missing-target'][index % 3] as string
+}
+
+export function shouldBreakCombinedAnnotation(variant: string, index: number) {
+  return (
+    (variant === 'mixed-errors' ||
+      variant === 'mixed-cors-errors' ||
+      variant === 'mixed-errors-iiif3-level2' ||
+      variant === 'mixed-cors-errors-iiif3-level2') &&
+    index % 2 === 1
+  )
+}
+
+export function createBrokenAnnotation(
+  annotation: unknown,
+  baseUrl: string,
+  image: ImageFixture,
+  variant: string
+) {
+  const localizedAnnotation = localizeFixtureUrls(annotation, baseUrl)
+  const brokenAnnotation = cloneJsonObject(localizedAnnotation)
+  const maps = Array.isArray(brokenAnnotation.items)
+    ? brokenAnnotation.items.map((item) => cloneJsonObject(item))
+    : []
+
+  if (variant === 'mixed-errors') {
+    return {
+      ...brokenAnnotation,
+      items: maps.map((map, index) =>
+        index % 2 === 0
+          ? map
+          : createBrokenAnnotationMap(
+              map,
+              image,
+              getCombinedAnnotationErrorVariant(index)
+            )
+      )
+    }
+  }
+
+  const firstMap = maps[0] ?? {}
+
+  return {
+    ...brokenAnnotation,
+    items: [createBrokenAnnotationMap(firstMap, image, variant)]
+  }
+}
+
+export function createBrokenAnnotationMap(
+  map: JsonObject,
+  image: ImageFixture,
+  variant: string
+) {
+  const brokenMap = cloneJsonObject(map)
+
+  if (variant === 'missing-target') {
+    delete brokenMap.target
+  } else if (variant === 'bad-resource-size') {
+    const target = cloneJsonObject(brokenMap.target)
+    const source = cloneJsonObject(target.source)
+
+    brokenMap.target = {
+      ...target,
+      source: {
+        ...source,
+        width: image.width * -1,
+        height: 'unknown'
+      }
+    }
+  } else if (variant === 'one-gcp') {
+    const body = cloneJsonObject(brokenMap.body)
+
+    brokenMap.body = {
+      ...body,
+      features: Array.isArray(body.features) ? body.features.slice(0, 1) : []
+    }
+  } else {
+    throw new Error(`Unknown annotation error variant: ${variant}`)
+  }
+
+  return brokenMap
+}

--- a/test/server/src/lib/server/behaviors.ts
+++ b/test/server/src/lib/server/behaviors.ts
@@ -1,0 +1,110 @@
+import { textResponse } from '../responses.ts'
+import type { CorsMode, IiifVersion, ImageComplianceLevel } from '../types.ts'
+import type { ImageServiceBehavior } from './image-api.ts'
+
+export const slowResourceDelayMs = 4_000
+const tooManyRequestsAfterMs = 20_000
+
+const imageServiceBehaviorStartedAt = new Map<string, number>()
+
+export function parseImageServiceBehavior(
+  behavior: string | undefined
+): ImageServiceBehavior | undefined {
+  if (!behavior) {
+    return undefined
+  }
+
+  if (
+    behavior === 'image-500' ||
+    behavior === 'service-500' ||
+    behavior === 'slow' ||
+    behavior === 'too-many-requests-after-20s'
+  ) {
+    return behavior
+  }
+
+  throw new Error(`Unknown image service behavior: ${behavior}`)
+}
+
+export function getCombinedImageServiceBehavior(
+  variant: string
+): ImageServiceBehavior | undefined {
+  if (variant === 'image-500-iiif3-level2') {
+    return 'image-500'
+  }
+
+  if (variant === 'service-500-iiif3-level2') {
+    return 'service-500'
+  }
+
+  if (variant === 'slow-iiif3-level2') {
+    return 'slow'
+  }
+
+  if (variant === 'too-many-requests-after-20s-iiif3-level2') {
+    return 'too-many-requests-after-20s'
+  }
+
+  return undefined
+}
+
+export function isSlowCombinedVariant(variant: string) {
+  return getCombinedImageServiceBehavior(variant) === 'slow'
+}
+
+export function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export async function delaySlowResource(variantOrBehavior: string | undefined) {
+  if (variantOrBehavior === 'slow') {
+    await delay(slowResourceDelayMs)
+  }
+}
+
+function getImageServiceBehaviorKey(
+  corsMode: CorsMode,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  imageId: string,
+  behavior: ImageServiceBehavior
+) {
+  return [corsMode, version, complianceLevel, imageId, behavior].join(':')
+}
+
+export function shouldReturnTooManyRequests(
+  corsMode: CorsMode,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  imageId: string,
+  behavior: ImageServiceBehavior | undefined
+) {
+  if (behavior !== 'too-many-requests-after-20s') {
+    return false
+  }
+
+  const key = getImageServiceBehaviorKey(
+    corsMode,
+    version,
+    complianceLevel,
+    imageId,
+    behavior
+  )
+  const now = Date.now()
+  const startedAt = imageServiceBehaviorStartedAt.get(key) ?? now
+
+  if (!imageServiceBehaviorStartedAt.has(key)) {
+    imageServiceBehaviorStartedAt.set(key, startedAt)
+  }
+
+  return now - startedAt >= tooManyRequestsAfterMs
+}
+
+export function tooManyRequestsResponse(corsMode: CorsMode) {
+  const response = textResponse('Too Many Requests', corsMode, 429)
+  response.headers.set('retry-after', '20')
+
+  return response
+}

--- a/test/server/src/lib/server/fixture-data.ts
+++ b/test/server/src/lib/server/fixture-data.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+
+import { parseAnnotation } from '@allmaps/annotation'
+import { IIIF, Manifest } from '@allmaps/iiif-parser'
+
+import {
+  loadImageDefinitions,
+  type ImageFixtureDefinition
+} from '../fixtures.ts'
+import { cloneJsonObject } from '../paths.ts'
+import type { JsonObject } from '../types.ts'
+
+export type ImageFixture = ImageFixtureDefinition
+
+const imageDefinitions = loadImageDefinitions()
+
+const images = new Map(imageDefinitions.map((image) => [image.id, image]))
+const originalManifests = new Map(
+  imageDefinitions.flatMap((image) => {
+    if (!image.originalManifestPath) {
+      return []
+    }
+
+    const originalManifest = JSON.parse(
+      readFileSync(image.originalManifestPath, 'utf8')
+    )
+    const parsedManifest = IIIF.parse(originalManifest, {
+      keepSource: true
+    })
+
+    if (!(parsedManifest instanceof Manifest)) {
+      throw new Error(`${image.originalManifestPath} is not a IIIF manifest`)
+    }
+
+    return [
+      [
+        image.id,
+        {
+          parsedManifest,
+          source: originalManifest
+        }
+      ] as const
+    ]
+  })
+)
+
+export function getImage(imageId: string) {
+  const image = images.get(imageId)
+
+  if (!image) {
+    throw new Error(`Unknown image fixture: ${imageId}`)
+  }
+
+  return image
+}
+
+export function getImages() {
+  return [...images.values()]
+}
+
+export function getOriginalManifest(image: ImageFixture) {
+  return originalManifests.get(image.id)
+}
+
+export function getGeoreferencedMap(image: ImageFixture) {
+  const annotation = JSON.parse(readFileSync(image.annotationPath, 'utf8'))
+  const maps = parseAnnotation(annotation)
+  const map = maps[0]
+
+  if (!map) {
+    throw new Error(`No georeferenced map found for ${image.id}`)
+  }
+
+  return map
+}
+
+export function hasMultipleMapAnnotations(image: ImageFixture) {
+  const annotation = JSON.parse(readFileSync(image.annotationPath, 'utf8'))
+
+  return Array.isArray(annotation.items) && annotation.items.length > 1
+}
+
+export function getFirstCanvas(sourceManifest: JsonObject) {
+  return cloneJsonObject(sourceManifest.sequences?.[0]?.canvases?.[0])
+}
+
+export function getFirstImageAnnotation(sourceManifest: JsonObject) {
+  return cloneJsonObject(
+    sourceManifest.sequences?.[0]?.canvases?.[0]?.images?.[0]
+  )
+}
+
+export function getFirstImageResource(sourceManifest: JsonObject) {
+  return cloneJsonObject(
+    sourceManifest.sequences?.[0]?.canvases?.[0]?.images?.[0]?.resource
+  )
+}

--- a/test/server/src/lib/server/iiif2.ts
+++ b/test/server/src/lib/server/iiif2.ts
@@ -1,0 +1,119 @@
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function getIiif2Label(value: unknown, fallback: string): string {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    const firstLabel = value
+      .map((item) => getIiif2Label(item, ''))
+      .find((item) => item.length > 0)
+
+    return firstLabel ?? fallback
+  }
+
+  if (isJsonObject(value)) {
+    if ('@value' in value) {
+      return getIiif2Label(value['@value'], fallback)
+    }
+
+    if ('value' in value) {
+      return getIiif2Label(value.value, fallback)
+    }
+
+    for (const item of Object.values(value)) {
+      const label = getIiif2Label(item, '')
+
+      if (label.length > 0) {
+        return label
+      }
+    }
+  }
+
+  return fallback
+}
+
+export function getIiif2Rendering(value: unknown) {
+  const resources = Array.isArray(value) ? value : value ? [value] : []
+  const rendering = resources.flatMap((resource) => {
+    if (!isJsonObject(resource)) {
+      return []
+    }
+
+    const id = resource['@id'] ?? resource.id
+
+    if (typeof id !== 'string') {
+      return []
+    }
+
+    return [
+      {
+        '@id': id,
+        ...(typeof (resource['@type'] ?? resource.type) === 'string'
+          ? { '@type': resource['@type'] ?? resource.type }
+          : {}),
+        label: getIiif2Label(resource.label, 'Rendering'),
+        ...(typeof resource.format === 'string'
+          ? { format: resource.format }
+          : {})
+      }
+    ]
+  })
+
+  return rendering.length > 0 ? rendering : undefined
+}
+
+export function getIiif2Thumbnail(value: unknown) {
+  type Iiif2Thumbnail =
+    | string
+    | {
+        '@id': string
+        '@type'?: unknown
+        format?: string
+        height?: number
+        width?: number
+      }
+
+  const resources = Array.isArray(value) ? value : value ? [value] : []
+  const thumbnails: Iiif2Thumbnail[] = []
+
+  for (const resource of resources) {
+    if (typeof resource === 'string') {
+      thumbnails.push(resource)
+      continue
+    }
+
+    if (!isJsonObject(resource)) {
+      continue
+    }
+
+    const id = resource['@id'] ?? resource.id
+
+    if (typeof id !== 'string') {
+      continue
+    }
+
+    thumbnails.push({
+      '@id': id,
+      ...(typeof (resource['@type'] ?? resource.type) === 'string'
+        ? { '@type': resource['@type'] ?? resource.type }
+        : {}),
+      ...(typeof resource.format === 'string'
+        ? { format: resource.format }
+        : {}),
+      ...(typeof resource.height === 'number'
+        ? { height: resource.height }
+        : {}),
+      ...(typeof resource.width === 'number' ? { width: resource.width } : {})
+    })
+  }
+
+  return thumbnails.length > 0 ? thumbnails : undefined
+}

--- a/test/server/src/lib/server/image-api.ts
+++ b/test/server/src/lib/server/image-api.ts
@@ -1,0 +1,738 @@
+import sharp from 'sharp'
+
+import type { ImageFixtureDefinition as ImageFixture } from '../fixtures.ts'
+import { getImageServiceId, cloneJsonObject } from '../paths.ts'
+import { imageResponse } from '../responses.ts'
+import type {
+  CorsMode,
+  IiifVersion,
+  ImageComplianceLevel,
+  JsonObject,
+  Region,
+  Size
+} from '../types.ts'
+
+export type Link = {
+  label: string
+  href: string
+  version?: IiifVersion
+  versionLabel?: string
+  complianceLevel?: ImageComplianceLevel
+  complianceLabel?: string
+  group?: string
+}
+
+export type ImageApiService = {
+  version: IiifVersion
+  complianceLevel: ImageComplianceLevel
+}
+
+export type ImageServiceBehavior =
+  | 'image-500'
+  | 'service-500'
+  | 'slow'
+  | 'too-many-requests-after-20s'
+
+export type ImageApiServiceReference = ImageApiService & {
+  behavior?: ImageServiceBehavior
+}
+
+export const catalogImageComplianceLevels = ['level0', 'level2'] as const
+export const catalogImageApiServices = (['2', '3'] as const).flatMap(
+  (version) =>
+    catalogImageComplianceLevels.map((complianceLevel) => ({
+      version,
+      complianceLevel
+    }))
+)
+
+export function getImageApiVersionLabel(version: IiifVersion) {
+  return version === '2' ? '2.1' : '3.0'
+}
+
+export function getImageApiLabel(version: IiifVersion) {
+  return `IIIF Image API ${getImageApiVersionLabel(version)}`
+}
+
+export function createImageApiLink(
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  label: string,
+  href: string
+) {
+  return {
+    label,
+    href,
+    version,
+    versionLabel: getImageApiLabel(version),
+    complianceLevel,
+    complianceLabel: complianceLevel
+  }
+}
+
+export function isImageComplianceLevel(
+  value: string
+): value is ImageComplianceLevel {
+  return value === 'level0' || value === 'level1' || value === 'level2'
+}
+
+export function getIiif2Profile(complianceLevel: ImageComplianceLevel) {
+  return `http://iiif.io/api/image/2/${complianceLevel}.json`
+}
+
+export function getImageServiceProfile(
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel
+) {
+  return version === '2' ? getIiif2Profile(complianceLevel) : complianceLevel
+}
+
+export function getImageServiceType(version: IiifVersion) {
+  return version === '2' ? 'ImageService2' : 'ImageService3'
+}
+
+export function getWrongImageServiceType(version: IiifVersion) {
+  return version === '2' ? 'ImageService3' : 'ImageService2'
+}
+
+export function getManifestImageRequest(
+  imageServiceId: string,
+  imageApiVersion: IiifVersion
+) {
+  const imagePathSize = imageApiVersion === '2' ? 'full' : 'max'
+
+  return `${imageServiceId}/full/${imagePathSize}/0/default.jpg`
+}
+
+export function getManifestImageBodyDimensions(image: ImageFixture) {
+  return {
+    width: image.width,
+    height: image.height
+  }
+}
+
+export function parseNumber(value: string, name: string) {
+  const number = Number(value)
+
+  if (!Number.isFinite(number)) {
+    throw new Error(`Invalid ${name}: ${value}`)
+  }
+
+  return number
+}
+
+export function parsePositiveNumber(value: string, name: string) {
+  const number = parseNumber(value, name)
+
+  if (number <= 0) {
+    throw new Error(`Invalid ${name}: ${value}`)
+  }
+
+  return number
+}
+
+function parseRegion(regionParameter: string, image: ImageFixture): Region {
+  if (regionParameter === 'full') {
+    return {
+      left: 0,
+      top: 0,
+      width: image.width,
+      height: image.height
+    }
+  }
+
+  const isPercent = regionParameter.startsWith('pct:')
+  const values = (isPercent ? regionParameter.slice(4) : regionParameter)
+    .split(',')
+    .map((value) => parseNumber(value, 'region value'))
+
+  if (values.length !== 4) {
+    throw new Error(`Invalid region: ${regionParameter}`)
+  }
+
+  const [x, y, width, height] = values
+  const region = isPercent
+    ? {
+        left: Math.round((x / 100) * image.width),
+        top: Math.round((y / 100) * image.height),
+        width: Math.round((width / 100) * image.width),
+        height: Math.round((height / 100) * image.height)
+      }
+    : {
+        left: Math.round(x),
+        top: Math.round(y),
+        width: Math.round(width),
+        height: Math.round(height)
+      }
+
+  if (
+    region.left < 0 ||
+    region.top < 0 ||
+    region.width <= 0 ||
+    region.height <= 0 ||
+    region.left + region.width > image.width ||
+    region.top + region.height > image.height
+  ) {
+    throw new Error(`Region outside image bounds: ${regionParameter}`)
+  }
+
+  return region
+}
+
+function parseSize(sizeParameter: string, region: Region): Size | undefined {
+  if (sizeParameter === 'full' || sizeParameter === 'max') {
+    return undefined
+  }
+
+  if (sizeParameter.startsWith('pct:')) {
+    const percentage = parsePositiveNumber(sizeParameter.slice(4), 'percentage')
+
+    return {
+      width: Math.round((percentage / 100) * region.width)
+    }
+  }
+
+  const fit = sizeParameter.startsWith('!') ? 'inside' : 'fill'
+  const size = fit === 'inside' ? sizeParameter.slice(1) : sizeParameter
+  const [width, height] = size.split(',')
+
+  if (width && height) {
+    return {
+      width: Math.round(parsePositiveNumber(width, 'width')),
+      height: Math.round(parsePositiveNumber(height, 'height')),
+      fit
+    }
+  }
+
+  if (width) {
+    return {
+      width: Math.round(parsePositiveNumber(width, 'width'))
+    }
+  }
+
+  if (height) {
+    return {
+      height: Math.round(parsePositiveNumber(height, 'height'))
+    }
+  }
+
+  throw new Error(`Invalid size: ${sizeParameter}`)
+}
+
+function parseOutputFormat(format: string) {
+  if (format === 'jpg' || format === 'jpeg') {
+    return {
+      contentType: 'image/jpeg',
+      sharpFormat: 'jpeg' as const
+    }
+  }
+
+  if (format === 'png' || format === 'webp') {
+    return {
+      contentType: `image/${format}`,
+      sharpFormat: format as 'png' | 'webp'
+    }
+  }
+
+  throw new Error(`Unsupported format: ${format}`)
+}
+
+function getOutputDimensions(region: Region, size: Size | undefined) {
+  if (!size) {
+    return {
+      width: region.width,
+      height: region.height
+    }
+  }
+
+  if (size.width && size.height) {
+    if (size.fit === 'inside') {
+      const scale = Math.min(
+        size.width / region.width,
+        size.height / region.height
+      )
+
+      return {
+        width: Math.round(region.width * scale),
+        height: Math.round(region.height * scale)
+      }
+    }
+
+    return {
+      width: size.width,
+      height: size.height
+    }
+  }
+
+  if (size.width) {
+    return {
+      width: size.width,
+      height: Math.round((region.height / region.width) * size.width)
+    }
+  }
+
+  if (size.height) {
+    return {
+      width: Math.round((region.width / region.height) * size.height),
+      height: size.height
+    }
+  }
+
+  return {
+    width: region.width,
+    height: region.height
+  }
+}
+
+function assertLevel0TileRequest(
+  image: ImageFixture,
+  region: Region,
+  size: Size | undefined,
+  rotation: string,
+  quality: string,
+  format: string
+) {
+  if (rotation !== '0' || quality !== 'default' || format !== 'jpg') {
+    throw new Error('Level 0 only serves default JPEG requests')
+  }
+
+  const isFullRegion =
+    region.left === 0 &&
+    region.top === 0 &&
+    region.width === image.width &&
+    region.height === image.height
+  if (isFullRegion && !size) {
+    return
+  }
+
+  if (isFullRegion) {
+    throw new Error(
+      'Level 0 only serves full/max full-image requests and tiles declared in info.json'
+    )
+  }
+
+  if (!size?.width || size.fit === 'inside') {
+    throw new Error(
+      'Level 0 requests must use full/max full-image syntax, width-only tile size syntax, or exact tile size syntax'
+    )
+  }
+
+  const tile = getTiles(image)[0]
+  const scaleFactor = Math.round(region.width / size.width)
+  const expectedOutputWidth = Math.ceil(region.width / scaleFactor)
+  const expectedOutputHeight = Math.ceil(region.height / scaleFactor)
+  const requestedOutputHeight = size.height ?? expectedOutputHeight
+
+  if (
+    !tile.scaleFactors.includes(scaleFactor) ||
+    size.width !== expectedOutputWidth ||
+    requestedOutputHeight !== expectedOutputHeight ||
+    expectedOutputWidth > tile.width ||
+    expectedOutputHeight > tile.height ||
+    region.left % (tile.width * scaleFactor) !== 0 ||
+    region.top % (tile.height * scaleFactor) !== 0 ||
+    region.width > tile.width * scaleFactor ||
+    region.height > tile.height * scaleFactor ||
+    region.left + region.width > image.width ||
+    region.top + region.height > image.height
+  ) {
+    throw new Error(
+      'Level 0 only serves full/max full-image requests and tiles declared in info.json'
+    )
+  }
+}
+
+function createWatermark(output: { width: number; height: number }) {
+  const label =
+    output.width < 240 ? 'SCALED-DOWN COPY' : 'SCALED-DOWN COPY OF ORIGINAL'
+  const pixelSize = Math.max(1, Math.min(3, Math.floor(output.width / 260)))
+  const paddingX = Math.max(6, pixelSize * 5)
+  const paddingY = Math.max(5, pixelSize * 4)
+  const letterGap = pixelSize
+  const spaceWidth = pixelSize * 3
+  const glyphHeight = pixelSize * 7
+  const logoSize = Math.max(10, pixelSize * 9)
+  const contentHeight = Math.max(glyphHeight, logoSize)
+  const logoX = paddingX
+  const logoY = paddingY + Math.round((contentHeight - logoSize) / 2)
+  const glyphY = paddingY + Math.round((contentHeight - glyphHeight) / 2)
+  let cursorX = paddingX + logoSize + pixelSize * 4
+  const rects: string[] = []
+
+  for (const character of label) {
+    if (character === ' ') {
+      cursorX += spaceWidth
+      continue
+    }
+
+    const glyph = watermarkGlyphs[character]
+
+    if (!glyph) {
+      continue
+    }
+
+    for (const [rowIndex, row] of glyph.entries()) {
+      for (const [columnIndex, value] of [...row].entries()) {
+        if (value === '1') {
+          rects.push(
+            `<rect x="${cursorX + columnIndex * pixelSize}" y="${
+              glyphY + rowIndex * pixelSize
+            }" width="${pixelSize}" height="${pixelSize}"/>`
+          )
+        }
+      }
+    }
+
+    cursorX += glyph[0].length * pixelSize + letterGap
+  }
+
+  const width = Math.min(output.width, cursorX + paddingX - letterGap)
+  const height = contentHeight + paddingY * 2
+
+  return Buffer.from(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <rect width="100%" height="100%" fill="black" fill-opacity="0.58"/>
+      <g fill="white" fill-opacity="0.92">
+        ${createWatermarkLogo(logoX, logoY, logoSize)}
+        ${rects.join('')}
+      </g>
+    </svg>
+  `)
+}
+
+function createWatermarkLogo(x: number, y: number, size: number) {
+  return `
+    <svg x="${x}" y="${y}" width="${size}" height="${size}" viewBox="0 0 1440 1440">
+      <polygon points="1275.2,1031.6 720,1359.5 164.9,1031.7 230.3,993 720,1282.2 1209.8,993"/>
+      <polygon points="1275.2,875.8 720,1203.7 164.8,875.8 230.2,837.2 720,1126.4 1209.8,837.2"/>
+      <polygon points="1275.2,720 720,1047.9 164.8,720 230.2,681.4 720,970.5 1209.8,681.4"/>
+      <polygon points="1275.1,564.2 1209.7,602.8 1143.2,642.1 720,892 296.7,642.1 230.2,602.8 164.8,564.2 230.2,525.5 720,814.7 1209.7,525.5"/>
+      <path d="M720,80.5L164.8,408.4L720,736.2l555.1-327.9L720,80.5z M676.6,639.9l-93.5-54l68.6-71.1L513.6,435l-122.7,39.8l-93.5-54l608-178.7l80.6,46.5L676.6,639.9z"/>
+      <polygon points="827.2,334.1 705.9,459.1 610.5,404"/>
+    </svg>
+  `
+}
+
+const watermarkGlyphs: Record<string, string[]> = {
+  A: ['01110', '10001', '10001', '11111', '10001', '10001', '10001'],
+  C: ['01111', '10000', '10000', '10000', '10000', '10000', '01111'],
+  D: ['11110', '10001', '10001', '10001', '10001', '10001', '11110'],
+  E: ['11111', '10000', '10000', '11110', '10000', '10000', '11111'],
+  F: ['11111', '10000', '10000', '11110', '10000', '10000', '10000'],
+  G: ['01111', '10000', '10000', '10011', '10001', '10001', '01111'],
+  I: ['11111', '00100', '00100', '00100', '00100', '00100', '11111'],
+  L: ['10000', '10000', '10000', '10000', '10000', '10000', '11111'],
+  N: ['10001', '11001', '10101', '10011', '10001', '10001', '10001'],
+  O: ['01110', '10001', '10001', '10001', '10001', '10001', '01110'],
+  P: ['11110', '10001', '10001', '11110', '10000', '10000', '10000'],
+  R: ['11110', '10001', '10001', '11110', '10100', '10010', '10001'],
+  S: ['01111', '10000', '10000', '01110', '00001', '00001', '11110'],
+  W: ['10001', '10001', '10001', '10101', '10101', '10101', '01010'],
+  Y: ['10001', '10001', '01010', '00100', '00100', '00100', '00100'],
+  '-': ['00000', '00000', '00000', '11111', '00000', '00000', '00000']
+}
+
+function getScaleFactors(image: ImageFixture) {
+  const scaleFactors = [1]
+  const largestDimension = Math.max(image.width, image.height)
+
+  while (512 * scaleFactors.at(-1)! < largestDimension) {
+    scaleFactors.push(scaleFactors.at(-1)! * 2)
+  }
+
+  return scaleFactors
+}
+
+function getSizes(image: ImageFixture) {
+  const sizes = [...getScaleFactors(image)].reverse().map((scaleFactor) => ({
+    width: Math.ceil(image.width / scaleFactor),
+    height: Math.ceil(image.height / scaleFactor)
+  }))
+  const hasFullSize = sizes.some(
+    (size) => size.width === image.width && size.height === image.height
+  )
+
+  return hasFullSize
+    ? sizes
+    : [
+        ...sizes,
+        {
+          width: image.width,
+          height: image.height
+        }
+      ]
+}
+
+export function getTiles(image: ImageFixture) {
+  return [
+    {
+      width: 512,
+      height: 512,
+      scaleFactors: getScaleFactors(image)
+    }
+  ]
+}
+
+export function createInfoJson(
+  request: Request,
+  corsMode: CorsMode,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  image: ImageFixture,
+  behavior?: ImageServiceBehavior
+) {
+  const id = getImageServiceId(
+    request,
+    corsMode,
+    version,
+    complianceLevel,
+    image.id,
+    behavior
+  )
+  const tiles = getTiles(image)
+
+  if (version === '2') {
+    const profile: (JsonObject | string)[] =
+      complianceLevel === 'level0'
+        ? [`http://iiif.io/api/image/2/${complianceLevel}.json`]
+        : [
+            `http://iiif.io/api/image/2/${complianceLevel}.json`,
+            {
+              formats:
+                complianceLevel === 'level2'
+                  ? ['jpg', 'png', 'webp']
+                  : ['jpg', 'webp'],
+              qualities:
+                complianceLevel === 'level2'
+                  ? ['default', 'color']
+                  : ['default'],
+              supports:
+                complianceLevel === 'level2'
+                  ? [
+                      'regionByPx',
+                      'regionByPct',
+                      'sizeByW',
+                      'sizeByH',
+                      'sizeByWh',
+                      'sizeByPct',
+                      'sizeByConfinedWh',
+                      'cors'
+                    ]
+                  : ['regionByPx', 'sizeByW', 'sizeByH', 'sizeByPct', 'cors']
+            }
+          ]
+
+    return {
+      '@context': 'http://iiif.io/api/image/2/context.json',
+      '@id': id,
+      protocol: 'http://iiif.io/api/image',
+      width: image.width,
+      height: image.height,
+      tiles,
+      ...(complianceLevel === 'level0' ? {} : { sizes: getSizes(image) }),
+      profile
+    }
+  }
+
+  const level3Extras =
+    complianceLevel === 'level0'
+      ? {}
+      : complianceLevel === 'level1'
+        ? {
+            extraFormats: ['webp'],
+            extraFeatures: ['regionByPx', 'sizeByW', 'sizeByH', 'cors']
+          }
+        : {
+            extraFormats: ['png', 'webp'],
+            extraQualities: ['color'],
+            extraFeatures: [
+              'regionByPx',
+              'regionByPct',
+              'sizeByW',
+              'sizeByH',
+              'sizeByWh',
+              'sizeByPct',
+              'sizeByConfinedWh',
+              'cors'
+            ]
+          }
+
+  return {
+    '@context': 'http://iiif.io/api/image/3/context.json',
+    id,
+    type: 'ImageService3',
+    protocol: 'http://iiif.io/api/image',
+    width: image.width,
+    height: image.height,
+    tiles,
+    ...(complianceLevel === 'level0' ? {} : { sizes: getSizes(image) }),
+    profile: complianceLevel,
+    ...level3Extras
+  }
+}
+
+export function createBrokenInfoJson(
+  request: Request,
+  corsMode: CorsMode,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  image: ImageFixture,
+  variant: string
+) {
+  const infoJson = cloneJsonObject(
+    createInfoJson(request, corsMode, version, complianceLevel, image)
+  )
+
+  if (variant === 'missing-dimensions') {
+    delete infoJson.width
+    delete infoJson.height
+
+    return infoJson
+  }
+
+  if (variant === 'bad-tiles') {
+    return {
+      ...infoJson,
+      tiles: [
+        {
+          width: '512',
+          height: 0,
+          scaleFactors: ['one', 2, -4]
+        }
+      ]
+    }
+  }
+
+  throw new Error(`Unknown info.json error variant: ${variant}`)
+}
+
+export async function createImageRequestResponse(
+  corsMode: CorsMode,
+  complianceLevel: ImageComplianceLevel,
+  image: ImageFixture,
+  regionParameter: string,
+  sizeParameter: string,
+  rotation: string,
+  quality: string,
+  file: string
+) {
+  if (rotation !== '0') {
+    throw new Error('Only rotation 0 is supported')
+  }
+
+  if (quality !== 'default' && quality !== 'color') {
+    throw new Error('Only default and color quality are supported')
+  }
+
+  const fileMatch = file.match(/^(.+)\.(jpg|jpeg|png|webp)$/)
+
+  if (!fileMatch) {
+    throw new Error(`Invalid image request file: ${file}`)
+  }
+
+  const [, fileQuality, format] = fileMatch
+
+  if (fileQuality !== quality) {
+    throw new Error('Path quality and file quality do not match')
+  }
+
+  const region = parseRegion(regionParameter, image)
+  const size = parseSize(sizeParameter, region)
+  const outputFormat = parseOutputFormat(format)
+
+  if (complianceLevel === 'level0') {
+    assertLevel0TileRequest(image, region, size, rotation, quality, format)
+  }
+
+  const outputDimensions = getOutputDimensions(region, size)
+  let transformer = sharp(image.imagePath).extract(region)
+
+  if (size) {
+    transformer = transformer.resize(size)
+  }
+
+  const buffer = await transformer
+    .composite([
+      {
+        input: createWatermark(outputDimensions),
+        gravity: 'southeast'
+      }
+    ])
+    .toFormat(outputFormat.sharpFormat)
+    .toBuffer()
+
+  return imageResponse(buffer, corsMode, outputFormat.contentType)
+}
+
+export function getImageServiceBaseUrl(
+  baseUrl: string,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  imageId: string,
+  behavior?: ImageServiceBehavior
+) {
+  return `${baseUrl}/iiif/${version}/${complianceLevel}/${imageId}${behavior ? `/${behavior}` : ''}`
+}
+
+export function getLevel0TileExample(
+  image: ImageFixture,
+  imageServiceUrl: string
+) {
+  const tile = getTiles(image)[0]
+  const width = Math.min(tile.width, image.width)
+  const height = Math.min(tile.height, image.height)
+
+  return `${imageServiceUrl}/0,0,${width},${height}/${width},/0/default.jpg`
+}
+
+export function getImageRequestExamples(
+  image: ImageFixture,
+  version: IiifVersion,
+  complianceLevel: ImageComplianceLevel,
+  imageServiceUrl: string
+): Link[] {
+  if (complianceLevel === 'level0') {
+    return [
+      createImageApiLink(
+        version,
+        complianceLevel,
+        'Declared tile',
+        getLevel0TileExample(image, imageServiceUrl)
+      )
+    ]
+  }
+
+  const examples = [
+    createImageApiLink(
+      version,
+      complianceLevel,
+      'Full image, 600px wide',
+      `${imageServiceUrl}/full/600,/0/default.jpg`
+    ),
+    createImageApiLink(
+      version,
+      complianceLevel,
+      'Pixel region',
+      `${imageServiceUrl}/0,0,512,512/256,/0/default.jpg`
+    )
+  ]
+
+  if (complianceLevel === 'level2') {
+    examples.push(
+      createImageApiLink(
+        version,
+        complianceLevel,
+        'Percentage region',
+        `${imageServiceUrl}/pct:10,10,50,50/400,/0/default.jpg`
+      ),
+      createImageApiLink(
+        version,
+        complianceLevel,
+        'Confined WebP thumbnail',
+        `${imageServiceUrl}/full/!300,300/0/default.webp`
+      )
+    )
+  }
+
+  return examples
+}

--- a/test/server/src/lib/server/navplace.ts
+++ b/test/server/src/lib/server/navplace.ts
@@ -1,0 +1,113 @@
+import { GcpTransformer } from '@allmaps/transform'
+
+import type { Bbox, JsonObject, Point, Ring } from '../types.ts'
+import { getGeoreferencedMap, type ImageFixture } from './fixture-data.ts'
+
+const navPlaceContext = 'http://iiif.io/api/extension/navplace/context.json'
+const presentation3Context = 'http://iiif.io/api/presentation/3/context.json'
+
+function computeBbox(points: Ring): Bbox {
+  return [
+    Math.min(...points.map((point) => point[0])),
+    Math.min(...points.map((point) => point[1])),
+    Math.max(...points.map((point) => point[0])),
+    Math.max(...points.map((point) => point[1]))
+  ]
+}
+
+function bboxToCenter(bbox: Bbox): Point {
+  return [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2]
+}
+
+function bboxToRing(bbox: Bbox): Ring {
+  return [
+    [bbox[0], bbox[1]],
+    [bbox[2], bbox[1]],
+    [bbox[2], bbox[3]],
+    [bbox[0], bbox[3]],
+    [bbox[0], bbox[1]]
+  ]
+}
+
+function getGeoMask(image: ImageFixture): Ring {
+  const georeferencedMap = getGeoreferencedMap(image)
+  const transformer = GcpTransformer.fromGeoreferencedMap(georeferencedMap)
+  const resourceMask = georeferencedMap.resourceMask as unknown as Ring
+
+  return transformer.transformToGeo([resourceMask])[0] as unknown as Ring
+}
+
+function createGeoJsonFeatureCollection(
+  manifestId: string,
+  geometry:
+    | {
+        type: 'Point'
+        coordinates: Point
+      }
+    | {
+        type: 'Polygon'
+        coordinates: Ring[]
+      },
+  label: string
+) {
+  return {
+    id: `${manifestId}/navplace`,
+    type: 'FeatureCollection',
+    features: [
+      {
+        id: `${manifestId}/navplace/feature/1`,
+        type: 'Feature',
+        properties: {
+          label: {
+            none: [label]
+          }
+        },
+        geometry
+      }
+    ]
+  }
+}
+
+export function addNavPlaceContext(manifest: JsonObject) {
+  const context = manifest['@context']
+
+  return {
+    ...manifest,
+    '@context': Array.isArray(context)
+      ? [navPlaceContext, ...context.filter((item) => item !== navPlaceContext)]
+      : [navPlaceContext, context ?? presentation3Context]
+  }
+}
+
+export function createNavPlace(
+  manifestId: string,
+  image: ImageFixture,
+  variant: string
+) {
+  const geoMask = getGeoMask(image)
+  const geoMaskBbox = computeBbox(geoMask)
+
+  if (variant === 'navplace-midpoint') {
+    return createGeoJsonFeatureCollection(
+      manifestId,
+      {
+        type: 'Point',
+        coordinates: bboxToCenter(geoMaskBbox)
+      },
+      `${image.label} midpoint`
+    )
+  }
+
+  if (variant === 'navplace-bbox') {
+    return createGeoJsonFeatureCollection(
+      manifestId,
+      {
+        type: 'Polygon',
+        coordinates: [bboxToRing(geoMaskBbox)]
+      },
+      `${image.label} bounding box`
+    )
+  }
+
+  throw new Error(`Unknown navPlace variant: ${variant}`)
+}

--- a/test/server/static/iiif/images/e861bd9af6573765/annotation.json
+++ b/test/server/static/iiif/images/e861bd9af6573765/annotation.json
@@ -45,9 +45,7 @@
           "provider": [
             {
               "label": {
-                "none": [
-                  "David Rumsey Map Collection"
-                ]
+                "none": ["David Rumsey Map Collection"]
               },
               "homepage": [
                 {
@@ -71,673 +69,421 @@
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1091.33,
-                572.91
-              ]
+              "resourceCoords": [1091.33, 572.91]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -5.6931398,
-                56.1290282
-              ]
+              "coordinates": [-5.6931398, 56.1290282]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                969.336,
-                231.304
-              ]
+              "resourceCoords": [969.336, 231.304]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -6.2921755,
-                58.5220974
-              ]
+              "coordinates": [-6.2921755, 58.5220974]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1439.05,
-                352.463
-              ]
+              "resourceCoords": [1439.05, 352.463]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -2.1077545,
-                57.687078
-              ]
+              "coordinates": [-2.1077545, 57.687078]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1515.237,
-                1425.272
-              ]
+              "resourceCoords": [1515.237, 1425.272]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -1.5642528,
-                50.6648133
-              ]
+              "coordinates": [-1.5642528, 50.6648133]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1320.205,
-                227.685
-              ]
+              "resourceCoords": [1320.205, 227.685]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -3.0589806,
-                58.6152482
-              ]
+              "coordinates": [-3.0589806, 58.6152482]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1843.124,
-                1360.129
-              ]
+              "resourceCoords": [1843.124, 1360.129]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                1.5829224,
-                50.8667829
-              ]
+              "coordinates": [1.5829224, 50.8667829]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1415.911,
-                888.553
-              ]
+              "resourceCoords": [1415.911, 888.553]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -2.8041724,
-                54.0553335
-              ]
+              "coordinates": [-2.8041724, 54.0553335]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                2031.073,
-                1041.654
-              ]
+              "resourceCoords": [2031.073, 1041.654]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                4.7685316,
-                52.9630668
-              ]
+              "coordinates": [4.7685316, 52.9630668]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1300.529,
-                1500.17
-              ]
+              "resourceCoords": [1300.529, 1500.17]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -3.6827528,
-                50.2116403
-              ]
+              "coordinates": [-3.6827528, 50.2116403]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1090.071,
-                1472.162
-              ]
+              "resourceCoords": [1090.071, 1472.162]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -5.7572694,
-                50.055299
-              ]
+              "coordinates": [-5.7572694, 50.055299]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                2065.546,
-                1113.091
-              ]
+              "resourceCoords": [2065.546, 1113.091]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                4.8989454,
-                52.3782708
-              ]
+              "coordinates": [4.8989454, 52.3782708]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1405.994,
-                1288.378
-              ]
+              "resourceCoords": [1405.994, 1288.378]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -2.7145095,
-                51.5021859
-              ]
+              "coordinates": [-2.7145095, 51.5021859]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1217.101,
-                878.797
-              ]
+              "resourceCoords": [1217.101, 878.797]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.8110672,
-                54.0536704
-              ]
+              "coordinates": [-4.8110672, 54.0536704]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1188.61,
-                212.422
-              ]
+              "resourceCoords": [1188.61, 212.422]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.9900338,
-                58.6192943
-              ]
+              "coordinates": [-4.9900338, 58.6192943]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1873.032,
-                1332.436
-              ]
+              "resourceCoords": [1873.032, 1332.436]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                2.1563264,
-                50.9926064
-              ]
+              "coordinates": [2.1563264, 50.9926064]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1658.009,
-                1274.374
-              ]
+              "resourceCoords": [1658.009, 1274.374]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -0.1039544,
-                51.5125903
-              ]
+              "coordinates": [-0.1039544, 51.5125903]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1036.079,
-                315.643
-              ]
+              "resourceCoords": [1036.079, 315.643]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -6.3246552,
-                57.6977199
-              ]
+              "coordinates": [-6.3246552, 57.6977199]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1076.533,
-                683.369
-              ]
+              "resourceCoords": [1076.533, 683.369]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -6.0638886,
-                55.1914932
-              ]
+              "coordinates": [-6.0638886, 55.1914932]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1485.959,
-                631.916
-              ]
+              "resourceCoords": [1485.959, 631.916]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -1.9970339,
-                55.7600182
-              ]
+              "coordinates": [-1.9970339, 55.7600182]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1236.62,
-                810.979
-              ]
+              "resourceCoords": [1236.62, 810.979]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.3666423,
-                54.4102787
-              ]
+              "coordinates": [-4.3666423, 54.4102787]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1116.358,
-                436.173
-              ]
+              "resourceCoords": [1116.358, 436.173]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -5.419424,
-                57.2145558
-              ]
+              "coordinates": [-5.419424, 57.2145558]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                953.753,
-                357.026
-              ]
+              "resourceCoords": [953.753, 357.026]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -7.0098124,
-                57.7342696
-              ]
+              "coordinates": [-7.0098124, 57.7342696]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                925.576,
-                539.394
-              ]
+              "resourceCoords": [925.576, 539.394]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -7.64484,
-                56.7834886
-              ]
+              "coordinates": [-7.64484, 56.7834886]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1270.463,
-                400.455
-              ]
+              "resourceCoords": [1270.463, 400.455]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.2224492,
-                57.4863184
-              ]
+              "coordinates": [-4.2224492, 57.4863184]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1066.459,
-                1153.844
-              ]
+              "resourceCoords": [1066.459, 1153.844]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -6.3794676,
-                52.1819789
-              ]
+              "coordinates": [-6.3794676, 52.1819789]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                816.963,
-                1082.093
-              ]
+              "resourceCoords": [816.963, 1082.093]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -8.5999123,
-                52.6665622
-              ]
+              "coordinates": [-8.5999123, 52.6665622]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1220.879,
-                843.079
-              ]
+              "resourceCoords": [1220.879, 843.079]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.6139344,
-                54.256732
-              ]
+              "coordinates": [-4.6139344, 54.256732]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1165.313,
-                722.864
-              ]
+              "resourceCoords": [1165.313, 722.864]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.9562325,
-                54.8845784
-              ]
+              "coordinates": [-4.9562325, 54.8845784]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                603.356,
-                1146.134
-              ]
+              "resourceCoords": [603.356, 1146.134]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -10.4519227,
-                52.1025876
-              ]
+              "coordinates": [-10.4519227, 52.1025876]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1660.528,
-                973.836
-              ]
+              "resourceCoords": [1660.528, 973.836]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                0.1497194,
-                53.6347421
-              ]
+              "coordinates": [0.1497194, 53.6347421]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1731.52,
-                1104.594
-              ]
+              "resourceCoords": [1731.52, 1104.594]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                1.2735899,
-                52.6129583
-              ]
+              "coordinates": [1.2735899, 52.6129583]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1097.154,
-                687.617
-              ]
+              "resourceCoords": [1097.154, 687.617]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -5.7594092,
-                55.3132087
-              ]
+              "coordinates": [-5.7594092, 55.3132087]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                733.22,
-                743.477
-              ]
+              "resourceCoords": [733.22, 743.477]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -8.8004504,
-                54.6891435
-              ]
+              "coordinates": [-8.8004504, 54.6891435]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                694.812,
-                883.675
-              ]
+              "resourceCoords": [694.812, 883.675]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -10.2259674,
-                53.980454
-              ]
+              "coordinates": [-10.2259674, 53.980454]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                806.416,
-                747.882
-              ]
+              "resourceCoords": [806.416, 747.882]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -8.1406198,
-                54.6279314
-              ]
+              "coordinates": [-8.1406198, 54.6279314]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                776.508,
-                988.627
-              ]
+              "resourceCoords": [776.508, 988.627]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -9.0349589,
-                53.2894364
-              ]
+              "coordinates": [-9.0349589, 53.2894364]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1852.884,
-                1445.098
-              ]
+              "resourceCoords": [1852.884, 1445.098]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                1.5486593,
-                50.2575365
-              ]
+              "coordinates": [1.5486593, 50.2575365]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1233.157,
-                850.946
-              ]
+              "resourceCoords": [1233.157, 850.946]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -4.4569548,
-                54.1632023
-              ]
+              "coordinates": [-4.4569548, 54.1632023]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1368.216,
-                616.653
-              ]
+              "resourceCoords": [1368.216, 616.653]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -3.1762894,
-                55.9486951
-              ]
+              "coordinates": [-3.1762894, 55.9486951]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1804.086,
-                1092.95
-              ]
+              "resourceCoords": [1804.086, 1092.95]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                1.7381192,
-                52.6153276
-              ]
+              "coordinates": [1.7381192, 52.6153276]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1000.504,
-                567.245
-              ]
+              "resourceCoords": [1000.504, 567.245]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -6.9189583,
-                56.444894
-              ]
+              "coordinates": [-6.9189583, 56.444894]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                813.814,
-                651.27
-              ]
+              "resourceCoords": [813.814, 651.27]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -8.2855904,
-                55.1571087
-              ]
+              "coordinates": [-8.2855904, 55.1571087]
             }
           }
         ],

--- a/test/server/static/iiif/images/f6033bee94f7763e/annotation.json
+++ b/test/server/static/iiif/images/f6033bee94f7763e/annotation.json
@@ -25,18 +25,14 @@
               "id": "http://localhost:5506/cors/manifests/2/f6033bee94f7763e.json/canvas/1",
               "type": "Canvas",
               "label": {
-                "none": [
-                  "No.14. Europa : Geologie, Tektonic"
-                ]
+                "none": ["No.14. Europa : Geologie, Tektonic"]
               },
               "partOf": [
                 {
                   "id": "http://localhost:5506/cors/manifests/2/f6033bee94f7763e.json",
                   "type": "Manifest",
                   "label": {
-                    "none": [
-                      "No.14. Europa : Geologie, Tektonic"
-                    ]
+                    "none": ["No.14. Europa : Geologie, Tektonic"]
                   }
                 }
               ]
@@ -45,9 +41,7 @@
           "provider": [
             {
               "label": {
-                "none": [
-                  "David Rumsey Map Collection"
-                ]
+                "none": ["David Rumsey Map Collection"]
               },
               "homepage": [
                 {
@@ -79,49 +73,31 @@
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1542.856,
-                628.981
-              ]
+              "resourceCoords": [1542.856, 628.981]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                30.3088374,
-                59.9265149
-              ]
+              "coordinates": [30.3088374, 59.9265149]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                487.865,
-                1186.648
-              ]
+              "resourceCoords": [487.865, 1186.648]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                -9.288174,
-                43.0615478
-              ]
+              "coordinates": [-9.288174, 43.0615478]
             }
           },
           {
             "type": "Feature",
             "properties": {
-              "resourceCoords": [
-                1845.687,
-                1585.84
-              ]
+              "resourceCoords": [1845.687, 1585.84]
             },
             "geometry": {
               "type": "Point",
-              "coordinates": [
-                34.5756332,
-                35.6739821
-              ]
+              "coordinates": [34.5756332, 35.6739821]
             }
           }
         ],

--- a/test/server/test/generated-resources.test.ts
+++ b/test/server/test/generated-resources.test.ts
@@ -1,0 +1,505 @@
+import { parseAnnotation } from '@allmaps/annotation'
+import { IIIF } from '@allmaps/iiif-parser'
+import { describe, expect, test } from 'vitest'
+
+import { createCatalog, handleFixtureRequest } from '../src/lib/server.ts'
+
+type JsonObject = Record<string, unknown>
+
+type InfoExpectation = 'valid' | 'missing-dimensions' | 'bad-tiles'
+type ManifestExpectation = 'valid' | 'missing-image-service'
+
+type Resource<T extends string> = {
+  name: string
+  href: string
+  expectation: T
+}
+
+type AnnotationResource =
+  | {
+      name: string
+      href: string
+      data?: undefined
+    }
+  | {
+      name: string
+      href?: undefined
+      data: unknown
+    }
+
+const baseUrl = 'http://localhost:5506/cors'
+const catalog = createCatalog(new Request(`${baseUrl}/`), 'cors')
+const combinedAnnotationHttpErrorStatuses = [401, 403, 404, 429, 500, 503]
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function getFixturePath(href: string) {
+  const url = new URL(href)
+  const [, corsMode, ...pathSegments] = url.pathname.split('/')
+
+  return {
+    corsMode,
+    path: pathSegments.join('/')
+  }
+}
+
+async function getFixtureResponse(href: string) {
+  const { corsMode, path } = getFixturePath(href)
+
+  return handleFixtureRequest(new Request(href), corsMode, path)
+}
+
+async function getJsonResource(href: string) {
+  const response = await getFixtureResponse(href)
+  const text = await response.text()
+
+  expect(response.status, href).toBe(200)
+
+  return JSON.parse(text) as unknown
+}
+
+function getParseError(parse: () => unknown) {
+  try {
+    parse()
+  } catch (error) {
+    return error
+  }
+}
+
+function getIssuePaths(error: unknown) {
+  if (
+    isJsonObject(error) &&
+    Array.isArray(error.issues) &&
+    error.issues.every(isJsonObject)
+  ) {
+    return error.issues.map((issue) =>
+      Array.isArray(issue.path) ? issue.path.join('.') : ''
+    )
+  }
+
+  return []
+}
+
+function getInfoResources(): Resource<InfoExpectation>[] {
+  return catalog.images.flatMap((image) => [
+    ...image.imageServices.map((link) => ({
+      name: `${image.id} ${link.label} ${link.versionLabel} ${link.complianceLabel}`,
+      href: `${link.href}/info.json`,
+      expectation: 'valid' as const
+    })),
+    ...image.errors.imageServices
+      .filter((link) => link.href.endsWith('/info.json'))
+      .map((link) => ({
+        name: `${image.id} ${link.label} ${link.versionLabel} ${link.complianceLabel}`,
+        href: link.href,
+        expectation: 'valid' as const
+      })),
+    ...image.errors.infoJsons.map((link) => ({
+      name: `${image.id} ${link.label} ${link.versionLabel} ${link.complianceLabel}`,
+      href: link.href,
+      expectation: link.href.includes('/missing-dimensions/')
+        ? ('missing-dimensions' as const)
+        : ('bad-tiles' as const)
+    }))
+  ])
+}
+
+function getManifestResources(): Resource<ManifestExpectation>[] {
+  return [
+    ...catalog.combinedImages.manifests.map((link) => ({
+      name: `combined ${link.label}`,
+      href: link.href,
+      expectation: 'valid' as const
+    })),
+    ...catalog.images.flatMap((image) => [
+      ...image.manifestResources.map((link) => ({
+        name: `${image.id} ${link.label} ${link.versionLabel} ${link.complianceLabel}`,
+        href: link.href,
+        expectation: 'valid' as const
+      })),
+      ...image.errors.manifests.map((link) => ({
+        name: `${image.id} ${link.label} ${link.versionLabel} ${link.complianceLabel}`,
+        href: link.href,
+        expectation: link.href.includes('/manifests/2/')
+          ? ('missing-image-service' as const)
+          : ('valid' as const)
+      }))
+    ])
+  ]
+}
+
+function getAnnotationRouteResources(): AnnotationResource[] {
+  const links = [
+    ...catalog.combinedImages.annotations,
+    ...catalog.images.flatMap((image) => [
+      ...image.annotations,
+      ...image.errors.annotations
+    ])
+  ].filter((link) => !isCombinedAnnotationHttpErrorResource(link.href))
+
+  return links.map((link) => ({
+    name: link.label,
+    href: link.href
+  }))
+}
+
+function isCombinedAnnotationHttpErrorResource(href: string) {
+  return combinedAnnotationHttpErrorStatuses.some((status) =>
+    href.includes(`/annotations/combined/http-${status}.json`)
+  )
+}
+
+function isSlowResource(href: string) {
+  return href.includes('/slow-iiif3-level2')
+}
+
+function getAnnotationItems(annotation: unknown) {
+  if (isJsonObject(annotation) && Array.isArray(annotation.items)) {
+    return annotation.items
+  }
+
+  return [annotation]
+}
+
+function getAnnotationShape(annotation: unknown) {
+  const items = getAnnotationItems(annotation)
+  let hasMissingTarget = false
+  let hasBadResourceSize = false
+  let hasOneGcp = false
+
+  for (const item of items) {
+    if (!isJsonObject(item)) {
+      continue
+    }
+
+    const target = item.target
+
+    if (!isJsonObject(target)) {
+      hasMissingTarget = true
+      continue
+    }
+
+    if (isJsonObject(target.source)) {
+      if (
+        ('width' in target.source &&
+          (typeof target.source.width !== 'number' ||
+            target.source.width <= 0)) ||
+        ('height' in target.source &&
+          (typeof target.source.height !== 'number' ||
+            target.source.height <= 0))
+      ) {
+        hasBadResourceSize = true
+      }
+    }
+
+    if (
+      isJsonObject(item.body) &&
+      Array.isArray(item.body.features) &&
+      item.body.features.length === 1
+    ) {
+      hasOneGcp = true
+    }
+  }
+
+  return {
+    hasMissingTarget,
+    hasBadResourceSize,
+    hasOneGcp
+  }
+}
+
+function getFirstAnnotationImageServiceId(annotation: unknown) {
+  const firstItem = getAnnotationItems(annotation)[0]
+
+  if (!isJsonObject(firstItem) || !isJsonObject(firstItem.target)) {
+    throw new Error('Annotation has no target')
+  }
+
+  const { source } = firstItem.target
+
+  if (!isJsonObject(source) || typeof source.id !== 'string') {
+    throw new Error('Annotation target has no image service id')
+  }
+
+  return source.id
+}
+
+function getAnnotationImageServiceIds(annotation: unknown) {
+  return [
+    ...new Set(
+      getAnnotationItems(annotation).flatMap((item) => {
+        if (!isJsonObject(item) || !isJsonObject(item.target)) {
+          return []
+        }
+
+        const { source } = item.target
+
+        return isJsonObject(source) && typeof source.id === 'string'
+          ? [source.id]
+          : []
+      })
+    )
+  ]
+}
+
+function collectAnnotationPagesFromManifest(
+  manifest: unknown,
+  name: string
+): AnnotationResource[] {
+  if (!isJsonObject(manifest)) {
+    return []
+  }
+
+  const resources: AnnotationResource[] = []
+
+  function collectAnnotationPages(value: unknown, source: string) {
+    if (!Array.isArray(value)) {
+      return
+    }
+
+    for (const annotationPage of value) {
+      if (!isJsonObject(annotationPage)) {
+        continue
+      }
+
+      if (
+        annotationPage.type === 'AnnotationPage' &&
+        Array.isArray(annotationPage.items)
+      ) {
+        resources.push({
+          name: source,
+          data: annotationPage
+        })
+      } else if (
+        annotationPage.type === 'AnnotationPage' &&
+        typeof annotationPage.id === 'string'
+      ) {
+        resources.push({
+          name: source,
+          href: annotationPage.id
+        })
+      }
+    }
+  }
+
+  collectAnnotationPages(manifest.annotations, `${name} manifest annotations`)
+
+  if (Array.isArray(manifest.items)) {
+    for (const [index, canvas] of manifest.items.entries()) {
+      if (isJsonObject(canvas)) {
+        collectAnnotationPages(
+          canvas.annotations,
+          `${name} canvas ${index + 1} annotations`
+        )
+      }
+    }
+  }
+
+  return resources
+}
+
+async function getGeneratedAnnotationResources() {
+  const resources = getAnnotationRouteResources()
+  const seenHrefs = new Set(
+    resources.flatMap((resource) => resource.href ?? [])
+  )
+
+  for (const resource of getManifestResources()) {
+    if (isSlowResource(resource.href)) {
+      continue
+    }
+
+    const manifest = await getJsonResource(resource.href)
+
+    for (const annotationResource of collectAnnotationPagesFromManifest(
+      manifest,
+      resource.name
+    )) {
+      if (annotationResource.href) {
+        if (isSlowResource(annotationResource.href)) {
+          continue
+        }
+
+        if (seenHrefs.has(annotationResource.href)) {
+          continue
+        }
+
+        seenHrefs.add(annotationResource.href)
+      }
+
+      resources.push(annotationResource)
+    }
+  }
+
+  return resources
+}
+
+describe('generated IIIF info.json resources', () => {
+  test.each(getInfoResources())('$name', async ({ href, expectation }) => {
+    const data = await getJsonResource(href)
+    const error = getParseError(() => IIIF.parse(data))
+
+    if (expectation === 'valid') {
+      expect(error).toBeUndefined()
+    } else if (expectation === 'missing-dimensions') {
+      expect(getIssuePaths(error)).toEqual(
+        expect.arrayContaining(['width', 'height'])
+      )
+    } else {
+      expect(getIssuePaths(error)).toEqual(
+        expect.arrayContaining(['tiles.0.width', 'tiles.0.scaleFactors.0'])
+      )
+    }
+  })
+})
+
+describe('generated IIIF manifests', () => {
+  test.each(getManifestResources())(
+    '$name',
+    async ({ href, expectation }) => {
+      const data = await getJsonResource(href)
+      const error = getParseError(() => IIIF.parse(data))
+
+      if (expectation === 'valid') {
+        expect(error).toBeUndefined()
+      } else {
+        expect(getIssuePaths(error)).toContain(
+          'sequences.0.canvases.0.images.0.resource.service'
+        )
+      }
+    },
+    20_000
+  )
+})
+
+describe('generated georeference annotations', () => {
+  test.each(combinedAnnotationHttpErrorStatuses)(
+    'combined annotation page returns HTTP %s',
+    async (status) => {
+      const response = await getFixtureResponse(
+        `${baseUrl}/annotations/combined/http-${status}.json`
+      )
+
+      expect(response.status).toBe(status)
+    }
+  )
+
+  test('service failure variant returns valid annotation page and failing image service resources', async () => {
+    const annotation = await getJsonResource(
+      `${baseUrl}/annotations/combined/service-500-iiif3-level2.json`
+    )
+    const serviceId = getFirstAnnotationImageServiceId(annotation)
+    const infoResponse = await getFixtureResponse(`${serviceId}/info.json`)
+    const imageResponse = await getFixtureResponse(
+      `${serviceId}/full/256,/0/default.jpg`
+    )
+
+    expect(() => parseAnnotation(annotation)).not.toThrow()
+    expect(infoResponse.status).toBe(500)
+    expect(imageResponse.status).toBe(500)
+  })
+
+  test('mixed image request failure variant contains working and failing image requests', async () => {
+    const annotation = await getJsonResource(
+      `${baseUrl}/annotations/combined/mixed-image-500-iiif3-level2.json`
+    )
+    const serviceIds = getAnnotationImageServiceIds(annotation)
+    const workingServiceId = serviceIds.find(
+      (serviceId) => !serviceId.includes('/image-500')
+    )
+    const failingServiceId = serviceIds.find((serviceId) =>
+      serviceId.includes('/image-500')
+    )
+
+    expect(workingServiceId).toBeDefined()
+    expect(failingServiceId).toBeDefined()
+    expect(
+      (await getFixtureResponse(`${workingServiceId}/info.json`)).status
+    ).toBe(200)
+    expect(
+      (await getFixtureResponse(`${workingServiceId}/full/64,/0/default.jpg`))
+        .status
+    ).toBe(200)
+    expect(
+      (await getFixtureResponse(`${failingServiceId}/info.json`)).status
+    ).toBe(200)
+    expect(
+      (await getFixtureResponse(`${failingServiceId}/full/64,/0/default.jpg`))
+        .status
+    ).toBe(500)
+  })
+
+  test('mixed image service failure variant contains working and failing image services', async () => {
+    const annotation = await getJsonResource(
+      `${baseUrl}/annotations/combined/mixed-service-500-iiif3-level2.json`
+    )
+    const serviceIds = getAnnotationImageServiceIds(annotation)
+    const workingServiceId = serviceIds.find(
+      (serviceId) => !serviceId.includes('/service-500')
+    )
+    const failingServiceId = serviceIds.find((serviceId) =>
+      serviceId.includes('/service-500')
+    )
+
+    expect(workingServiceId).toBeDefined()
+    expect(failingServiceId).toBeDefined()
+    expect(
+      (await getFixtureResponse(`${workingServiceId}/info.json`)).status
+    ).toBe(200)
+    expect(
+      (await getFixtureResponse(`${workingServiceId}/full/64,/0/default.jpg`))
+        .status
+    ).toBe(200)
+    expect(
+      (await getFixtureResponse(`${failingServiceId}/info.json`)).status
+    ).toBe(500)
+    expect(
+      (await getFixtureResponse(`${failingServiceId}/full/64,/0/default.jpg`))
+        .status
+    ).toBe(500)
+  })
+
+  test('parse or fail with expected annotation errors', async () => {
+    const resources = await getGeneratedAnnotationResources()
+
+    expect(resources.length).toBeGreaterThan(0)
+
+    for (const resource of resources) {
+      const data = resource.href
+        ? await getJsonResource(resource.href)
+        : resource.data
+      const shape = getAnnotationShape(data)
+      const error = getParseError(() => parseAnnotation(data))
+
+      if (shape.hasMissingTarget) {
+        expect(
+          getIssuePaths(error).some((path) => path.endsWith('.target')),
+          `${resource.name} should fail on missing target`
+        ).toBe(true)
+      } else if (shape.hasBadResourceSize) {
+        expect(
+          getIssuePaths(error).some((path) => path.endsWith('.target.source')),
+          `${resource.name} should fail on invalid resource size`
+        ).toBe(true)
+      } else {
+        expect(error, resource.name).toBeUndefined()
+
+        const maps = parseAnnotation(data)
+
+        if (shape.hasOneGcp) {
+          expect(
+            maps.some((map) => map.gcps.length === 1),
+            `${resource.name} should include a one-GCP map`
+          ).toBe(true)
+        } else {
+          expect(
+            maps.every((map) => map.gcps.length > 1),
+            `${resource.name} should include georeferenceable maps`
+          ).toBe(true)
+        }
+      }
+    }
+  }, 20_000)
+})

--- a/test/server/tsconfig.json
+++ b/test/server/tsconfig.json
@@ -4,12 +4,14 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "rootDir": ".",
+    "skipLibCheck": true,
     "types": ["node"]
   },
   "include": [
     "scripts/**/*.ts",
     "src/**/*.ts",
     "src/**/*.svelte",
+    "test/**/*.ts",
     "svelte.config.js",
     "vite.config.ts"
   ],


### PR DESCRIPTION
## Summary

- extract generated IIIF test-server helpers into focused modules
- add generated resource coverage for info.json, manifests, annotation pages, and mixed failure variants
- add browsable root and README entries for the new combined error scenarios

## Validation

- `pnpm --filter @allmaps/test-iiif-server run test`
- `pnpm --filter @allmaps/test-iiif-server run types`

The full precommit hook is currently blocked by an unrelated `@allmaps/basemap` type error in `packages/basemap/src/index.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Test IIIF Server with more sample endpoints for combined annotation pages, mixed success/error cases, and additional HTTP status responses.
  * Added broader IIIF image and manifest fixture coverage, including new response variants and georeference/navigation place examples.
* **Bug Fixes**
  * Improved handling for failing image service requests and combined annotation scenarios so error responses are surfaced consistently.
* **Tests**
  * Added automated checks that validate generated IIIF resources, annotation parsing, and expected failure paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->