### PR TITLE
Improve viewer source load errors

### DIFF
--- a/apps/viewer/src/app.d.ts
+++ b/apps/viewer/src/app.d.ts
@@ -1,12 +1,13 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
+import type { SourceLoadErrorCode } from '$lib/shared/source-errors.js'
+
 declare global {
   namespace App {
-    // interface Error {}
-    // interface Locals {}
-    // interface PageData {}
-    // interface PageState {}
-    // interface Platform {}
+    interface Error {
+      message: string
+      title?: string
+      details?: string
+      code?: SourceLoadErrorCode
+    }
   }
 }
 

--- a/apps/viewer/src/lib/shared/source-errors.ts
+++ b/apps/viewer/src/lib/shared/source-errors.ts
@@ -1,0 +1,134 @@
+export type SourceLoadErrorCode =
+  | 'annotation-without-maps'
+  // TODO: add `canvas-without-maps` once Viewer and Editor can load IIIF Canvas resources directly.
+  | 'image-without-maps'
+  | 'manifest-without-maps'
+
+type SourceLoadErrorInfo = {
+  message: string
+  title: string
+}
+
+const sourceLoadErrors: Record<SourceLoadErrorCode, SourceLoadErrorInfo> = {
+  'annotation-without-maps': {
+    title: 'Annotation contains no maps',
+    message:
+      'This Georeference Annotation does not contain any georeferenced maps.'
+  },
+  'image-without-maps': {
+    title: 'No georeferenced maps found',
+    message:
+      'This IIIF image was loaded, but Allmaps could not find georeferenced maps for it.'
+  },
+  'manifest-without-maps': {
+    title: 'No georeferenced maps found',
+    message:
+      'This IIIF manifest does not contain embedded Georeference Annotations, and Allmaps could not find georeferenced maps for it.'
+  }
+}
+
+export class SourceLoadError extends Error {
+  code: SourceLoadErrorCode
+  status = 422
+  title: string
+
+  constructor(code: SourceLoadErrorCode) {
+    super(sourceLoadErrors[code].message)
+
+    this.name = 'SourceLoadError'
+    this.code = code
+    this.title = sourceLoadErrors[code].title
+  }
+}
+
+type SourceHttpErrorOptions = {
+  cause?: unknown
+  details?: string
+}
+
+export class SourceHttpError extends Error {
+  url: string
+  status: number
+  statusText: string
+  title = 'Could not load remote resource'
+  details?: string
+  cause?: unknown
+
+  constructor(
+    url: string,
+    status: number,
+    statusText = '',
+    options: SourceHttpErrorOptions = {}
+  ) {
+    const statusLabel = statusText ? ` ${statusText}` : ''
+
+    super(`Remote server returned HTTP ${status}${statusLabel}.`)
+
+    this.name = 'SourceHttpError'
+    this.url = url
+    this.status = status
+    this.statusText = statusText
+    this.details = options.details
+    this.cause = options.cause
+  }
+}
+
+export function getSourceLoadErrorTitle(message: string) {
+  const code = getSourceLoadErrorCode(message)
+  return code ? sourceLoadErrors[code].title : undefined
+}
+
+export function getSourceLoadErrorCode(message: string) {
+  return (
+    Object.entries(sourceLoadErrors) as [
+      SourceLoadErrorCode,
+      SourceLoadErrorInfo
+    ][]
+  ).find(([, sourceLoadError]) => sourceLoadError.message === message)?.[0]
+}
+
+export function getSourceErrorCode(error: unknown) {
+  if (error instanceof SourceLoadError) {
+    return error.code
+  }
+
+  return error instanceof Error
+    ? getSourceLoadErrorCode(error.message)
+    : undefined
+}
+
+export function getSourceErrorTitle(error: unknown) {
+  if (error instanceof SourceLoadError || error instanceof SourceHttpError) {
+    return error.title
+  }
+
+  return error instanceof Error
+    ? getSourceLoadErrorTitle(error.message)
+    : undefined
+}
+
+export function getSourceErrorDetails(error: unknown) {
+  return error instanceof SourceHttpError ? error.details : undefined
+}
+
+export function getSourceLoadErrorStatus(error: unknown) {
+  return error instanceof SourceLoadError || error instanceof SourceHttpError
+    ? error.status
+    : 500
+}
+
+export function getSourceLoadErrorEditorUrl(
+  code: SourceLoadErrorCode | undefined,
+  sourceUrl: string | null | undefined
+) {
+  if (
+    !sourceUrl ||
+    (code !== 'manifest-without-maps' && code !== 'image-without-maps')
+  ) {
+    return
+  }
+
+  const params = new URLSearchParams({ url: sourceUrl })
+
+  return `https://editor.allmaps.org/images?${params.toString()}`
+}

--- a/apps/viewer/src/lib/shared/source.ts
+++ b/apps/viewer/src/lib/shared/source.ts
@@ -4,12 +4,18 @@ import { fetchAnnotationsFromApi } from '@allmaps/stdlib'
 import { generateChecksum } from '@allmaps/id/sync'
 
 import { getAllmapsIdFromUrl } from '$lib/shared/api.js'
+import { SourceHttpError, SourceLoadError } from '$lib/shared/source-errors.js'
+import {
+  formatIssues,
+  formatValidationIssuesFromMessage
+} from '$lib/shared/validation-error.js'
 
 import type { GeoreferencedMap, PartOfItem } from '@allmaps/annotation'
 import type { Canvas } from '@allmaps/iiif-parser'
 import type { Manifest } from '@allmaps/iiif-parser'
 
 import type {
+  InvalidGeoreferenceAnnotation,
   ParsedSource,
   UrlSource,
   StringSource
@@ -24,6 +30,22 @@ type AnnotationPage = {
 type AnnotationWithPurpose = {
   motivation?: unknown
   purpose?: unknown
+}
+
+type AnnotationParseContext = {
+  resource?: GeoreferencedMap['resource']
+  canvas?: PartOfItem
+  manifest?: PartOfItem
+  iiifManifest?: Manifest
+}
+
+type ParsedGeoreferenceAnnotations = {
+  maps: GeoreferencedMap[]
+  invalidAnnotations: InvalidGeoreferenceAnnotation[]
+}
+
+type ErrorWithIssues = {
+  issues?: unknown
 }
 
 function hasGeoreferencingValue(value: unknown) {
@@ -46,24 +68,225 @@ function hasGeoreferencingPurpose(annotation: unknown) {
   return hasGeoreferencingValue(motivation) || hasGeoreferencingValue(purpose)
 }
 
-function parseGeoreferenceAnnotation(annotation: unknown) {
-  try {
-    return parseAnnotation(annotation)
-  } catch {
-    return []
+function getStringProperty(value: unknown, key: string) {
+  if (value && typeof value === 'object' && key in value) {
+    const property = value[key as keyof typeof value]
+
+    if (typeof property === 'string') {
+      return property
+    }
   }
 }
 
-function parseGeoreferenceAnnotationPage(annotationPage: AnnotationPage) {
+function getAnnotationId(annotation: unknown) {
+  return (
+    getStringProperty(annotation, 'id') ?? getStringProperty(annotation, '@id')
+  )
+}
+
+function getErrorIssues(error: unknown) {
+  const issues = formatIssues(
+    error && typeof error === 'object'
+      ? (error as ErrorWithIssues).issues
+      : undefined
+  )
+
+  if (issues.length > 0 || !(error instanceof Error)) {
+    return issues
+  }
+
+  return formatValidationIssuesFromMessage(error.message)
+}
+
+function getErrorMessage(error: unknown) {
+  const issues = getErrorIssues(error)
+  const firstIssue = issues[0]
+
+  if (firstIssue) {
+    return `${firstIssue.message} at ${firstIssue.path}`
+  }
+
+  return error instanceof Error
+    ? error.message
+    : 'Invalid Georeference Annotation'
+}
+
+function getAnnotationTargetSource(annotation: unknown) {
+  if (
+    !annotation ||
+    typeof annotation !== 'object' ||
+    !('target' in annotation)
+  ) {
+    return
+  }
+
+  const target = annotation.target
+
+  if (!target || typeof target !== 'object' || !('source' in target)) {
+    return
+  }
+
+  const source = target.source
+
+  return source && typeof source === 'object' ? source : undefined
+}
+
+function getManifestPartOfItem(manifest: Manifest): PartOfItem {
+  return {
+    id: manifest.uri,
+    type: 'Manifest',
+    label: manifest.label
+  }
+}
+
+function getCanvasPartOfItem(canvas: Canvas, manifest: Manifest): PartOfItem {
+  return {
+    id: canvas.uri,
+    type: 'Canvas',
+    label: canvas.label,
+    partOf: [getManifestPartOfItem(manifest)]
+  }
+}
+
+function getCanvasResource(
+  canvas: Canvas,
+  manifest: Manifest
+): GeoreferencedMap['resource'] {
+  return {
+    id: canvas.image.uri,
+    type: getImageServiceType(canvas.image.majorVersion),
+    width: canvas.image.width,
+    height: canvas.image.height,
+    partOf: [getCanvasPartOfItem(canvas, manifest)]
+  }
+}
+
+function getAnnotationContext(
+  annotation: unknown,
+  context: AnnotationParseContext
+): AnnotationParseContext {
+  if (context.resource || !context.iiifManifest) {
+    return context
+  }
+
+  const source = getAnnotationTargetSource(annotation)
+  const sourceId =
+    getStringProperty(source, 'id') ?? getStringProperty(source, '@id')
+
+  if (!sourceId) {
+    return context
+  }
+
+  const canvas = context.iiifManifest.canvases.find(
+    (currentCanvas) => currentCanvas.uri === sourceId
+  )
+
+  if (!canvas) {
+    return context
+  }
+
+  return {
+    ...context,
+    resource: getCanvasResource(canvas, context.iiifManifest),
+    canvas: getCanvasPartOfItem(canvas, context.iiifManifest),
+    manifest: getManifestPartOfItem(context.iiifManifest)
+  }
+}
+
+function createInvalidGeoreferenceAnnotation(
+  annotation: unknown,
+  error: unknown,
+  context: AnnotationParseContext,
+  index: number
+): InvalidGeoreferenceAnnotation | undefined {
+  const annotationContext = getAnnotationContext(annotation, context)
+  const { resource } = annotationContext
+
+  if (!resource) {
+    return
+  }
+
+  const annotationId = getAnnotationId(annotation)
+  const validationIssues = getErrorIssues(error)
+  const message = getErrorMessage(error)
+
+  return {
+    id:
+      annotationId ??
+      generateChecksum({
+        annotation,
+        index,
+        resourceId: resource.id,
+        message
+      }),
+    annotationId,
+    resource,
+    canvas: annotationContext.canvas,
+    manifest: annotationContext.manifest,
+    message,
+    validationIssues
+  }
+}
+
+function parseGeoreferenceAnnotation(
+  annotation: unknown,
+  context: AnnotationParseContext,
+  index: number
+): ParsedGeoreferenceAnnotations {
+  try {
+    return {
+      maps: parseAnnotation(annotation),
+      invalidAnnotations: []
+    }
+  } catch (error) {
+    const invalidAnnotation = createInvalidGeoreferenceAnnotation(
+      annotation,
+      error,
+      context,
+      index
+    )
+
+    return {
+      maps: [],
+      invalidAnnotations: invalidAnnotation ? [invalidAnnotation] : []
+    }
+  }
+}
+
+function emptyGeoreferenceAnnotations(): ParsedGeoreferenceAnnotations {
+  return {
+    maps: [],
+    invalidAnnotations: []
+  }
+}
+
+function parseGeoreferenceAnnotationPage(
+  annotationPage: AnnotationPage,
+  context: AnnotationParseContext = {}
+): ParsedGeoreferenceAnnotations {
   const annotations = hasGeoreferencingPurpose(annotationPage)
     ? annotationPage.items
     : annotationPage.items?.filter(hasGeoreferencingPurpose)
 
   if (!annotations || annotations.length === 0) {
-    return []
+    return emptyGeoreferenceAnnotations()
   }
 
-  return annotations.flatMap(parseGeoreferenceAnnotation)
+  return annotations.reduce<ParsedGeoreferenceAnnotations>(
+    (result, annotation, index) => {
+      const parsedAnnotation = parseGeoreferenceAnnotation(
+        annotation,
+        context,
+        index
+      )
+
+      result.maps.push(...parsedAnnotation.maps)
+      result.invalidAnnotations.push(...parsedAnnotation.invalidAnnotations)
+
+      return result
+    },
+    emptyGeoreferenceAnnotations()
+  )
 }
 
 async function fetchAnnotationPage(
@@ -118,6 +341,22 @@ function addMapCanvasIds(map: GeoreferencedMap, canvasIds: Set<string>) {
   }
 }
 
+function addInvalidAnnotationCanvasIds(
+  invalidAnnotation: InvalidGeoreferenceAnnotation,
+  canvasIds: Set<string>
+) {
+  if (invalidAnnotation.canvas?.id) {
+    canvasIds.add(invalidAnnotation.canvas.id)
+  }
+
+  for (const canvas of findPartOfItemsOfType(
+    invalidAnnotation.resource.partOf,
+    'Canvas'
+  )) {
+    canvasIds.add(canvas.id)
+  }
+}
+
 function filterApiMaps(
   apiMaps: GeoreferencedMap[],
   embeddedMaps: GeoreferencedMap[],
@@ -136,21 +375,6 @@ function filterApiMaps(
 
     return ![...canvasIds].some((canvasId) => embeddedCanvasIds.has(canvasId))
   })
-}
-
-function getCanvasPartOfItem(canvas: Canvas, manifest: Manifest): PartOfItem {
-  return {
-    id: canvas.uri,
-    type: 'Canvas',
-    label: canvas.label,
-    partOf: [
-      {
-        id: manifest.uri,
-        type: 'Manifest',
-        label: manifest.label
-      }
-    ]
-  }
 }
 
 function getImageServiceType(
@@ -180,10 +404,7 @@ function normalizeMapResourceForCanvas(
     ...map,
     resource: {
       ...map.resource,
-      id: canvas.image.uri,
-      type: getImageServiceType(canvas.image.majorVersion),
-      width: canvas.image.width,
-      height: canvas.image.height,
+      ...getCanvasResource(canvas, manifest),
       partOf: [canvasPartOfItem]
     }
   }
@@ -209,42 +430,72 @@ async function parseManifestGeoreferenceAnnotations(
   fetch = globalThis.fetch
 ) {
   const maps: GeoreferencedMap[] = []
+  const invalidAnnotations: InvalidGeoreferenceAnnotation[] = []
   const canvasIds = new Set<string>()
+  const manifestPartOfItem = getManifestPartOfItem(manifest)
 
   for (const annotationPage of manifest.annotations ?? []) {
     const fetchedAnnotationPage = await fetchAnnotationPage(
       annotationPage,
       fetch
     )
-    const pageMaps = parseGeoreferenceAnnotationPage(fetchedAnnotationPage).map(
-      (map) => normalizeMapResourceForManifest(map, manifest)
+    const parsedAnnotationPage = parseGeoreferenceAnnotationPage(
+      fetchedAnnotationPage,
+      {
+        manifest: manifestPartOfItem,
+        iiifManifest: manifest
+      }
+    )
+    const pageMaps = parsedAnnotationPage.maps.map((map) =>
+      normalizeMapResourceForManifest(map, manifest)
     )
 
     for (const map of pageMaps) {
       addMapCanvasIds(map, canvasIds)
     }
 
+    for (const invalidAnnotation of parsedAnnotationPage.invalidAnnotations) {
+      addInvalidAnnotationCanvasIds(invalidAnnotation, canvasIds)
+    }
+
     maps.push(...pageMaps)
+    invalidAnnotations.push(...parsedAnnotationPage.invalidAnnotations)
   }
 
   for (const canvas of manifest.canvases) {
     let canvasHasGeoreferenceAnnotation = false
+    const canvasPartOfItem = getCanvasPartOfItem(canvas, manifest)
+    const canvasContext = {
+      resource: getCanvasResource(canvas, manifest),
+      canvas: canvasPartOfItem,
+      manifest: manifestPartOfItem,
+      iiifManifest: manifest
+    }
 
     for (const annotationPage of canvas.annotations ?? []) {
       const fetchedAnnotationPage = await fetchAnnotationPage(
         annotationPage,
         fetch
       )
-      const pageMaps = parseGeoreferenceAnnotationPage(
-        fetchedAnnotationPage
-      ).map((map) => normalizeMapResourceForCanvas(map, canvas, manifest))
+      const parsedAnnotationPage = parseGeoreferenceAnnotationPage(
+        fetchedAnnotationPage,
+        canvasContext
+      )
+      const pageMaps = parsedAnnotationPage.maps.map((map) =>
+        normalizeMapResourceForCanvas(map, canvas, manifest)
+      )
+      const pageInvalidAnnotations = parsedAnnotationPage.invalidAnnotations
 
-      if (pageMaps.length > 0) {
+      if (pageMaps.length > 0 || pageInvalidAnnotations.length > 0) {
         canvasHasGeoreferenceAnnotation = true
         for (const map of pageMaps) {
           addMapCanvasIds(map, canvasIds)
         }
+        for (const invalidAnnotation of pageInvalidAnnotations) {
+          addInvalidAnnotationCanvasIds(invalidAnnotation, canvasIds)
+        }
         maps.push(...pageMaps)
+        invalidAnnotations.push(...pageInvalidAnnotations)
       }
     }
 
@@ -255,6 +506,7 @@ async function parseManifestGeoreferenceAnnotations(
 
   return {
     maps,
+    invalidAnnotations,
     canvasIds,
     hasAnnotationsForAllCanvases:
       manifest.canvases.length > 0 &&
@@ -275,6 +527,11 @@ async function parseSource(
   ) {
     // json is probably a Georeference Annotation
     const maps = parseAnnotation(json)
+
+    if (maps.length === 0) {
+      throw new SourceLoadError('annotation-without-maps')
+    }
+
     return {
       type: 'annotation',
       maps
@@ -286,6 +543,7 @@ async function parseSource(
 
     let apiMaps: GeoreferencedMap[] | undefined
     let embeddedMaps: GeoreferencedMap[] | undefined
+    let invalidEmbeddedAnnotations: InvalidGeoreferenceAnnotation[] | undefined
     let embeddedCanvasIds = new Set<string>()
     let hasAnnotationsForAllCanvases = false
 
@@ -294,6 +552,8 @@ async function parseSource(
         await parseManifestGeoreferenceAnnotations(parsedIiif, fetch)
 
       embeddedMaps = manifestGeoreferenceAnnotations.maps
+      invalidEmbeddedAnnotations =
+        manifestGeoreferenceAnnotations.invalidAnnotations
       embeddedCanvasIds = manifestGeoreferenceAnnotations.canvasIds
       hasAnnotationsForAllCanvases =
         manifestGeoreferenceAnnotations.hasAnnotationsForAllCanvases
@@ -301,6 +561,7 @@ async function parseSource(
 
     if (!hasAnnotationsForAllCanvases) {
       try {
+        // TODO: rename function... this doesn't fetch annotations, but maps.
         const apiAnnotations = await fetchAnnotationsFromApi(
           annotationsBaseUrl,
           parsedIiif,
@@ -322,10 +583,24 @@ async function parseSource(
       }
     }
 
+    if (
+      parsedIiif.type === 'manifest' &&
+      (embeddedMaps?.length ?? 0) === 0 &&
+      (invalidEmbeddedAnnotations?.length ?? 0) === 0 &&
+      (apiMaps?.length ?? 0) === 0
+    ) {
+      throw new SourceLoadError('manifest-without-maps')
+    }
+
+    if (parsedIiif.type === 'image' && (apiMaps?.length ?? 0) === 0) {
+      throw new SourceLoadError('image-without-maps')
+    }
+
     return {
       type: 'iiif',
       iiif: parsedIiif,
       embeddedMaps,
+      invalidEmbeddedAnnotations,
       apiMaps
     }
   }
@@ -336,7 +611,25 @@ export async function sourceFromUrl(
   url: string,
   fetch = globalThis.fetch
 ): Promise<UrlSource> {
-  const data = await fetch(url).then((response) => response.json())
+  const response = await fetch(url)
+  let data: unknown
+
+  try {
+    data = await response.json()
+  } catch (err) {
+    if (!response.ok) {
+      throw new SourceHttpError(url, response.status, response.statusText, {
+        cause: err,
+        details: err instanceof Error ? err.message : String(err)
+      })
+    }
+
+    throw err
+  }
+
+  if (!response.ok) {
+    throw new SourceHttpError(url, response.status, response.statusText)
+  }
 
   const allmapsId = getAllmapsIdFromUrl(url)
 

--- a/apps/viewer/src/lib/state/source.svelte.ts
+++ b/apps/viewer/src/lib/state/source.svelte.ts
@@ -2,6 +2,7 @@ import { setContext, getContext } from 'svelte'
 
 import type { Source } from '$lib/types/shared.js'
 import type { UiState } from '$lib/state/ui.svelte.js'
+import type { SourceLoadErrorCode } from '$lib/shared/source-errors.js'
 
 const SOURCE_KEY = Symbol('source')
 
@@ -10,6 +11,10 @@ export type SourceErrorReason = 'url' | 'data'
 export type SourceError = {
   reason: SourceErrorReason
   message: string
+  code?: SourceLoadErrorCode
+  title?: string
+  details?: string
+  corsLikely?: boolean
   sourceUrl?: string
 }
 

--- a/apps/viewer/src/lib/types/shared.ts
+++ b/apps/viewer/src/lib/types/shared.ts
@@ -6,6 +6,8 @@ import type {
 } from '@allmaps/iiif-parser'
 import type { GeoreferencedMap, PartOfItem } from '@allmaps/annotation'
 
+import type { FormattedValidationIssue } from '$lib/shared/validation-error.js'
+
 type AllmapsSourceType = 'manifests' | 'images' | 'maps'
 
 export type AllmapsId = `${AllmapsSourceType}/${string}`
@@ -24,7 +26,7 @@ export type Organization = {
 
 export type OrganizationSummary = {
   organization: Organization
-  otherOrganizationCount: number
+  otherOrganizationCount?: number
 }
 
 type BaseSource = {
@@ -43,6 +45,7 @@ export type ParsedSource =
       type: 'iiif'
       iiif: Image | Manifest | Collection
       embeddedMaps?: GeoreferencedMap[]
+      invalidEmbeddedAnnotations?: InvalidGeoreferenceAnnotation[]
       apiMaps?: GeoreferencedMap[]
     }
 
@@ -70,9 +73,18 @@ export type MapsByCanvas = {
 export type MapsByImage = {
   resource: GeoreferencedMap['resource']
   maps: GeoreferencedMap[]
+  invalidAnnotations?: InvalidGeoreferenceAnnotation[]
 }
 
-// export type MapsHierarchy = (MapsByManifest | MapsByCanvas | MapsByImage)[]
+export type InvalidGeoreferenceAnnotation = {
+  id: string
+  annotationId?: string
+  resource: GeoreferencedMap['resource']
+  canvas?: PartOfItem
+  manifest?: PartOfItem
+  message: string
+  validationIssues: FormattedValidationIssue[]
+}
 
 export type MapsHierarchy = {
   mapsByManifest?: MapsByManifest[]

--- a/apps/viewer/src/routes/(app)/+layout.server.ts
+++ b/apps/viewer/src/routes/(app)/+layout.server.ts
@@ -1,4 +1,14 @@
+import { error } from '@sveltejs/kit'
+
 import { sourceFromUrl } from '$lib/shared/source.js'
+import {
+  getSourceErrorCode,
+  getSourceErrorDetails,
+  getSourceErrorTitle,
+  getSourceLoadErrorStatus,
+  SourceHttpError,
+  SourceLoadError
+} from '$lib/shared/source-errors.js'
 
 import type { LayoutServerLoad } from './$types'
 
@@ -30,7 +40,16 @@ export const load: LayoutServerLoad = async ({ fetch, url, parent }) => {
         source,
         urlParam
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof SourceLoadError || err instanceof SourceHttpError) {
+        error(getSourceLoadErrorStatus(err), {
+          message: err.message,
+          code: getSourceErrorCode(err),
+          title: getSourceErrorTitle(err),
+          details: getSourceErrorDetails(err)
+        })
+      }
+
       // An error occurred while fetching the source.
       // This probably means the URL is invalid or unvailable, but it
       // could also mean the host institution is blocking traffic from

--- a/apps/viewer/src/routes/(app)/+layout.ts
+++ b/apps/viewer/src/routes/(app)/+layout.ts
@@ -1,6 +1,12 @@
 import { error } from '@sveltejs/kit'
 
 import { sourceFromUrl } from '$lib/shared/source.js'
+import {
+  getSourceErrorCode,
+  getSourceErrorDetails,
+  getSourceErrorTitle,
+  getSourceLoadErrorStatus
+} from '$lib/shared/source-errors.js'
 
 import type { LayoutLoad } from './$types'
 
@@ -35,8 +41,11 @@ export const load: LayoutLoad = async ({ data, fetch, url, parent }) => {
         message = err.message
       }
 
-      error(500, {
-        message
+      error(getSourceLoadErrorStatus(err), {
+        message,
+        code: getSourceErrorCode(err),
+        title: getSourceErrorTitle(err),
+        details: getSourceErrorDetails(err)
       })
     }
   }


### PR DESCRIPTION
## Summary

Adds typed viewer source-load error handling and carries source failures through the app layout/load state.

## Stack

This is PR 1 of 4 in the `new-viewer` stack. Base: `develop`.

## Validation

Not run; this PR was created from the staged GitButler split only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, structured error messages when a source can’t be loaded or parsed.
  * Improved handling of invalid georeference annotations so they can be surfaced with more context.

* **Bug Fixes**
  * Better distinguishes missing-map cases for annotations, manifests, and images.
  * Remote load failures now return more helpful details, including status information and likely CORS issues.
  * Error screens now preserve useful titles, codes, and details instead of showing only a generic failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->