### PR TITLE
Add viewer attribution rich text helpers

### DIFF
--- a/apps/viewer/src/lib/shared/attribution.ts
+++ b/apps/viewer/src/lib/shared/attribution.ts
@@ -1,0 +1,223 @@
+import { parseLanguageString } from '@allmaps/iiif-inspector'
+
+import {
+  isSafeHref,
+  parseRichTextValue,
+  type RichTextPart
+} from '$lib/shared/html.js'
+import { getCanonicalCanvas, getCanonicalManifest } from '$lib/shared/iiif.js'
+
+import type { GeoreferencedMap } from '@allmaps/annotation'
+import type { Manifest as IIIFManifest } from '@allmaps/iiif-parser'
+
+export type AttributionPart = RichTextPart
+
+export type GeoreferencedMapAttributionRow = {
+  key: string
+  label: string
+  organization?: AttributionPart[]
+  attribution?: AttributionPart[]
+}
+
+export type GeoreferencedMapAttributionGroup = {
+  key: string
+  label: string
+  rows: GeoreferencedMapAttributionRow[]
+}
+
+function parseAttributionValue(value: string) {
+  return parseRichTextValue(value, { decodeText: true })
+}
+
+function parseLabel(label?: Parameters<typeof parseLanguageString>[0]) {
+  return parseLanguageString(label, 'en').trim()
+}
+
+function getKnownLabel(label?: Parameters<typeof parseLanguageString>[0]) {
+  const parsedLabel = parseLabel(label)
+
+  return parsedLabel && parsedLabel !== '-' ? parsedLabel : undefined
+}
+
+function getManifestAttribution(manifest?: IIIFManifest) {
+  const attribution = parseLabel(manifest?.requiredStatement?.value)
+
+  return attribution ? parseAttributionValue(attribution) : undefined
+}
+
+function getOrganizationAttribution(map: GeoreferencedMap) {
+  const provider = map.resource.provider?.[0]
+  const label = parseLabel(provider?.label)
+
+  const homepage = provider?.homepage?.[0]?.id
+
+  if (label) {
+    return [
+      homepage && isSafeHref(homepage)
+        ? {
+            type: 'link' as const,
+            label,
+            href: homepage
+          }
+        : {
+            type: 'text' as const,
+            value: label
+          }
+    ]
+  }
+
+  try {
+    const url = new URL(map.resource.id)
+
+    return [
+      {
+        type: 'link' as const,
+        label: url.hostname,
+        href: url.origin
+      }
+    ]
+  } catch {
+    return
+  }
+}
+
+function getUnknownAttribution() {
+  return [
+    {
+      type: 'text' as const,
+      value: 'Unknown'
+    }
+  ]
+}
+
+function getPartsKey(parts: AttributionPart[] | undefined) {
+  if (!parts) {
+    return ''
+  }
+
+  return parts
+    .map((part) => {
+      if (part.type === 'link') {
+        return `${part.type}:${part.href}:${part.label}`
+      }
+
+      if (part.type === 'text') {
+        return `${part.type}:${part.value}`
+      }
+
+      return part.type
+    })
+    .join('|')
+}
+
+function getImageLabel(index: number) {
+  return `Map ${index + 1}`
+}
+
+function getCanvasLabel(map: GeoreferencedMap) {
+  const canvas = getCanonicalCanvas(map)
+
+  if (canvas) {
+    return getKnownLabel(canvas.label) ?? canvas.id
+  }
+}
+
+function getManifestLabel(map: GeoreferencedMap) {
+  const manifest = getCanonicalManifest(map)
+
+  if (manifest) {
+    return getKnownLabel(manifest.label) ?? manifest.id
+  }
+}
+
+function getAttributionScope(map: GeoreferencedMap, index: number) {
+  const manifest = getCanonicalManifest(map)
+
+  if (manifest) {
+    return {
+      key: `manifest:${manifest.id}`,
+      label: getManifestLabel(map) ?? manifest.id,
+      manifest
+    }
+  }
+
+  const canvas = getCanonicalCanvas(map)
+
+  if (canvas) {
+    return {
+      key: `canvas:${canvas.id}`,
+      label: getCanvasLabel(map) ?? canvas.id
+    }
+  }
+
+  return {
+    key: `image:${map.resource.id}`,
+    label: getImageLabel(index)
+  }
+}
+
+function getAttributionForScope(
+  scope: ReturnType<typeof getAttributionScope>,
+  getParsedManifest: (manifestId: string) => IIIFManifest | undefined,
+  isManifestLoading: (manifestId: string) => boolean
+) {
+  const manifestId = scope.manifest?.id
+
+  if (manifestId) {
+    const manifest = getParsedManifest(manifestId)
+    const manifestAttribution = getManifestAttribution(manifest)
+
+    if (manifestAttribution || isManifestLoading(manifestId)) {
+      return manifestAttribution
+    }
+  }
+
+  return getUnknownAttribution()
+}
+
+export function getGeoreferencedMapAttributionGroups(
+  maps: GeoreferencedMap[],
+  getParsedManifest: (manifestId: string) => IIIFManifest | undefined,
+  isManifestLoading: (manifestId: string) => boolean
+) {
+  const groups = new Map<string, GeoreferencedMapAttributionGroup>()
+
+  maps.forEach((map, index) => {
+    const scope = getAttributionScope(map, index)
+
+    if (groups.has(scope.key)) {
+      return
+    }
+
+    const organization = getOrganizationAttribution(map)
+    const attribution = getAttributionForScope(
+      scope,
+      getParsedManifest,
+      isManifestLoading
+    )
+
+    if (!organization && !attribution) {
+      return
+    }
+
+    groups.set(scope.key, {
+      key: scope.key,
+      label: scope.label,
+      rows: [
+        {
+          key: [
+            scope.key,
+            scope.label,
+            getPartsKey(organization),
+            getPartsKey(attribution)
+          ].join(':'),
+          label: scope.label,
+          organization,
+          attribution
+        }
+      ]
+    })
+  })
+
+  return [...groups.values()]
+}

--- a/apps/viewer/src/lib/shared/html.ts
+++ b/apps/viewer/src/lib/shared/html.ts
@@ -1,0 +1,174 @@
+export type RichTextPart =
+  | {
+      type: 'text'
+      value: string
+    }
+  | {
+      type: 'link'
+      href: string
+      label: string
+    }
+  | {
+      type: 'break'
+    }
+
+type ParseRichTextOptions = {
+  decodeText?: boolean
+}
+
+export function decodeHtmlEntities(value: string) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+}
+
+export function isSafeHref(href: string) {
+  try {
+    const url = new URL(href)
+    return ['http:', 'https:', 'mailto:'].includes(url.protocol)
+  } catch {
+    return false
+  }
+}
+
+export function parseSafeHref(value: string) {
+  const trimmedValue = value.trim()
+
+  return isSafeHref(trimmedValue) ? trimmedValue : undefined
+}
+
+export function parseSafeHtmlParts(value: string): RichTextPart[] | undefined {
+  const trimmedValue = value.trim()
+
+  if (!/<[^>]+>/.test(trimmedValue)) {
+    return
+  }
+
+  const parts: RichTextPart[] = []
+  const tagPattern = /<[^>]+>/g
+  let lastIndex = 0
+  let spanDepth = 0
+  let activeLink:
+    | {
+        href: string
+        label: string
+      }
+    | undefined
+
+  const appendText = (text: string) => {
+    if (!text) {
+      return
+    }
+
+    const decodedText = decodeHtmlEntities(text)
+
+    if (activeLink) {
+      activeLink.label += decodedText
+    } else if (decodedText) {
+      parts.push({
+        type: 'text',
+        value: decodedText
+      })
+    }
+  }
+
+  for (const match of trimmedValue.matchAll(tagPattern)) {
+    appendText(trimmedValue.slice(lastIndex, match.index))
+
+    const tag = match[0].slice(1, -1).trim()
+
+    if (/^span$/i.test(tag)) {
+      spanDepth += 1
+    } else if (/^\/span$/i.test(tag)) {
+      if (spanDepth === 0 || activeLink) {
+        return
+      }
+
+      spanDepth -= 1
+    } else if (/^br\s*\/?$/i.test(tag)) {
+      if (activeLink) {
+        return
+      }
+
+      parts.push({ type: 'break' })
+    } else if (/^a(?:\s|$)/i.test(tag)) {
+      if (activeLink) {
+        return
+      }
+
+      const hrefMatch = tag.match(
+        /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i
+      )
+      const href = hrefMatch?.[1] ?? hrefMatch?.[2] ?? hrefMatch?.[3]
+
+      if (!href || !isSafeHref(href)) {
+        return
+      }
+
+      activeLink = {
+        href,
+        label: ''
+      }
+    } else if (/^\/a$/i.test(tag)) {
+      if (!activeLink) {
+        return
+      }
+
+      parts.push({
+        type: 'link',
+        href: activeLink.href,
+        label: activeLink.label.trim() || activeLink.href
+      })
+      activeLink = undefined
+    } else {
+      return
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  appendText(trimmedValue.slice(lastIndex))
+
+  if (spanDepth !== 0 || activeLink) {
+    return
+  }
+
+  return parts.length > 0 ? parts : undefined
+}
+
+function parsePlainRichTextParts(
+  value: string,
+  options: ParseRichTextOptions = {}
+): RichTextPart[] {
+  const trimmedValue = value.trim()
+  const href = parseSafeHref(trimmedValue)
+
+  if (href) {
+    return [
+      {
+        type: 'link',
+        href,
+        label: href
+      }
+    ]
+  }
+
+  return [
+    {
+      type: 'text',
+      value: options.decodeText
+        ? decodeHtmlEntities(trimmedValue)
+        : trimmedValue
+    }
+  ]
+}
+
+export function parseRichTextValue(
+  value: string,
+  options: ParseRichTextOptions = {}
+) {
+  return parseSafeHtmlParts(value) ?? parsePlainRichTextParts(value, options)
+}

--- a/apps/viewer/test/html.test.ts
+++ b/apps/viewer/test/html.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  decodeHtmlEntities,
+  isSafeHref,
+  parseRichTextValue,
+  parseSafeHref,
+  parseSafeHtmlParts
+} from '../src/lib/shared/html.js'
+
+describe('viewer safe rich text parsing', () => {
+  test('decodes the HTML entities used in IIIF metadata values', () => {
+    expect(decodeHtmlEntities('&lt;a&gt;AT&amp;T &quot;Maps&quot;&#39;s')).toBe(
+      '<a>AT&T "Maps"\'s'
+    )
+  })
+
+  test('only allows absolute http, https, and mailto hrefs', () => {
+    expect(isSafeHref('https://example.org/maps')).toBe(true)
+    expect(isSafeHref('http://example.org/maps')).toBe(true)
+    expect(isSafeHref('mailto:maps@example.org')).toBe(true)
+    expect(isSafeHref('/relative/path')).toBe(false)
+    expect(isSafeHref('javascript:alert(1)')).toBe(false)
+  })
+
+  test('parses safe anchor, span, and break markup into rich text parts', () => {
+    expect(
+      parseSafeHtmlParts(
+        'Provided by <span><a href="https://example.org">Example &amp; Co</a></span><br />Archive'
+      )
+    ).toEqual([
+      {
+        type: 'text',
+        value: 'Provided by '
+      },
+      {
+        type: 'link',
+        href: 'https://example.org',
+        label: 'Example & Co'
+      },
+      {
+        type: 'break'
+      },
+      {
+        type: 'text',
+        value: 'Archive'
+      }
+    ])
+  })
+
+  test('supports single-quoted and unquoted anchor hrefs', () => {
+    expect(
+      parseSafeHtmlParts("<a href='https://example.org'>Example</a>")
+    ).toEqual([
+      {
+        type: 'link',
+        href: 'https://example.org',
+        label: 'Example'
+      }
+    ])
+
+    expect(
+      parseSafeHtmlParts('<a href=https://example.org>Example</a>')
+    ).toEqual([
+      {
+        type: 'link',
+        href: 'https://example.org',
+        label: 'Example'
+      }
+    ])
+  })
+
+  test('rejects unsupported or unsafe markup', () => {
+    expect(parseSafeHtmlParts('<strong>Example</strong>')).toBeUndefined()
+    expect(
+      parseSafeHtmlParts('<span data-x="1">Example</span>')
+    ).toBeUndefined()
+    expect(
+      parseSafeHtmlParts('<a href="javascript:alert(1)">Example</a>')
+    ).toBeUndefined()
+    expect(
+      parseSafeHtmlParts('<a href="https://example.org">Example')
+    ).toBeUndefined()
+    expect(
+      parseSafeHtmlParts(
+        '<a href="https://example.org"><span>Example</span></a>'
+      )
+    ).toBeUndefined()
+  })
+
+  test('parses plain values with attribution-compatible text decoding', () => {
+    expect(parseRichTextValue('https://example.org/maps')).toEqual([
+      {
+        type: 'link',
+        href: 'https://example.org/maps',
+        label: 'https://example.org/maps'
+      }
+    ])
+    expect(parseRichTextValue('AT&amp;T', { decodeText: true })).toEqual([
+      {
+        type: 'text',
+        value: 'AT&T'
+      }
+    ])
+  })
+
+  test('keeps plain text undecoded unless requested', () => {
+    expect(parseRichTextValue('AT&amp;T')).toEqual([
+      {
+        type: 'text',
+        value: 'AT&amp;T'
+      }
+    ])
+  })
+
+  test('extracts safe plain hrefs from trimmed values', () => {
+    expect(parseSafeHref(' https://example.org/maps ')).toBe(
+      'https://example.org/maps'
+    )
+    expect(parseSafeHref('not a url')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Adds helpers for rendering attribution rich text/html content and includes focused coverage for the HTML handling.

## Stack

This is PR 3 of 4 in the `new-viewer` stack. Base: `viewer-image-render-failures`.

Depends on #573.

## Validation

Not run; this PR was created from the staged GitButler split only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing rich text and safe links in viewer content.
  * Introduced grouped attribution display for georeferenced maps, including manifest, provider, and fallback attribution details.
* **Bug Fixes**
  * Improved handling of HTML entities, line breaks, and trimmed URLs.
  * Safer link rendering now rejects unsafe or invalid URLs and unsupported markup.
* **Tests**
  * Added coverage for rich text parsing, safe URL validation, and attribution-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->