### PR TITLE
Track viewer image and render failures

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -31,13 +31,13 @@
   "dependencies": {
     "@allmaps/annotation": "workspace:^",
     "@allmaps/background-color": "workspace:^",
-    "@allmaps/id": "workspace:^",
     "@allmaps/basemap": "workspace:^",
     "@allmaps/bearing": "workspace:^",
     "@allmaps/components": "workspace:^",
     "@allmaps/env": "workspace:^",
-    "@allmaps/iiif-parser": "workspace:^",
+    "@allmaps/id": "workspace:^",
     "@allmaps/iiif-inspector": "workspace:^",
+    "@allmaps/iiif-parser": "workspace:^",
     "@allmaps/maplibre": "workspace:^",
     "@allmaps/project": "workspace:^",
     "@allmaps/render": "workspace:^",
@@ -46,7 +46,9 @@
     "@allmaps/ui": "workspace:^",
     "bits-ui": "catalog:",
     "comlink": "^4.4.1",
-    "maplibre-gl": "catalog:"
+    "lodash-es": "^4.17.21",
+    "maplibre-gl": "catalog:",
+    "simplify-js": "^1.2.4"
   },
   "devDependencies": {
     "@allmaps/types": "workspace:^",
@@ -56,11 +58,13 @@
     "@sveltejs/kit": "^2.49.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/vite": "^4.1.17",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "catalog:",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.13.1",
     "globals": "^16.5.0",
+    "phosphor-svelte": "^3.0.1",
     "prettier": "^3.7.4",
     "prettier-plugin-svelte": "^3.4.0",
     "prettier-plugin-tailwindcss": "^0.7.2",
@@ -71,7 +75,6 @@
     "typescript-eslint": "^8.48.1",
     "vite": "catalog:",
     "vite-plugin-devtools-json": "^1.0.0",
-    "phosphor-svelte": "^3.0.1",
     "wrangler": "catalog:"
   }
 }

--- a/apps/viewer/src/lib/shared/iiif.ts
+++ b/apps/viewer/src/lib/shared/iiif.ts
@@ -1,5 +1,6 @@
 import { parseLanguageString } from '@allmaps/iiif-inspector'
-import type { PartOf, PartOfItem } from '@allmaps/annotation'
+
+import type { GeoreferencedMap, PartOf, PartOfItem } from '@allmaps/annotation'
 
 type PartOfItemWithParent = PartOfItem & {
   parent?: PartOfItem
@@ -39,4 +40,36 @@ export function labelFromPartOfItem(item: PartOfItem) {
   if (item.label) {
     return parseLanguageString(item.label)
   }
+}
+
+function normalizeIiifResourceId(id: string) {
+  return id.replace(/\/info\.json$/, '').replace(/\/$/, '')
+}
+
+function isImageServiceCanvas(map: GeoreferencedMap, canvas: PartOfItem) {
+  return (
+    normalizeIiifResourceId(canvas.id) ===
+    normalizeIiifResourceId(map.resource.id)
+  )
+}
+
+export function getCanonicalCanvas(map: GeoreferencedMap) {
+  const canvases = findCanvases(map.resource.partOf ?? [])
+
+  return (
+    canvases.find((canvas) => !isImageServiceCanvas(map, canvas)) ?? canvases[0]
+  )
+}
+
+export function getCanonicalManifest(map: GeoreferencedMap) {
+  const canvas = getCanonicalCanvas(map)
+  const manifests = (canvas?.partOf ?? []).filter(
+    (item) => item.type === 'Manifest'
+  )
+
+  if (manifests.length > 0) {
+    return manifests[0]
+  }
+
+  return findManifests(map.resource.partOf ?? [])[0]
 }

--- a/apps/viewer/src/lib/shared/metadata.ts
+++ b/apps/viewer/src/lib/shared/metadata.ts
@@ -1,10 +1,23 @@
+import { parseLanguageString } from '@allmaps/iiif-inspector'
 import type { LanguageString } from '@allmaps/iiif-parser'
 import type { GeoreferencedMap, PartOf, PartOfItem } from '@allmaps/annotation'
+
+import { getCanonicalCanvas, getCanonicalManifest } from '$lib/shared/iiif.js'
 
 import type { OrganizationSummary, SourceLabels } from '$lib/types/shared.js'
 
 const DOMINANT_ORGANIZATION_THRESHOLD = 0.6
 const DOMINANT_MANIFEST_THRESHOLD = 0.8
+
+function getMeaningfulLabel(label?: LanguageString) {
+  const labelString = parseLanguageString(label, 'en')?.trim()
+
+  if (!labelString || labelString === '-') {
+    return undefined
+  }
+
+  return label
+}
 
 function countManifestsById(
   maps: GeoreferencedMap[]
@@ -14,16 +27,18 @@ function countManifestsById(
     { count: number; label: LanguageString }
   >()
   for (const map of maps) {
-    for (const partOfItem of flattenPartOf(map.resource.partOf)) {
-      if (partOfItem.type === 'Manifest' && partOfItem.id) {
-        const key = partOfItem.id
-        const label = partOfItem.label
+    const manifest = getCanonicalManifest(map)
+
+    if (manifest?.id && manifest.label) {
+      const key = manifest.id
+
+      if (manifestCounts.has(key)) {
+        manifestCounts.get(key)!.count++
+      } else {
+        const label = getMeaningfulLabel(manifest.label)
+
         if (label) {
-          if (manifestCounts.has(key)) {
-            manifestCounts.get(key)!.count++
-          } else {
-            manifestCounts.set(key, { count: 1, label })
-          }
+          manifestCounts.set(key, { count: 1, label })
         }
       }
     }
@@ -42,39 +57,17 @@ export function* flattenPartOf(partOf?: PartOf): Generator<PartOfItem> {
   }
 }
 
-function getPartOfItemsByMapId(maps: GeoreferencedMap[]) {
-  const partOfItemsByMapId: Map<string, PartOfItem[]> = new Map()
-
-  for (const map of maps) {
-    const partOfs = [...flattenPartOf(map.resource.partOf)]
-    if (map.id) {
-      partOfItemsByMapId.set(map.id, partOfs)
-    }
-  }
-
-  return partOfItemsByMapId
-}
-
-function findFirstParfOfItemOfType(
-  partOfItems: PartOfItem[],
-  type: string
-): PartOfItem | undefined {
-  return partOfItems.find((partOfItem) => partOfItem.type === type)
-}
-
 export function getSourceLabels(
   maps: GeoreferencedMap[],
   selectedMapId?: string
 ): SourceLabels {
   if (selectedMapId) {
-    const partOfItemsByMapId = getPartOfItemsByMapId(maps)
+    const selectedMap = maps.find((map) => map.id === selectedMapId)
 
-    if (partOfItemsByMapId.has(selectedMapId)) {
-      const partOfItems = partOfItemsByMapId.get(selectedMapId) || []
-
+    if (selectedMap) {
       return {
-        manifest: findFirstParfOfItemOfType(partOfItems, 'Manifest')?.label,
-        canvas: findFirstParfOfItemOfType(partOfItems, 'Canvas')?.label
+        manifest: getMeaningfulLabel(getCanonicalManifest(selectedMap)?.label),
+        canvas: getMeaningfulLabel(getCanonicalCanvas(selectedMap)?.label)
       }
     }
   }
@@ -101,6 +94,7 @@ export function getSourceLabels(
 
   if (
     maps.length > 0 &&
+    otherMapCount > 0 &&
     dominantManifest.count / maps.length > DOMINANT_MANIFEST_THRESHOLD
   ) {
     return {

--- a/apps/viewer/src/lib/state/background-colors.svelte.ts
+++ b/apps/viewer/src/lib/state/background-colors.svelte.ts
@@ -30,11 +30,7 @@ export class BackgroundColorsState extends BackgroundColorEventTarget {
   #computingIds = new Set<string>()
   #worker: Remote<BackgroundColorWorkerType>
 
-  constructor(
-    mapsState: MapsState,
-    imagesState: ImagesState,
-    paused: boolean
-  ) {
+  constructor(mapsState: MapsState, imagesState: ImagesState, paused: boolean) {
     super()
 
     this.#mapsState = mapsState
@@ -126,6 +122,16 @@ export class BackgroundColorsState extends BackgroundColorEventTarget {
 
   getBackgroundColorForMap(mapId: string) {
     return this.#backgroundColors.get(mapId)
+  }
+
+  hasBackgroundColorForMap(mapId: string) {
+    return this.#backgroundColors.has(mapId)
+  }
+
+  get hasBackgroundColors() {
+    return this.#mapsState.maps.some(
+      (map) => map.id && this.hasBackgroundColorForMap(map.id)
+    )
   }
 }
 

--- a/apps/viewer/src/lib/state/errors.svelte.ts
+++ b/apps/viewer/src/lib/state/errors.svelte.ts
@@ -1,0 +1,307 @@
+import { getContext, setContext } from 'svelte'
+
+import type { Manifest } from '@allmaps/iiif-parser'
+
+import type { ImageError, ImagesState } from '$lib/state/images.svelte.js'
+import type { MapRenderError, MapsState } from '$lib/state/maps.svelte.js'
+import type { SourceError, SourceState } from '$lib/state/source.svelte.js'
+import type { Source } from '$lib/types/shared.js'
+
+const ERRORS_KEY = Symbol('errors')
+
+type JsonObject = Record<string, unknown>
+
+export type ViewerBlockingError =
+  | {
+      type: 'source'
+      sourceError: SourceError
+    }
+  | {
+      type: 'images'
+      imageErrors: ImageError[]
+      sourceImageCount: number
+    }
+  | {
+      type: 'map-render'
+      mapRenderError: MapRenderError
+    }
+
+export type SourceInfoWarningType =
+  | 'invalid-annotation'
+  | 'image'
+  | 'map-render'
+
+export type SourceInfoWarningDetail = {
+  type: SourceInfoWarningType
+  text: string
+}
+
+export type ViewerErrorType =
+  | ViewerBlockingError['type']
+  | SourceInfoWarningType
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+function hasGeoreferencingValue(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value === 'georeferencing'
+  } else if (Array.isArray(value)) {
+    return value.some(hasGeoreferencingValue)
+  }
+
+  return false
+}
+
+function hasGeoreferencingPurpose(annotation: unknown): boolean {
+  if (!isJsonObject(annotation)) {
+    return false
+  }
+
+  return (
+    hasGeoreferencingValue(annotation.motivation) ||
+    hasGeoreferencingValue(annotation.purpose)
+  )
+}
+
+function countAnnotationPageItems(annotationPage: unknown) {
+  if (!isJsonObject(annotationPage)) {
+    return
+  }
+
+  const items = annotationPage.items
+
+  if (!Array.isArray(items)) {
+    return
+  }
+
+  if (hasGeoreferencingPurpose(annotationPage)) {
+    return items.length
+  }
+
+  return items.filter(hasGeoreferencingPurpose).length
+}
+
+function countSourceAnnotationItems(source: Source) {
+  if (!isJsonObject(source.data)) {
+    return
+  }
+
+  if (source.data.type === 'Annotation') {
+    return 1
+  }
+
+  if (source.data.type === 'AnnotationPage') {
+    return countAnnotationPageItems(source.data)
+  }
+}
+
+function countManifestAnnotationItems(manifest: Manifest) {
+  let count = 0
+
+  for (const canvas of manifest.canvases) {
+    for (const annotationPage of canvas.annotations ?? []) {
+      count += countAnnotationPageItems(annotationPage) ?? 0
+    }
+  }
+
+  return count
+}
+
+function countInvalidAnnotations(source?: Source) {
+  if (!source) {
+    return 0
+  }
+
+  if (source.parsed.type === 'annotation') {
+    const annotationCount = countSourceAnnotationItems(source)
+
+    if (annotationCount === undefined) {
+      return 0
+    }
+
+    return Math.max(0, annotationCount - source.parsed.maps.length)
+  }
+
+  const invalidEmbeddedAnnotationCount =
+    source.parsed.invalidEmbeddedAnnotations?.length ?? 0
+
+  if (invalidEmbeddedAnnotationCount > 0) {
+    return invalidEmbeddedAnnotationCount
+  }
+
+  if (source.parsed.iiif.type !== 'manifest') {
+    return 0
+  }
+
+  return Math.max(
+    0,
+    countManifestAnnotationItems(source.parsed.iiif) -
+      (source.parsed.embeddedMaps?.length ?? 0)
+  )
+}
+
+function getInvalidAnnotationWarningDetail(
+  invalidAnnotationCount: number
+): SourceInfoWarningDetail | undefined {
+  if (invalidAnnotationCount === 0) {
+    return
+  }
+
+  return {
+    type: 'invalid-annotation',
+    text: `${pluralize(
+      invalidAnnotationCount,
+      'Georeference Annotation'
+    )} could not be parsed.`
+  }
+}
+
+function getImageLoadWarningDetail(
+  sourceImageCount: number,
+  imageErrorCount: number
+): SourceInfoWarningDetail | undefined {
+  if (imageErrorCount === 0) {
+    return
+  }
+
+  if (sourceImageCount > 0 && imageErrorCount === sourceImageCount) {
+    return {
+      type: 'image',
+      text: `All ${pluralize(sourceImageCount, 'image')} could not be loaded`
+    }
+  } else if (sourceImageCount > 0) {
+    return {
+      type: 'image',
+      text: `${imageErrorCount} of ${pluralize(
+        sourceImageCount,
+        'image'
+      )} could not be loaded.`
+    }
+  }
+
+  return {
+    type: 'image',
+    text: `${pluralize(imageErrorCount, 'image')} could not be loaded`
+  }
+}
+
+function getMapRenderWarningDetail(
+  mapRenderErrorCount: number
+): SourceInfoWarningDetail | undefined {
+  if (mapRenderErrorCount === 0) {
+    return
+  }
+
+  return {
+    type: 'map-render',
+    text: `${pluralize(mapRenderErrorCount, 'map')} could not be warped`
+  }
+}
+
+function compactDetails(details: Array<SourceInfoWarningDetail | undefined>) {
+  return details.filter((detail) => detail !== undefined)
+}
+
+export class ErrorsState {
+  #sourceState: SourceState
+  #mapsState: MapsState
+  #imagesState: ImagesState
+
+  #imageErrors = $derived.by(() => [...this.#imagesState.imageErrors.values()])
+  #mapRenderErrors = $derived.by(() => this.#mapsState.mapRenderErrors)
+
+  #invalidAnnotationCount = $derived.by(() =>
+    countInvalidAnnotations(this.#sourceState.source)
+  )
+
+  #sourceInfoWarningDetails = $derived.by(() =>
+    compactDetails([
+      getInvalidAnnotationWarningDetail(this.#invalidAnnotationCount),
+      getMapRenderWarningDetail(this.#mapRenderErrors.length),
+      getImageLoadWarningDetail(
+        this.#imagesState.sourceImageCount,
+        this.#imagesState.imageErrorCount
+      )
+    ])
+  )
+
+  #viewerBlockingError = $derived.by((): ViewerBlockingError | undefined => {
+    if (this.#sourceState.error) {
+      return {
+        type: 'source',
+        sourceError: this.#sourceState.error
+      }
+    }
+
+    if (this.#mapsState.mapCount === 1 && this.#mapRenderErrors.length === 1) {
+      return {
+        type: 'map-render',
+        mapRenderError: this.#mapRenderErrors[0]
+      }
+    }
+
+    if (this.#imagesState.allSourceImagesFailed) {
+      return {
+        type: 'images',
+        imageErrors: this.#imageErrors,
+        sourceImageCount: this.#imagesState.sourceImageCount
+      }
+    }
+  })
+
+  constructor(
+    sourceState: SourceState,
+    mapsState: MapsState,
+    imagesState: ImagesState
+  ) {
+    this.#sourceState = sourceState
+    this.#mapsState = mapsState
+    this.#imagesState = imagesState
+  }
+
+  get viewerBlockingError() {
+    return this.#viewerBlockingError
+  }
+
+  get sourceInfoWarningDetails() {
+    return this.#sourceInfoWarningDetails
+  }
+
+  get hasSourceInfoWarnings() {
+    return this.#sourceInfoWarningDetails.length > 0
+  }
+
+  get sourceImageCount() {
+    return this.#imagesState.sourceImageCount
+  }
+
+  get imageErrorCount() {
+    return this.#imagesState.imageErrorCount
+  }
+}
+
+export function setErrorsState(
+  sourceState: SourceState,
+  mapsState: MapsState,
+  imagesState: ImagesState
+) {
+  return setContext(
+    ERRORS_KEY,
+    new ErrorsState(sourceState, mapsState, imagesState)
+  )
+}
+
+export function getErrorsState() {
+  const errorsState = getContext<ErrorsState>(ERRORS_KEY)
+  if (!errorsState) {
+    throw new Error('ErrorsState is not set')
+  }
+
+  return errorsState
+}

--- a/apps/viewer/src/lib/state/iiif.svelte.ts
+++ b/apps/viewer/src/lib/state/iiif.svelte.ts
@@ -1,12 +1,9 @@
 import { setContext, getContext } from 'svelte'
 import { SvelteMap } from 'svelte/reactivity'
 
-import {
-  Manifest as IIIFManifest,
-  type Canvas as IIIFCanvas
-} from '@allmaps/iiif-parser'
-import { findYearInCanvas, findYearInManifest } from '@allmaps/iiif-inspector'
+import { Manifest as IIIFManifest } from '@allmaps/iiif-parser'
 import { fetchJson } from '@allmaps/stdlib'
+// import { findYearInCanvas, findYearInManifest } from '@allmaps/iiif-inspector'
 
 import { findManifests } from '$lib/shared/iiif.js'
 
@@ -33,11 +30,24 @@ type FetchResult = FetchingResult | ManifestResult | ErrorResult
 export class IiifState {
   #mapsState: MapsState
 
-  #manifestItems = $derived.by(() =>
-    this.#mapsState.maps.flatMap((map) =>
+  #manifestItems = $derived.by(() => [
+    ...this.#mapsState.maps.flatMap((map) =>
       findManifests(map.resource.partOf ?? [])
+    ),
+    ...this.#mapsState.invalidEmbeddedAnnotations.flatMap(
+      (invalidAnnotation) => [
+        ...(invalidAnnotation.manifest
+          ? [
+              {
+                ...invalidAnnotation.manifest,
+                parent: invalidAnnotation.canvas
+              }
+            ]
+          : []),
+        ...findManifests(invalidAnnotation.resource.partOf ?? [])
+      ]
     )
-  )
+  ])
 
   #manifestIds = $derived.by(() => {
     const manifestIds: string[] = []
@@ -53,24 +63,6 @@ export class IiifState {
     return manifestIds
   })
 
-  #manifestCanvasIds = $derived.by(() => {
-    const canvasIdsByManifestId = new SvelteMap<string, string[]>()
-
-    for (const item of this.#manifestItems) {
-      if (item.parent?.type !== 'Canvas') {
-        continue
-      }
-
-      const canvasIds = canvasIdsByManifestId.get(item.id) ?? []
-
-      if (!canvasIds.includes(item.parent.id)) {
-        canvasIdsByManifestId.set(item.id, [...canvasIds, item.parent.id])
-      }
-    }
-
-    return canvasIdsByManifestId
-  })
-
   #fetchedManifests = $state<SvelteMap<string, FetchResult>>(new SvelteMap())
   #parsedManifests = $derived(
     new SvelteMap(
@@ -83,33 +75,51 @@ export class IiifState {
     )
   )
 
-  #year = $derived.by(() => {
-    const years = [...this.#parsedManifests.entries()]
-      .map(([manifestId, manifest]) => {
-        const canvasYears = (this.#manifestCanvasIds.get(manifestId) ?? [])
-          .map((canvasId) => {
-            const canvas = this.getParsedCanvas(manifestId, canvasId)
-            return findYearInCanvas(canvas)
-          })
-          .filter((year) => year !== undefined)
+  // #manifestCanvasIds = $derived.by(() => {
+  //   const canvasIdsByManifestId = new SvelteMap<string, string[]>()
 
-        return {
-          manifest: findYearInManifest(manifest),
-          canvas: canvasYears[0]
-        }
-      })
-      .filter(({ manifest, canvas }) => manifest || canvas)
+  //   for (const item of this.#manifestItems) {
+  //     if (item.parent?.type !== 'Canvas') {
+  //       continue
+  //     }
 
-    if (years.length > 0) {
-      const year = years[0]
+  //     const canvasIds = canvasIdsByManifestId.get(item.id) ?? []
 
-      if (year.canvas) {
-        return year.canvas
-      } else {
-        return year.manifest
-      }
-    }
-  })
+  //     if (!canvasIds.includes(item.parent.id)) {
+  //       canvasIdsByManifestId.set(item.id, [...canvasIds, item.parent.id])
+  //     }
+  //   }
+
+  //   return canvasIdsByManifestId
+  // })
+
+  // #year = $derived.by(() => {
+  //   const years = [...this.#parsedManifests.entries()]
+  //     .map(([manifestId, manifest]) => {
+  //       const canvasYears = (this.#manifestCanvasIds.get(manifestId) ?? [])
+  //         .map((canvasId) => {
+  //           const canvas = this.getParsedCanvas(manifestId, canvasId)
+  //           return findYearInCanvas(canvas)
+  //         })
+  //         .filter((year) => year !== undefined)
+
+  //       return {
+  //         manifest: findYearInManifest(manifest),
+  //         canvas: canvasYears[0]
+  //       }
+  //     })
+  //     .filter(({ manifest, canvas }) => manifest || canvas)
+
+  //   if (years.length > 0) {
+  //     const year = years[0]
+
+  //     if (year.canvas) {
+  //       return year.canvas
+  //     } else {
+  //       return year.manifest
+  //     }
+  //   }
+  // })
 
   constructor(mapsState: MapsState) {
     this.#mapsState = mapsState
@@ -164,10 +174,6 @@ export class IiifState {
     }
   }
 
-  get parsedManifests() {
-    return [...this.#parsedManifests.values()]
-  }
-
   get manifestIds() {
     return this.#manifestIds
   }
@@ -176,10 +182,6 @@ export class IiifState {
     return [...this.#fetchedManifests.values()].some(
       (result) => result.state === 'fetching'
     )
-  }
-
-  get year() {
-    return this.#year
   }
 }
 

--- a/apps/viewer/src/lib/state/images.svelte.ts
+++ b/apps/viewer/src/lib/state/images.svelte.ts
@@ -1,20 +1,20 @@
 import { setContext, getContext } from 'svelte'
 import { SvelteSet, SvelteMap } from 'svelte/reactivity'
 
-import { ResourceFetchError, fetchImageBitmap } from '@allmaps/stdlib'
+import {
+  ResourceFetchError,
+  fetchImageBitmap,
+  fetchImageInfo
+} from '@allmaps/stdlib'
 
-import type { Image as IIIFImage } from '@allmaps/iiif-parser'
+import { Image, type Image as IIIFImage } from '@allmaps/iiif-parser'
 import type { ImageRequest } from '@allmaps/types'
 
 import type { MapsState } from '$lib/state/maps.svelte.js'
 
 const IMAGES_KEY = Symbol('images')
 
-export type ImageErrorKind =
-  | 'network-or-cors'
-  | 'http'
-  | 'parse'
-  | 'unknown'
+export type ImageErrorKind = 'network-or-cors' | 'http' | 'parse' | 'unknown'
 
 export type ImageErrorSource = 'info-json' | 'tile'
 
@@ -40,12 +40,24 @@ export type ImageTileError = BaseImageError & {
 
 export type ImageError = ImageInfoError | ImageTileError
 
+export type ImageThumbnailError = Omit<BaseImageError, 'source'> & {
+  source: 'thumbnail'
+  thumbnailUrl?: string
+}
+
+export type ImageDisplayError = ImageError | ImageThumbnailError
+
 type ImageErrorOptions = {
   imageInfoUrl?: string
   tileUrl?: string
+  thumbnailUrl?: string
   kind?: string
   corsLikely?: boolean
   status?: number
+}
+
+function ensureError(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error))
 }
 
 function normalizeImageErrorKind(kind?: string): ImageErrorKind {
@@ -65,6 +77,9 @@ export class ImagesState {
     const imageIds = new SvelteSet<string>()
     this.#mapsState.maps.forEach((map) => {
       imageIds.add(map.resource.id)
+    })
+    this.#mapsState.invalidEmbeddedAnnotations.forEach((invalidAnnotation) => {
+      imageIds.add(invalidAnnotation.resource.id)
     })
 
     return imageIds
@@ -89,10 +104,13 @@ export class ImagesState {
   })
 
   #thumbnails = $state(new SvelteMap<string, ImageBitmap>())
+  #loadedImageIds = $state(new SvelteSet<string>())
   #imageInfoErrors = $state(new SvelteMap<string, ImageInfoError>())
   #imageTileErrors = $state(
     new SvelteMap<string, SvelteMap<string, ImageTileError>>()
   )
+  #thumbnailErrors = $state(new SvelteMap<string, ImageThumbnailError>())
+  #fetchingImageInfoIds = new Set<string>()
   #fetchingIds = new Set<string>()
 
   constructor(mapsState: MapsState, fetchingThumbnailsPaused = true) {
@@ -114,8 +132,32 @@ export class ImagesState {
         }
       }
 
+      for (const imageId of this.#loadedImageIds.keys()) {
+        if (!sourceImageIds.has(imageId)) {
+          this.#loadedImageIds.delete(imageId)
+        }
+      }
+
+      for (const imageId of this.#thumbnailErrors.keys()) {
+        if (!sourceImageIds.has(imageId)) {
+          this.#thumbnailErrors.delete(imageId)
+        }
+      }
+
       if (this.#fetchingThumbnailsPaused) {
         return
+      }
+
+      for (const imageId of sourceImageIds) {
+        if (
+          this.#parsedImages.has(imageId) ||
+          this.#imageInfoErrors.has(imageId) ||
+          this.#fetchingImageInfoIds.has(imageId)
+        ) {
+          continue
+        }
+
+        this.#fetchImageInfoFor(imageId)
       }
 
       const currentIds = new Set(this.#parsedImagesBySourceImageId.keys())
@@ -128,7 +170,11 @@ export class ImagesState {
       }
 
       for (const [imageId, parsedImage] of this.#parsedImagesBySourceImageId) {
-        if (this.#thumbnails.has(imageId) || this.#fetchingIds.has(imageId)) {
+        if (
+          this.#thumbnails.has(imageId) ||
+          this.#thumbnailErrors.has(imageId) ||
+          this.#fetchingIds.has(imageId)
+        ) {
           continue
         }
         this.#fetchThumbnailFor(imageId, parsedImage)
@@ -136,27 +182,60 @@ export class ImagesState {
     })
   }
 
+  async #fetchImageInfoFor(imageId: string) {
+    this.#fetchingImageInfoIds.add(imageId)
+    const imageInfoUrl = `${imageId}/info.json`
+
+    try {
+      const imageInfo = await fetchImageInfo(imageId)
+      const parsedImage = Image.parse(imageInfo)
+
+      if (this.#sourceImageIds.has(imageId)) {
+        this.addParsedImage(imageId, parsedImage)
+      }
+    } catch (error) {
+      const imageInfoError = ensureError(error)
+      this.addImageInfoError(imageId, imageInfoError, {
+        imageInfoUrl,
+        kind: error instanceof ResourceFetchError ? undefined : 'parse'
+      })
+      console.warn(
+        `Unable to fetch image information for image ${imageId}:`,
+        imageInfoError
+      )
+    } finally {
+      this.#fetchingImageInfoIds.delete(imageId)
+    }
+  }
+
   async #fetchThumbnailFor(imageId: string, parsedImage: IIIFImage) {
     this.#fetchingIds.add(imageId)
     const thumbnailSize = { width: 512, height: 512 }
+    let thumbnailUrl: string | undefined
     try {
       const imageRequest = parsedImage.getImageRequest(thumbnailSize)
 
       const bitmap = Array.isArray(imageRequest)
         ? await this.#fetchTiledThumbnail(parsedImage, imageRequest)
         : await fetchImageBitmap(
-            parsedImage.getImageUrl(imageRequest, {
+            (thumbnailUrl = parsedImage.getImageUrl(imageRequest, {
               preferredFormats: ['webp', 'jpg']
-            })
+            }))
           )
 
       if (this.#parsedImagesBySourceImageId.has(imageId)) {
+        this.#thumbnailErrors.delete(imageId)
         this.#thumbnails.set(imageId, bitmap)
       } else {
         bitmap.close()
       }
     } catch (error) {
-      console.warn(`Unable to fetch thumbnail for image ${imageId}:`, error)
+      const thumbnailError = ensureError(error)
+      this.addImageThumbnailError(imageId, thumbnailError, { thumbnailUrl })
+      console.warn(
+        `Unable to fetch thumbnail for image ${imageId}:`,
+        thumbnailError
+      )
     } finally {
       this.#fetchingIds.delete(imageId)
     }
@@ -208,10 +287,6 @@ export class ImagesState {
     return this.#thumbnails
   }
 
-  get imageInfoErrors() {
-    return this.#imageInfoErrors
-  }
-
   get imageTileErrors() {
     return this.#imageTileErrors
   }
@@ -220,11 +295,15 @@ export class ImagesState {
     const imageErrors = new Map<string, ImageError>()
 
     for (const [imageId, imageInfoError] of this.#imageInfoErrors) {
+      if (this.#loadedImageIds.has(imageId)) {
+        continue
+      }
+
       imageErrors.set(imageId, imageInfoError)
     }
 
     for (const [imageId, tileErrors] of this.#imageTileErrors) {
-      if (imageErrors.has(imageId)) {
+      if (imageErrors.has(imageId) || this.#loadedImageIds.has(imageId)) {
         continue
       }
 
@@ -256,12 +335,16 @@ export class ImagesState {
     )
   }
 
-  get someSourceImagesFailed() {
-    return this.imageErrorCount > 0
-  }
-
   getImageError(imageId: string) {
     return this.imageErrors.get(imageId)
+  }
+
+  getImageThumbnailError(imageId: string) {
+    return this.#thumbnailErrors.get(imageId)
+  }
+
+  getThumbnailDisplayError(imageId: string): ImageDisplayError | undefined {
+    return this.#thumbnailErrors.get(imageId) ?? this.getImageError(imageId)
   }
 
   getImageErrors(imageId: string) {
@@ -305,6 +388,7 @@ export class ImagesState {
 
       this.#parsedImages.set(imageId, parsedImage)
       this.#imageInfoErrors.delete(imageId)
+      this.#thumbnailErrors.delete(imageId)
       changed = true
     }
 
@@ -318,6 +402,10 @@ export class ImagesState {
     error: Error,
     options: ImageErrorOptions = {}
   ) {
+    if (this.#loadedImageIds.has(imageId)) {
+      return
+    }
+
     const resourceFetchError =
       error instanceof ResourceFetchError ? error : undefined
 
@@ -338,6 +426,10 @@ export class ImagesState {
     error: Error,
     options: ImageErrorOptions = {}
   ) {
+    if (this.#loadedImageIds.has(imageId)) {
+      return
+    }
+
     const tileUrl = options.tileUrl
     if (!tileUrl) {
       return
@@ -363,6 +455,36 @@ export class ImagesState {
     })
   }
 
+  markImageTileLoaded(imageId: string) {
+    if (!this.#sourceImageIds.has(imageId)) {
+      return
+    }
+
+    this.#loadedImageIds.add(imageId)
+    this.#imageInfoErrors.delete(imageId)
+    this.#imageTileErrors.delete(imageId)
+  }
+
+  addImageThumbnailError(
+    imageId: string,
+    error: Error,
+    options: ImageErrorOptions = {}
+  ) {
+    const resourceFetchError =
+      error instanceof ResourceFetchError ? error : undefined
+
+    this.#thumbnailErrors.set(imageId, {
+      imageId,
+      source: 'thumbnail',
+      thumbnailUrl: options.thumbnailUrl,
+      kind: normalizeImageErrorKind(options.kind ?? resourceFetchError?.kind),
+      corsLikely: options.corsLikely ?? resourceFetchError?.corsLikely ?? false,
+      status: options.status ?? resourceFetchError?.status,
+      message: error.message,
+      error
+    })
+  }
+
   pauseFetchingThumbnails() {
     this.#fetchingThumbnailsPaused = true
   }
@@ -376,10 +498,10 @@ export function setImagesState(
   mapsState: MapsState,
   fetchingThumbnailsPaused?: boolean
 ) {
-  return setContext(
-    IMAGES_KEY,
-    new ImagesState(mapsState, fetchingThumbnailsPaused)
-  )
+  const imagesState = new ImagesState(mapsState, fetchingThumbnailsPaused)
+  mapsState.setImagesState(imagesState)
+
+  return setContext(IMAGES_KEY, imagesState)
 }
 
 export function getImagesState() {

--- a/apps/viewer/src/lib/state/maps.svelte.ts
+++ b/apps/viewer/src/lib/state/maps.svelte.ts
@@ -1,17 +1,27 @@
 import { setContext, getContext } from 'svelte'
-import { SvelteSet } from 'svelte/reactivity'
+import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+import simplify from 'simplify-js'
 
 import { generateChecksum } from '@allmaps/id/sync'
+import { isClosed } from '@allmaps/stdlib'
 
+import { getCanonicalCanvas, getCanonicalManifest } from '$lib/shared/iiif.js'
 import { searchParams } from '$lib/shared/params.js'
 
 import type { GeoreferencedMap, PartOfItem } from '@allmaps/annotation'
+import type { Point, Ring } from '@allmaps/types'
+import type { BatchMapResult } from '@allmaps/render'
 
-import type { MapsHierarchy, Source } from '$lib/types/shared.js'
+import type {
+  InvalidGeoreferenceAnnotation,
+  MapsHierarchy,
+  Source
+} from '$lib/types/shared.js'
 
 import type { SourceState } from '$lib/state/source.svelte.js'
 import type { UrlState } from '$lib/state/url.svelte.js'
 import type { UiState } from '$lib/state/ui.svelte.js'
+import type { ImagesState } from '$lib/state/images.svelte.js'
 
 const MAPS_KEY = Symbol('maps')
 
@@ -22,12 +32,39 @@ export type ThumbnailRegion = {
   height: number
 }
 
+export type MapRenderError = {
+  error: Error
+  mapId?: string
+  message: string
+}
+
 export class MapsState {
   #sourceState: SourceState
   #urlState: UrlState<typeof searchParams>
   #uiState: UiState
+  #imagesState = $state<ImagesState>()
 
   #maps = $derived.by(() => this.#getMapsFromSource(this.#sourceState.source))
+  #mapRenderErrors = $state(new SvelteMap<string, MapRenderError>())
+  #mapRenderErrorsRevision = $state(0)
+  #thumbnailRegions = new WeakMap<
+    GeoreferencedMap,
+    ThumbnailRegion | undefined
+  >()
+  #thumbnailResourceMasks = new WeakMap<
+    GeoreferencedMap,
+    Map<string, Ring | undefined>
+  >()
+
+  #invalidEmbeddedAnnotations = $derived.by(() => {
+    const source = this.#sourceState.source
+
+    if (source?.parsed.type === 'iiif') {
+      return source.parsed.invalidEmbeddedAnnotations ?? []
+    }
+
+    return []
+  })
 
   #embeddedMapIds = $derived.by(() => {
     const embeddedMapIds = new SvelteSet<string>()
@@ -52,26 +89,25 @@ export class MapsState {
     return this.#maps.filter((map) => map.id && !hiddenMapIds.includes(map.id))
   })
 
-  #mapsHierarchy = $derived(this.#getMapsHierarchy(this.#maps))
+  #selectableMaps = $derived.by(() => {
+    const hiddenMapIds = this.#uiState.hiddenMapIds
 
-  #thumbnailRegions = $derived.by(() => {
-    const thumbnailRegions = new Map<string, ThumbnailRegion | undefined>()
+    // eslint-disable-next-line
+    this.#mapRenderErrorsRevision
 
-    for (const map of this.#maps) {
-      if (map.id) {
-        thumbnailRegions.set(map.id, this.#computeThumbnailRegion(map))
-      }
-    }
-
-    return thumbnailRegions
+    return this.#maps.filter((map) => this.#isMapSelectable(map, hiddenMapIds))
   })
 
+  #mapsHierarchy = $derived(
+    this.#getMapsHierarchy(this.#maps, this.#invalidEmbeddedAnnotations)
+  )
+
   #previousMapId = $derived.by(() => {
-    return this.#getSiblingVisibleMapId(-1)
+    return this.#getSiblingSelectableMapId(-1)
   })
 
   #nextMapId = $derived.by(() => {
-    return this.#getSiblingVisibleMapId(1)
+    return this.#getSiblingSelectableMapId(1)
   })
 
   constructor(
@@ -108,10 +144,18 @@ export class MapsState {
     return []
   }
 
-  #getMapsHierarchy(maps: GeoreferencedMap[]): MapsHierarchy {
+  // TODO: this function needs cleaning-up / simplifying!
+  #getMapsHierarchy(
+    maps: GeoreferencedMap[],
+    invalidAnnotations: InvalidGeoreferenceAnnotation[]
+  ): MapsHierarchy {
     type ByResource = Map<
       string,
-      { resource: GeoreferencedMap['resource']; maps: GeoreferencedMap[] }
+      {
+        resource: GeoreferencedMap['resource']
+        maps: GeoreferencedMap[]
+        invalidAnnotations: InvalidGeoreferenceAnnotation[]
+      }
     >
     type ByCanvas = Map<string, { canvas: PartOfItem; byResource: ByResource }>
 
@@ -128,48 +172,125 @@ export class MapsState {
     const addToResource = (byResource: ByResource, map: GeoreferencedMap) => {
       const id = map.resource.id
       if (!byResource.has(id)) {
-        byResource.set(id, { resource: map.resource, maps: [] })
+        byResource.set(id, {
+          resource: map.resource,
+          maps: [],
+          invalidAnnotations: []
+        })
       }
       byResource.get(id)!.maps.push(map)
     }
 
-    for (const map of maps) {
-      const canvasItems = (map.resource.partOf ?? []).filter(
-        (item) => item.type === 'Canvas'
-      )
+    const addInvalidToResource = (
+      byResource: ByResource,
+      invalidAnnotation: InvalidGeoreferenceAnnotation
+    ) => {
+      const id = invalidAnnotation.resource.id
+      if (!byResource.has(id)) {
+        byResource.set(id, {
+          resource: invalidAnnotation.resource,
+          maps: [],
+          invalidAnnotations: []
+        })
+      }
+      byResource.get(id)!.invalidAnnotations.push(invalidAnnotation)
+    }
 
-      if (canvasItems.length === 0) {
+    const findPartOfItem = (
+      partOfItems: PartOfItem[] | undefined,
+      type: PartOfItem['type']
+    ): PartOfItem | undefined => {
+      for (const partOfItem of partOfItems ?? []) {
+        if (partOfItem.type === type) {
+          return partOfItem
+        }
+
+        const nestedPartOfItem = findPartOfItem(partOfItem.partOf, type)
+
+        if (nestedPartOfItem) {
+          return nestedPartOfItem
+        }
+      }
+
+      return undefined
+    }
+
+    const getInvalidAnnotationCanvas = (
+      invalidAnnotation: InvalidGeoreferenceAnnotation
+    ) =>
+      invalidAnnotation.canvas ??
+      findPartOfItem(invalidAnnotation.resource.partOf, 'Canvas')
+
+    const getInvalidAnnotationManifest = (
+      invalidAnnotation: InvalidGeoreferenceAnnotation,
+      canvas?: PartOfItem
+    ) =>
+      invalidAnnotation.manifest ??
+      findPartOfItem(canvas?.partOf, 'Manifest') ??
+      findPartOfItem(invalidAnnotation.resource.partOf, 'Manifest')
+
+    for (const map of maps) {
+      const canvas = getCanonicalCanvas(map)
+
+      if (!canvas) {
         addToResource(byResourceOnly, map)
       } else {
-        for (const canvas of canvasItems) {
-          const manifestItems = (canvas.partOf ?? []).filter(
-            (item) => item.type === 'Manifest'
-          )
+        const manifest = getCanonicalManifest(map)
 
-          if (manifestItems.length === 0) {
-            if (!byCanvasOnly.has(canvas.id)) {
-              byCanvasOnly.set(canvas.id, { canvas, byResource: new Map() })
-            }
-            addToResource(byCanvasOnly.get(canvas.id)!.byResource, map)
-          } else {
-            for (const manifest of manifestItems) {
-              if (!byManifest.has(manifest.id)) {
-                byManifest.set(manifest.id, { manifest, byCanvas: new Map() })
-              }
-              const manifestEntry = byManifest.get(manifest.id)!
-
-              if (!manifestEntry.byCanvas.has(canvas.id)) {
-                manifestEntry.byCanvas.set(canvas.id, {
-                  canvas,
-                  byResource: new Map()
-                })
-              }
-              addToResource(
-                manifestEntry.byCanvas.get(canvas.id)!.byResource,
-                map
-              )
-            }
+        if (!manifest) {
+          if (!byCanvasOnly.has(canvas.id)) {
+            byCanvasOnly.set(canvas.id, { canvas, byResource: new Map() })
           }
+          addToResource(byCanvasOnly.get(canvas.id)!.byResource, map)
+        } else {
+          if (!byManifest.has(manifest.id)) {
+            byManifest.set(manifest.id, { manifest, byCanvas: new Map() })
+          }
+          const manifestEntry = byManifest.get(manifest.id)!
+
+          if (!manifestEntry.byCanvas.has(canvas.id)) {
+            manifestEntry.byCanvas.set(canvas.id, {
+              canvas,
+              byResource: new Map()
+            })
+          }
+          addToResource(manifestEntry.byCanvas.get(canvas.id)!.byResource, map)
+        }
+      }
+    }
+
+    for (const invalidAnnotation of invalidAnnotations) {
+      const canvas = getInvalidAnnotationCanvas(invalidAnnotation)
+
+      if (!canvas) {
+        addInvalidToResource(byResourceOnly, invalidAnnotation)
+      } else {
+        const manifest = getInvalidAnnotationManifest(invalidAnnotation, canvas)
+
+        if (!manifest) {
+          if (!byCanvasOnly.has(canvas.id)) {
+            byCanvasOnly.set(canvas.id, { canvas, byResource: new Map() })
+          }
+          addInvalidToResource(
+            byCanvasOnly.get(canvas.id)!.byResource,
+            invalidAnnotation
+          )
+        } else {
+          if (!byManifest.has(manifest.id)) {
+            byManifest.set(manifest.id, { manifest, byCanvas: new Map() })
+          }
+          const manifestEntry = byManifest.get(manifest.id)!
+
+          if (!manifestEntry.byCanvas.has(canvas.id)) {
+            manifestEntry.byCanvas.set(canvas.id, {
+              canvas,
+              byResource: new Map()
+            })
+          }
+          addInvalidToResource(
+            manifestEntry.byCanvas.get(canvas.id)!.byResource,
+            invalidAnnotation
+          )
         }
       }
     }
@@ -206,25 +327,25 @@ export class MapsState {
     return result
   }
 
-  #getSiblingVisibleMapId(direction: -1 | 1) {
+  #getSiblingSelectableMapId(direction: -1 | 1) {
     const currentMapId = this.#urlState.params.mapId
 
-    if (this.#visibleMaps.length === 0) {
+    if (this.#selectableMaps.length === 0) {
       return undefined
     }
 
     if (!currentMapId) {
-      return this.#visibleMaps[0].id
+      return this.#selectableMaps[0].id
     }
 
-    const currentVisibleIndex = this.#visibleMaps.findIndex(
+    const currentVisibleIndex = this.#selectableMaps.findIndex(
       (map) => map.id === currentMapId
     )
 
     if (currentVisibleIndex !== -1) {
-      return this.#visibleMaps[
-        (currentVisibleIndex + direction + this.#visibleMaps.length) %
-          this.#visibleMaps.length
+      return this.#selectableMaps[
+        (currentVisibleIndex + direction + this.#selectableMaps.length) %
+          this.#selectableMaps.length
       ].id
     }
 
@@ -233,7 +354,7 @@ export class MapsState {
     )
 
     if (currentSourceIndex === -1) {
-      return this.#visibleMaps[0].id
+      return this.#selectableMaps[0].id
     }
 
     for (let offset = 1; offset <= this.#maps.length; offset++) {
@@ -243,10 +364,29 @@ export class MapsState {
             this.#maps.length
         ]
 
-      if (map.id && !this.#uiState.isMapHidden(map.id)) {
+      if (this.#isMapSelectable(map)) {
         return map.id
       }
     }
+  }
+
+  #isMapSelectable(
+    map: GeoreferencedMap,
+    hiddenMapIds = this.#uiState.hiddenMapIds
+  ) {
+    if (!map.id || hiddenMapIds.includes(map.id)) {
+      return false
+    }
+
+    if (this.#mapRenderErrors.has(map.id)) {
+      return false
+    }
+
+    if (this.#imagesState?.getImageError(map.resource.id)) {
+      return false
+    }
+
+    return true
   }
 
   #getResourceMaskBbox(resourceMask: GeoreferencedMap['resourceMask']) {
@@ -313,12 +453,88 @@ export class MapsState {
     }
   }
 
+  #getThumbnailMaskTolerance(
+    map: GeoreferencedMap,
+    region: ThumbnailRegion | undefined,
+    renderSize: number
+  ) {
+    const sourceWidth = region?.width || map.resource.width
+    const sourceHeight = region?.height || map.resource.height
+
+    if (!sourceWidth || !sourceHeight || renderSize <= 0) {
+      return 0
+    }
+
+    return (Math.max(sourceWidth, sourceHeight) / renderSize) * 1.5
+  }
+
+  #getThumbnailMaskCacheKey(tolerance: number) {
+    return tolerance.toFixed(2)
+  }
+
+  #simplifyThumbnailResourceMask(
+    resourceMask: Ring,
+    tolerance: number
+  ): Ring | undefined {
+    const openResourceMask = isClosed(resourceMask)
+      ? resourceMask.slice(0, -1)
+      : resourceMask
+
+    if (openResourceMask.length < 3) {
+      return
+    }
+
+    if (openResourceMask.length <= 8 || tolerance <= 0) {
+      return openResourceMask
+    }
+
+    const points = openResourceMask.map(([x, y]) => ({ x, y }))
+    const simplifiedPoints = simplify(points, tolerance, false)
+
+    if (simplifiedPoints.length < 3) {
+      return openResourceMask
+    }
+
+    return simplifiedPoints.map(({ x, y }) => [x, y] as Point)
+  }
+
+  #setMapRenderError(error: Error, mapId?: string, key?: string) {
+    this.#mapRenderErrors.set(
+      key ?? mapId ?? `unknown:${this.#mapRenderErrors.size}`,
+      {
+        error,
+        mapId,
+        message: error.message
+      }
+    )
+    this.#mapRenderErrorsRevision += 1
+  }
+
+  #clearMapRenderErrors() {
+    if (this.#mapRenderErrors.size === 0) {
+      return
+    }
+
+    this.#mapRenderErrors.clear()
+    this.#mapRenderErrorsRevision += 1
+  }
+
   get maps() {
     return this.#maps
   }
 
-  get visibleMaps() {
-    return this.#visibleMaps
+  get invalidEmbeddedAnnotations() {
+    return this.#invalidEmbeddedAnnotations
+  }
+
+  get selectableMaps() {
+    return this.#selectableMaps
+  }
+
+  get mapRenderErrors() {
+    // eslint-disable-next-line
+    this.#mapRenderErrorsRevision
+    return [...this.#mapRenderErrors.values()]
   }
 
   get mapCount() {
@@ -327,6 +543,10 @@ export class MapsState {
 
   get visibleMapCount() {
     return this.#visibleMaps.length
+  }
+
+  get selectableMapCount() {
+    return this.#selectableMaps.length
   }
 
   canHideMap(mapId?: string) {
@@ -348,12 +568,86 @@ export class MapsState {
     return this.#mapsHierarchy
   }
 
+  isMapSelectable(mapId?: string) {
+    if (!mapId) {
+      return false
+    }
+
+    const map = this.#maps.find((map) => map.id === mapId)
+
+    return map ? this.#isMapSelectable(map) : false
+  }
+
+  setImagesState(imagesState: ImagesState) {
+    this.#imagesState = imagesState
+  }
+
   getThumbnailRegion(map: GeoreferencedMap) {
-    return map.id ? this.#thumbnailRegions.get(map.id) : undefined
+    if (!this.#thumbnailRegions.has(map)) {
+      this.#thumbnailRegions.set(map, this.#computeThumbnailRegion(map))
+    }
+
+    return this.#thumbnailRegions.get(map)
+  }
+
+  getThumbnailResourceMask(
+    map: GeoreferencedMap,
+    region: ThumbnailRegion | undefined,
+    renderSize: number
+  ) {
+    const tolerance = this.#getThumbnailMaskTolerance(map, region, renderSize)
+    const cacheKey = this.#getThumbnailMaskCacheKey(tolerance)
+    let thumbnailResourceMasks = this.#thumbnailResourceMasks.get(map)
+
+    if (!thumbnailResourceMasks) {
+      thumbnailResourceMasks = new Map()
+      this.#thumbnailResourceMasks.set(map, thumbnailResourceMasks)
+    }
+
+    if (!thumbnailResourceMasks.has(cacheKey)) {
+      thumbnailResourceMasks.set(
+        cacheKey,
+        this.#simplifyThumbnailResourceMask(map.resourceMask, tolerance)
+      )
+    }
+
+    return thumbnailResourceMasks.get(cacheKey)
+  }
+
+  getMapRenderError(mapId?: string) {
+    // eslint-disable-next-line
+    this.#mapRenderErrorsRevision
+    if (!mapId) {
+      return
+    }
+
+    return this.#mapRenderErrors.get(mapId)
   }
 
   isEmbeddedMap(mapId?: string) {
     return !!mapId && this.#embeddedMapIds.has(mapId)
+  }
+
+  addMapRenderError(error: Error, mapId?: string) {
+    this.#setMapRenderError(error, mapId)
+  }
+
+  clearMapRenderErrors() {
+    this.#clearMapRenderErrors()
+  }
+
+  setMapRenderResults(results: BatchMapResult[]) {
+    this.#clearMapRenderErrors()
+
+    for (const result of results) {
+      if (result.ok) {
+        continue
+      }
+
+      const mapId = result.mapId ?? this.#maps[result.index]?.id
+      const key = mapId ?? String(result.index)
+      this.#setMapRenderError(result.error, mapId, key)
+    }
   }
 }
 

--- a/apps/viewer/src/lib/state/ui.svelte.ts
+++ b/apps/viewer/src/lib/state/ui.svelte.ts
@@ -5,7 +5,7 @@ import { UiEvents, UiEventTarget } from '$lib/shared/ui-events.js'
 const UI_KEY = Symbol('ui')
 
 type View = 'map' | 'image'
-type Modal = 'about'
+type Modal = 'about' | 'attribution' | 'keyboard'
 type ModalOpen = Modal | undefined
 
 export class UiState extends UiEventTarget {
@@ -126,10 +126,7 @@ export class UiState extends UiEventTarget {
   }
 
   toggleMetadataSectionCollapsed(key: string) {
-    this.setMetadataSectionCollapsed(
-      key,
-      !this.isMetadataSectionCollapsed(key)
-    )
+    this.setMetadataSectionCollapsed(key, !this.isMetadataSectionCollapsed(key))
   }
 
   get opacity() {

--- a/apps/viewer/src/lib/state/url.svelte.ts
+++ b/apps/viewer/src/lib/state/url.svelte.ts
@@ -361,6 +361,44 @@ export class UrlState<T extends SearchParams> {
 
     return `${url}${search}${newHash}`
   }
+
+  generateUrlsForParam<K extends keyof T>(
+    url: string,
+    key: K,
+    values: Array<InferParamType<T[K]> | undefined>
+  ): Map<InferParamType<T[K]> | undefined, string> {
+    const paramConfig = this.#searchParams[key] as SearchParam<any>
+    const baseSearchParams = new URLSearchParams(this.#url.searchParams)
+    const baseHashParams = this.#getHashParams()
+    const urls = new Map<InferParamType<T[K]> | undefined, string>()
+
+    for (const value of values) {
+      const stringValue = this.#stringifyParam(value as any, key)
+      const searchParams = new URLSearchParams(baseSearchParams)
+      const hashParams = new URLSearchParams(baseHashParams)
+
+      if (paramConfig.hash) {
+        if (stringValue !== undefined && stringValue !== null) {
+          hashParams.set(paramConfig.key, stringValue)
+        } else {
+          hashParams.delete(paramConfig.key)
+        }
+      } else if (stringValue !== undefined && stringValue !== null) {
+        searchParams.set(paramConfig.key, stringValue)
+      } else {
+        searchParams.delete(paramConfig.key)
+      }
+
+      const searchString = searchParams.toString()
+      const search = searchString ? `?${searchString}` : ''
+      const hashString = hashParams.toString()
+      const hash = hashString ? `#${hashString}` : ''
+
+      urls.set(value, `${url}${search}${hash}`)
+    }
+
+    return urls
+  }
 }
 
 export function setUrlState<T extends SearchParams>(url: URL, params: T) {

--- a/packages/components/src/lib/components/Thumbnail.svelte
+++ b/packages/components/src/lib/components/Thumbnail.svelte
@@ -2,6 +2,7 @@
   import { Image, type ImageRequest } from '@allmaps/iiif-parser'
   import { pink } from '@allmaps/tailwind'
 
+  import type { Snippet } from 'svelte'
   import type { Fit, Ring } from '@allmaps/types'
 
   type ThumbnailResourceMask = {
@@ -28,6 +29,26 @@
     height: number
   }
 
+  type ThumbnailError =
+    | string
+    | Error
+    | {
+        title?: string
+        message?: string
+      }
+
+  type ThumbnailLoadError = {
+    url: string
+    message: string
+  }
+
+  type ThumbnailErrorSnippetContext = {
+    title: string
+    message: string
+    error?: ThumbnailError
+    loadError?: ThumbnailLoadError
+  }
+
   type Props = {
     imageInfo?: unknown
     imageBitmap?: ImageBitmap
@@ -37,9 +58,13 @@
     sourceHeight?: number
     region?: ThumbnailRegion
     mode?: Fit
+    padding?: number
     borderColor?: string
     resourceMasks?: (Ring | ThumbnailResourceMask)[]
     alt?: string
+    error?: ThumbnailError
+    errorSnippet?: Snippet<[ThumbnailErrorSnippetContext]>
+    onImageError?: (error: ThumbnailLoadError) => void
   }
 
   let {
@@ -51,12 +76,17 @@
     sourceHeight: sourceHeightProp,
     region,
     mode = 'cover',
+    padding = 0,
     borderColor,
     resourceMasks = [],
-    alt
+    alt,
+    error,
+    errorSnippet,
+    onImageError
   }: Props = $props()
 
   let canvas = $state<HTMLCanvasElement>()
+  let loadError = $state<ThumbnailLoadError>()
 
   function getSourceWidth() {
     return sourceWidthProp || imageBitmap?.width || parsedImage?.width || 0
@@ -114,12 +144,35 @@
     return { left: 0, top: 0, width: renderWidth, height: renderHeight }
   }
 
-  function getBoxStyle(box: ImageBox) {
+  function getContentBox(
+    renderWidth: number,
+    renderHeight: number,
+    padding: number
+  ): ImageBox {
+    const maxPadding = Math.max(
+      0,
+      (Math.min(renderWidth, renderHeight) - 1) / 2
+    )
+    const contentPadding = Math.min(Math.max(padding, 0), maxPadding)
+
+    return {
+      left: contentPadding,
+      top: contentPadding,
+      width: renderWidth - contentPadding * 2,
+      height: renderHeight - contentPadding * 2
+    }
+  }
+
+  function getBoxStyle(
+    box: ImageBox,
+    containingWidth: number,
+    containingHeight: number
+  ) {
     return [
-      `left: ${(box.left / renderWidth) * 100}%`,
-      `top: ${(box.top / renderHeight) * 100}%`,
-      `width: ${(box.width / renderWidth) * 100}%`,
-      `height: ${(box.height / renderHeight) * 100}%`
+      `left: ${(box.left / containingWidth) * 100}%`,
+      `top: ${(box.top / containingHeight) * 100}%`,
+      `width: ${(box.width / containingWidth) * 100}%`,
+      `height: ${(box.height / containingHeight) * 100}%`
     ].join('; ')
   }
 
@@ -203,6 +256,36 @@
     )
   }
 
+  function getThumbnailErrorTitle(error?: ThumbnailError) {
+    if (error && typeof error === 'object' && !(error instanceof Error)) {
+      return error.title
+    }
+  }
+
+  function getThumbnailErrorMessage(error?: ThumbnailError) {
+    if (!error) {
+      return
+    }
+
+    if (typeof error === 'string') {
+      return error
+    }
+
+    if (error instanceof Error) {
+      return error.message
+    }
+
+    return error.message
+  }
+
+  function handleImageError(url: string) {
+    loadError = {
+      url,
+      message: 'The thumbnail image request failed.'
+    }
+    onImageError?.(loadError)
+  }
+
   let parsedImage = $derived(imageInfo ? Image.parse(imageInfo) : undefined)
   let sourceWidth = $derived(getSourceWidth())
   let sourceHeight = $derived(getSourceHeight())
@@ -210,18 +293,19 @@
   let displaySourceHeight = $derived(getDisplaySourceHeight())
   let renderWidth = $derived(getRenderWidth())
   let renderHeight = $derived(getRenderHeight())
+  let contentBox = $derived(getContentBox(renderWidth, renderHeight, padding))
   let imageBox = $derived(
     getImageBox(
       displaySourceWidth,
       displaySourceHeight,
-      renderWidth,
-      renderHeight,
+      contentBox.width,
+      contentBox.height,
       mode
     )
   )
   let borderBox = $derived(
     mode === 'cover'
-      ? { left: 0, top: 0, width: renderWidth, height: renderHeight }
+      ? { left: 0, top: 0, width: contentBox.width, height: contentBox.height }
       : imageBox
   )
   let imageRequest = $derived(
@@ -235,12 +319,16 @@
         }
       : parsedImage &&
           parsedImage.getImageRequest(
-            { width: renderWidth, height: renderHeight },
+            { width: contentBox.width, height: contentBox.height },
             mode
           )
   )
   let normalizedResourceMasks = $derived(
     resourceMasks.map(normalizeResourceMask)
+  )
+  let errorTitle = $derived(getThumbnailErrorTitle(error))
+  let errorMessage = $derived(
+    getThumbnailErrorMessage(error) ?? loadError?.message
   )
 
   $effect(() => {
@@ -284,6 +372,16 @@
       context.drawImage(imageBitmap, 0, 0)
     }
   })
+
+  $effect(() => {
+    // eslint-disable-next-line
+    imageBitmap
+    // eslint-disable-next-line
+    imageInfo
+    // eslint-disable-next-line
+    imageRequest
+    loadError = undefined
+  })
 </script>
 
 <div
@@ -291,69 +389,127 @@
   style="--border-color: {borderColor}"
   class="relative flex w-full overflow-hidden"
 >
-  <div class="absolute" style={getBoxStyle(imageBox)}>
-    {#if imageBitmap}
-      <canvas bind:this={canvas} class="h-full w-full"></canvas>
-    {:else if parsedImage && imageRequest && !Array.isArray(imageRequest)}
-      <img
-        class="h-full w-full"
-        alt={alt || `Thumbnail for ${parsedImage.uri}`}
-        src={parsedImage.getImageUrl(imageRequest)}
-      />
-    {:else if parsedImage && imageRequest && Array.isArray(imageRequest)}
-      {@const columnPercentages = getColumnPercentages(imageRequest)}
-      {@const rowPercentages = getRowPercentages(imageRequest)}
-
+  {#if errorMessage}
+    {@const title = errorTitle || 'Could not load thumbnail'}
+    {#if errorSnippet}
+      {@render errorSnippet({
+        title,
+        message: errorMessage,
+        error,
+        loadError
+      })}
+    {:else}
       <div
-        class="grid h-full w-full"
-        style:grid-template-columns={columnPercentages
-          .map((percentage) => `${percentage}%`)
-          .join(' ')}
-        style:grid-template-rows={rowPercentages
-          .map((percentage) => `${percentage}%`)
-          .join(' ')}
+        class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-red/20 p-3 text-center text-red"
+        role="status"
+        aria-label={title}
       >
-        {#each imageRequest as row, rowIndex (rowIndex)}
-          {#each row as tile, columnIndex (columnIndex)}
-            <img
-              class="h-full w-full"
-              src={parsedImage.getImageUrl(tile)}
-              alt={alt ||
-                `Thumbnail for ${parsedImage.uri} (${rowIndex}, ${columnIndex})`}
-            />
-          {/each}
-        {/each}
+        <p class="max-w-full text-sm font-medium leading-tight">{title}</p>
+        {#if errorMessage !== title}
+          <p class="max-w-full text-xs leading-snug">
+            {errorMessage}
+          </p>
+        {/if}
+        <!-- {#if loadError?.url && !error}
+          <p
+            class="max-w-full truncate font-mono text-[0.65rem] leading-tight text-gray-400"
+            title={loadError.url}
+          >
+            {loadError.url}
+          </p>
+        {/if} -->
       </div>
     {/if}
-  </div>
+  {:else}
+    <div
+      class="absolute"
+      style={getBoxStyle(contentBox, renderWidth, renderHeight)}
+    >
+      <div class="absolute inset-0 overflow-hidden">
+        <div
+          class="absolute"
+          style={getBoxStyle(imageBox, contentBox.width, contentBox.height)}
+        >
+          {#if imageBitmap}
+            <canvas bind:this={canvas} class="h-full w-full"></canvas>
+          {:else if parsedImage && imageRequest && !Array.isArray(imageRequest)}
+            {@const imageUrl = parsedImage.getImageUrl(imageRequest)}
+            <img
+              class="h-full w-full"
+              alt={alt || `Thumbnail for ${parsedImage.uri}`}
+              src={imageUrl}
+              onerror={() => handleImageError(imageUrl)}
+            />
+          {:else if parsedImage && imageRequest && Array.isArray(imageRequest)}
+            {@const columnPercentages = getColumnPercentages(imageRequest)}
+            {@const rowPercentages = getRowPercentages(imageRequest)}
 
-  {#if displaySourceWidth && displaySourceHeight && normalizedResourceMasks.length}
-    <div class="pointer-events-none absolute" style={getBoxStyle(imageBox)}>
-      <svg
-        class="h-full w-full"
-        viewBox="0 0 {displaySourceWidth} {displaySourceHeight}"
-        preserveAspectRatio="none"
-        aria-hidden="true"
-      >
-        {#each normalizedResourceMasks as mask, index (index)}
-          <polygon
-            class="transition-all"
-            points={getMaskPoints(mask.resourceMask)}
-            fill={getMaskFill(mask)}
-            fill-opacity={getMaskFillOpacity(mask)}
-            stroke={getMaskStroke(mask)}
-            stroke-opacity={getMaskStrokeOpacity(mask)}
-            stroke-width={getMaskStrokeWidth(mask)}
-          />
-        {/each}
-      </svg>
+            <div
+              class="grid h-full w-full"
+              style:grid-template-columns={columnPercentages
+                .map((percentage) => `${percentage}%`)
+                .join(' ')}
+              style:grid-template-rows={rowPercentages
+                .map((percentage) => `${percentage}%`)
+                .join(' ')}
+            >
+              {#each imageRequest as row, rowIndex (rowIndex)}
+                {#each row as tile, columnIndex (columnIndex)}
+                  {@const tileUrl = parsedImage.getImageUrl(tile)}
+                  <img
+                    class="h-full w-full"
+                    src={tileUrl}
+                    alt={alt ||
+                      `Thumbnail for ${parsedImage.uri} (${rowIndex}, ${columnIndex})`}
+                    onerror={() => handleImageError(tileUrl)}
+                  />
+                {/each}
+              {/each}
+            </div>
+          {/if}
+        </div>
+
+        {#if displaySourceWidth && displaySourceHeight && normalizedResourceMasks.length}
+          <div
+            class="pointer-events-none absolute"
+            style={getBoxStyle(imageBox, contentBox.width, contentBox.height)}
+          >
+            <svg
+              class="h-full w-full"
+              viewBox="0 0 {displaySourceWidth} {displaySourceHeight}"
+              preserveAspectRatio="none"
+              aria-hidden="true"
+            >
+              {#each normalizedResourceMasks as mask, index (index)}
+                <polygon
+                  class="transition-all"
+                  points={getMaskPoints(mask.resourceMask)}
+                  fill={getMaskFill(mask)}
+                  fill-opacity={getMaskFillOpacity(mask)}
+                  stroke={getMaskStroke(mask)}
+                  stroke-opacity={getMaskStrokeOpacity(mask)}
+                  stroke-width={getMaskStrokeWidth(mask)}
+                />
+              {/each}
+            </svg>
+          </div>
+        {/if}
+      </div>
+
+      {#if borderColor}
+        <div
+          class="pointer-events-none absolute outline-4 outline-(--border-color)"
+          style={getBoxStyle(borderBox, contentBox.width, contentBox.height)}
+          aria-hidden="true"
+        ></div>
+      {/if}
     </div>
   {/if}
 
-  {#if borderColor}
+  {#if errorMessage && borderColor}
     <div
       class="pointer-events-none absolute outline-4 outline-(--border-color)"
-      style={getBoxStyle(borderBox)}
+      style={getBoxStyle(contentBox, renderWidth, renderHeight)}
       aria-hidden="true"
     ></div>
   {/if}


### PR DESCRIPTION
## Summary

Tracks viewer image/render failure state across the IIIF, map, URL, UI, and thumbnail paths.

## Stack

This is PR 2 of 4 in the `new-viewer` stack. Base: `viewer-source-load-errors`.

Depends on #572.

## Validation

Not run; this PR was created from the staged GitButler split only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer thumbnail handling, including custom error messaging and fallback display when an image fails to load.
  * Expanded viewer controls with additional modal options and improved URL generation for sharing/filtering states.
  * Improved map and manifest selection so the viewer can better choose the most relevant content.

* **Bug Fixes**
  * Improved handling of missing or invalid image, map, and IIIF data.
  * Reduced incorrect counts and labels in map/source summaries.
  * Better filtering of selectable maps and clearer error reporting for failed loads and rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->