### PR TITLE
Fix viewer failure state handling

### DIFF
--- a/apps/viewer/src/lib/components/metadata/MapList.svelte
+++ b/apps/viewer/src/lib/components/metadata/MapList.svelte
@@ -624,29 +624,31 @@
       />
     {/each}
     {#each invalidAnnotations as invalidAnnotation, index (invalidAnnotation.id)}
-      {@const mapNumber = getInvalidAnnotationMapNumber(
-        invalidAnnotation,
-        rows.length + index
-      )}
-      {@const thumbnail = imagesState.thumbnails.get(
-        invalidAnnotation.resource.id
-      )}
-      {@const thumbnailError = thumbnail
-        ? undefined
-        : getThumbnailDisplayError(invalidAnnotation.resource.id)}
-      <li class="w-full flex flex-row min-w-0 gap-3 text-gray-700">
-        <ResourceThumbnail
-          resource={invalidAnnotation.resource}
-          {thumbnail}
-          {thumbnailError}
-          alt={invalidAnnotation.annotationId ?? invalidAnnotation.id}
-        />
-        <MapRowError
-          title={`Map ${mapNumber}`}
-          errorTitle="Georeference annotation error"
-          errorMessage={invalidAnnotation.message}
-        />
-      </li>
+      {#if invalidAnnotation.resource}
+        {@const mapNumber = getInvalidAnnotationMapNumber(
+          invalidAnnotation,
+          rows.length + index
+        )}
+        {@const thumbnail = imagesState.thumbnails.get(
+          invalidAnnotation.resource.id
+        )}
+        {@const thumbnailError = thumbnail
+          ? undefined
+          : getThumbnailDisplayError(invalidAnnotation.resource.id)}
+        <li class="w-full flex flex-row min-w-0 gap-3 text-gray-700">
+          <ResourceThumbnail
+            resource={invalidAnnotation.resource}
+            {thumbnail}
+            {thumbnailError}
+            alt={invalidAnnotation.annotationId ?? invalidAnnotation.id}
+          />
+          <MapRowError
+            title={`Map ${mapNumber}`}
+            errorTitle="Georeference annotation error"
+            errorMessage={invalidAnnotation.message}
+          />
+        </li>
+      {/if}
     {/each}
   </ol>
 {/snippet}

--- a/apps/viewer/src/lib/shared/iiif.ts
+++ b/apps/viewer/src/lib/shared/iiif.ts
@@ -63,9 +63,7 @@ export function getCanonicalCanvas(map: GeoreferencedMap) {
 
 export function getCanonicalManifest(map: GeoreferencedMap) {
   const canvas = getCanonicalCanvas(map)
-  const manifests = (canvas?.partOf ?? []).filter(
-    (item) => item.type === 'Manifest'
-  )
+  const manifests = findManifests(canvas?.partOf ?? [])
 
   if (manifests.length > 0) {
     return manifests[0]

--- a/apps/viewer/src/lib/shared/source.ts
+++ b/apps/viewer/src/lib/shared/source.ts
@@ -198,13 +198,9 @@ function createInvalidGeoreferenceAnnotation(
   error: unknown,
   context: AnnotationParseContext,
   index: number
-): InvalidGeoreferenceAnnotation | undefined {
+): InvalidGeoreferenceAnnotation {
   const annotationContext = getAnnotationContext(annotation, context)
   const { resource } = annotationContext
-
-  if (!resource) {
-    return
-  }
 
   const annotationId = getAnnotationId(annotation)
   const validationIssues = getErrorIssues(error)
@@ -216,7 +212,9 @@ function createInvalidGeoreferenceAnnotation(
       generateChecksum({
         annotation,
         index,
-        resourceId: resource.id,
+        resourceId: resource?.id,
+        canvasId: annotationContext.canvas?.id,
+        manifestId: annotationContext.manifest?.id,
         message
       }),
     annotationId,
@@ -248,7 +246,7 @@ function parseGeoreferenceAnnotation(
 
     return {
       maps: [],
-      invalidAnnotations: invalidAnnotation ? [invalidAnnotation] : []
+      invalidAnnotations: [invalidAnnotation]
     }
   }
 }
@@ -349,6 +347,10 @@ function addInvalidAnnotationCanvasIds(
     canvasIds.add(invalidAnnotation.canvas.id)
   }
 
+  if (!invalidAnnotation.resource) {
+    return
+  }
+
   for (const canvas of findPartOfItemsOfType(
     invalidAnnotation.resource.partOf,
     'Canvas'
@@ -431,7 +433,8 @@ async function parseManifestGeoreferenceAnnotations(
 ) {
   const maps: GeoreferencedMap[] = []
   const invalidAnnotations: InvalidGeoreferenceAnnotation[] = []
-  const canvasIds = new Set<string>()
+  const validMapCanvasIds = new Set<string>()
+  const annotatedCanvasIds = new Set<string>()
   const manifestPartOfItem = getManifestPartOfItem(manifest)
 
   for (const annotationPage of manifest.annotations ?? []) {
@@ -451,11 +454,12 @@ async function parseManifestGeoreferenceAnnotations(
     )
 
     for (const map of pageMaps) {
-      addMapCanvasIds(map, canvasIds)
+      addMapCanvasIds(map, validMapCanvasIds)
+      addMapCanvasIds(map, annotatedCanvasIds)
     }
 
     for (const invalidAnnotation of parsedAnnotationPage.invalidAnnotations) {
-      addInvalidAnnotationCanvasIds(invalidAnnotation, canvasIds)
+      addInvalidAnnotationCanvasIds(invalidAnnotation, annotatedCanvasIds)
     }
 
     maps.push(...pageMaps)
@@ -489,10 +493,11 @@ async function parseManifestGeoreferenceAnnotations(
       if (pageMaps.length > 0 || pageInvalidAnnotations.length > 0) {
         canvasHasGeoreferenceAnnotation = true
         for (const map of pageMaps) {
-          addMapCanvasIds(map, canvasIds)
+          addMapCanvasIds(map, validMapCanvasIds)
+          addMapCanvasIds(map, annotatedCanvasIds)
         }
         for (const invalidAnnotation of pageInvalidAnnotations) {
-          addInvalidAnnotationCanvasIds(invalidAnnotation, canvasIds)
+          addInvalidAnnotationCanvasIds(invalidAnnotation, annotatedCanvasIds)
         }
         maps.push(...pageMaps)
         invalidAnnotations.push(...pageInvalidAnnotations)
@@ -500,17 +505,22 @@ async function parseManifestGeoreferenceAnnotations(
     }
 
     if (canvasHasGeoreferenceAnnotation) {
-      canvasIds.add(canvas.uri)
+      annotatedCanvasIds.add(canvas.uri)
+
+      if (maps.some((map) => getMapCanvasIds(map).has(canvas.uri))) {
+        validMapCanvasIds.add(canvas.uri)
+      }
     }
   }
 
   return {
     maps,
     invalidAnnotations,
-    canvasIds,
+    validMapCanvasIds,
+    annotatedCanvasIds,
     hasAnnotationsForAllCanvases:
       manifest.canvases.length > 0 &&
-      canvasIds.size === manifest.canvases.length
+      validMapCanvasIds.size === manifest.canvases.length
   }
 }
 
@@ -554,7 +564,7 @@ async function parseSource(
       embeddedMaps = manifestGeoreferenceAnnotations.maps
       invalidEmbeddedAnnotations =
         manifestGeoreferenceAnnotations.invalidAnnotations
-      embeddedCanvasIds = manifestGeoreferenceAnnotations.canvasIds
+      embeddedCanvasIds = manifestGeoreferenceAnnotations.validMapCanvasIds
       hasAnnotationsForAllCanvases =
         manifestGeoreferenceAnnotations.hasAnnotationsForAllCanvases
     }

--- a/apps/viewer/src/lib/state/errors.svelte.ts
+++ b/apps/viewer/src/lib/state/errors.svelte.ts
@@ -239,7 +239,10 @@ export class ErrorsState {
       }
     }
 
-    if (this.#mapsState.mapCount === 1 && this.#mapRenderErrors.length === 1) {
+    if (
+      this.#mapsState.mapCount > 0 &&
+      this.#mapRenderErrors.length === this.#mapsState.mapCount
+    ) {
       return {
         type: 'map-render',
         mapRenderError: this.#mapRenderErrors[0]

--- a/apps/viewer/src/lib/state/iiif.svelte.ts
+++ b/apps/viewer/src/lib/state/iiif.svelte.ts
@@ -44,7 +44,8 @@ export class IiifState {
               }
             ]
           : []),
-        ...findManifests(invalidAnnotation.resource.partOf ?? [])
+        ...findManifests(invalidAnnotation.canvas?.partOf ?? []),
+        ...findManifests(invalidAnnotation.resource?.partOf ?? [])
       ]
     )
   ])

--- a/apps/viewer/src/lib/state/images.svelte.ts
+++ b/apps/viewer/src/lib/state/images.svelte.ts
@@ -79,7 +79,9 @@ export class ImagesState {
       imageIds.add(map.resource.id)
     })
     this.#mapsState.invalidEmbeddedAnnotations.forEach((invalidAnnotation) => {
-      imageIds.add(invalidAnnotation.resource.id)
+      if (invalidAnnotation.resource) {
+        imageIds.add(invalidAnnotation.resource.id)
+      }
     })
 
     return imageIds
@@ -144,6 +146,15 @@ export class ImagesState {
         }
       }
 
+      const currentIds = new Set(this.#parsedImagesBySourceImageId.keys())
+
+      for (const imageId of this.#thumbnails.keys()) {
+        if (!currentIds.has(imageId)) {
+          this.#thumbnails.get(imageId)?.close()
+          this.#thumbnails.delete(imageId)
+        }
+      }
+
       if (this.#fetchingThumbnailsPaused) {
         return
       }
@@ -158,15 +169,6 @@ export class ImagesState {
         }
 
         this.#fetchImageInfoFor(imageId)
-      }
-
-      const currentIds = new Set(this.#parsedImagesBySourceImageId.keys())
-
-      for (const imageId of this.#thumbnails.keys()) {
-        if (!currentIds.has(imageId)) {
-          this.#thumbnails.get(imageId)?.close()
-          this.#thumbnails.delete(imageId)
-        }
       }
 
       for (const [imageId, parsedImage] of this.#parsedImagesBySourceImageId) {

--- a/apps/viewer/src/lib/state/maps.svelte.ts
+++ b/apps/viewer/src/lib/state/maps.svelte.ts
@@ -185,6 +185,10 @@ export class MapsState {
       byResource: ByResource,
       invalidAnnotation: InvalidGeoreferenceAnnotation
     ) => {
+      if (!invalidAnnotation.resource) {
+        return
+      }
+
       const id = invalidAnnotation.resource.id
       if (!byResource.has(id)) {
         byResource.set(id, {
@@ -219,7 +223,7 @@ export class MapsState {
       invalidAnnotation: InvalidGeoreferenceAnnotation
     ) =>
       invalidAnnotation.canvas ??
-      findPartOfItem(invalidAnnotation.resource.partOf, 'Canvas')
+      findPartOfItem(invalidAnnotation.resource?.partOf, 'Canvas')
 
     const getInvalidAnnotationManifest = (
       invalidAnnotation: InvalidGeoreferenceAnnotation,
@@ -227,7 +231,7 @@ export class MapsState {
     ) =>
       invalidAnnotation.manifest ??
       findPartOfItem(canvas?.partOf, 'Manifest') ??
-      findPartOfItem(invalidAnnotation.resource.partOf, 'Manifest')
+      findPartOfItem(invalidAnnotation.resource?.partOf, 'Manifest')
 
     for (const map of maps) {
       const canvas = getCanonicalCanvas(map)

--- a/apps/viewer/src/lib/types/shared.ts
+++ b/apps/viewer/src/lib/types/shared.ts
@@ -79,7 +79,7 @@ export type MapsByImage = {
 export type InvalidGeoreferenceAnnotation = {
   id: string
   annotationId?: string
-  resource: GeoreferencedMap['resource']
+  resource?: GeoreferencedMap['resource']
   canvas?: PartOfItem
   manifest?: PartOfItem
   message: string

--- a/packages/components/src/lib/components/Thumbnail.svelte
+++ b/packages/components/src/lib/components/Thumbnail.svelte
@@ -328,7 +328,7 @@
   )
   let errorTitle = $derived(getThumbnailErrorTitle(error))
   let errorMessage = $derived(
-    getThumbnailErrorMessage(error) ?? loadError?.message
+    getThumbnailErrorMessage(error) ?? errorTitle ?? loadError?.message
   )
 
   $effect(() => {


### PR DESCRIPTION
## Summary

Fixes viewer failure-state edge cases found during review:

- keep invalid embedded annotations out of valid map coverage/API dedupe
- preserve manifest-scoped invalid annotations when resource lookup fails
- block the viewer when every map fails to render
- clean up stale thumbnails while thumbnail fetching is paused
- include invalid annotation canvas manifests in IIIF state
- render title-only thumbnail errors

## Stack

This is a follow-up PR in the `new-viewer` stack. Base: `viewer-interface-reorg`.

Depends on #575.

## Validation

- `./node_modules/.pnpm/node_modules/.bin/vitest run apps/viewer/test/html.test.ts`
- `apps/viewer/node_modules/.bin/tsc --noEmit --pretty false -p apps/viewer/tsconfig.json`
- `apps/viewer/node_modules/.bin/svelte-check --tsconfig apps/viewer/tsconfig.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when some annotation data is missing, preventing viewer errors and broken thumbnail/error rows.
  - Expanded manifest and map detection so embedded content is found more reliably, including nested relationships.
  - Updated blocking error handling so multiple map render failures are treated consistently.
  - Thumbnail errors now show clearer fallback messages.
  - Better cleanup of stale thumbnails and more accurate filtering of embedded maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->