### PR TITLE
Harden viewer attribution rich text

### DIFF
--- a/apps/viewer/src/lib/shared/attribution.ts
+++ b/apps/viewer/src/lib/shared/attribution.ts
@@ -68,14 +68,23 @@ function getOrganizationAttribution(map: GeoreferencedMap) {
 
   try {
     const url = new URL(map.resource.id)
+    const href = url.origin === 'null' ? url.href : url.origin
+    const label = url.hostname || url.href
 
-    return [
-      {
-        type: 'link' as const,
-        label: url.hostname,
-        href: url.origin
-      }
-    ]
+    return isSafeHref(href)
+      ? [
+          {
+            type: 'link' as const,
+            label,
+            href
+          }
+        ]
+      : [
+          {
+            type: 'text' as const,
+            value: label
+          }
+        ]
   } catch {
     return
   }
@@ -184,11 +193,6 @@ export function getGeoreferencedMapAttributionGroups(
 
   maps.forEach((map, index) => {
     const scope = getAttributionScope(map, index)
-
-    if (groups.has(scope.key)) {
-      return
-    }
-
     const organization = getOrganizationAttribution(map)
     const attribution = getAttributionForScope(
       scope,
@@ -200,23 +204,31 @@ export function getGeoreferencedMapAttributionGroups(
       return
     }
 
-    groups.set(scope.key, {
-      key: scope.key,
+    const row = {
+      key: [
+        scope.key,
+        scope.label,
+        getPartsKey(organization),
+        getPartsKey(attribution)
+      ].join(':'),
       label: scope.label,
-      rows: [
-        {
-          key: [
-            scope.key,
-            scope.label,
-            getPartsKey(organization),
-            getPartsKey(attribution)
-          ].join(':'),
-          label: scope.label,
-          organization,
-          attribution
-        }
-      ]
-    })
+      organization,
+      attribution
+    }
+
+    if (!groups.has(scope.key)) {
+      groups.set(scope.key, {
+        key: scope.key,
+        label: scope.label,
+        rows: []
+      })
+    }
+
+    const group = groups.get(scope.key)!
+
+    if (!group.rows.some((currentRow) => currentRow.key === row.key)) {
+      group.rows.push(row)
+    }
   })
 
   return [...groups.values()]

--- a/apps/viewer/src/lib/shared/html.ts
+++ b/apps/viewer/src/lib/shared/html.ts
@@ -16,13 +16,37 @@ type ParseRichTextOptions = {
   decodeText?: boolean
 }
 
+const HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  copy: '\u00a9',
+  gt: '>',
+  lt: '<',
+  nbsp: ' ',
+  quot: '"',
+  reg: '\u00ae'
+}
+
 export function decodeHtmlEntities(value: string) {
-  return value
-    .replaceAll('&amp;', '&')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#39;', "'")
+  return value.replace(
+    /&(?:#(\d+)|#x([0-9a-f]+)|([a-z][a-z0-9]+));/gi,
+    (entity, decimal, hexadecimal, name) => {
+      if (decimal || hexadecimal) {
+        const codePoint = Number.parseInt(
+          decimal ?? hexadecimal,
+          decimal ? 10 : 16
+        )
+
+        try {
+          return String.fromCodePoint(codePoint)
+        } catch {
+          return entity
+        }
+      }
+
+      return HTML_ENTITIES[name.toLowerCase()] ?? entity
+    }
+  )
 }
 
 export function isSafeHref(href: string) {
@@ -35,7 +59,7 @@ export function isSafeHref(href: string) {
 }
 
 export function parseSafeHref(value: string) {
-  const trimmedValue = value.trim()
+  const trimmedValue = decodeHtmlEntities(value).trim()
 
   return isSafeHref(trimmedValue) ? trimmedValue : undefined
 }
@@ -103,13 +127,14 @@ export function parseSafeHtmlParts(value: string): RichTextPart[] | undefined {
         /\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i
       )
       const href = hrefMatch?.[1] ?? hrefMatch?.[2] ?? hrefMatch?.[3]
+      const safeHref = href ? parseSafeHref(href) : undefined
 
-      if (!href || !isSafeHref(href)) {
+      if (!safeHref) {
         return
       }
 
       activeLink = {
-        href,
+        href: safeHref,
         label: ''
       }
     } else if (/^\/a$/i.test(tag)) {

--- a/apps/viewer/test/html.test.ts
+++ b/apps/viewer/test/html.test.ts
@@ -13,6 +13,9 @@ describe('viewer safe rich text parsing', () => {
     expect(decodeHtmlEntities('&lt;a&gt;AT&amp;T &quot;Maps&quot;&#39;s')).toBe(
       '<a>AT&T "Maps"\'s'
     )
+    expect(decodeHtmlEntities('Maps&nbsp;&#169;&#xAE;')).toBe(
+      'Maps \u00a9\u00ae'
+    )
   })
 
   test('only allows absolute http, https, and mailto hrefs', () => {
@@ -117,6 +120,23 @@ describe('viewer safe rich text parsing', () => {
     expect(parseSafeHref(' https://example.org/maps ')).toBe(
       'https://example.org/maps'
     )
+    expect(parseSafeHref('https://example.org/maps?a=1&amp;b=2')).toBe(
+      'https://example.org/maps?a=1&b=2'
+    )
     expect(parseSafeHref('not a url')).toBeUndefined()
+  })
+
+  test('decodes safe anchor href entities before storing links', () => {
+    expect(
+      parseSafeHtmlParts(
+        '<a href="https://example.org/maps?a=1&amp;b=2">Example</a>'
+      )
+    ).toEqual([
+      {
+        type: 'link',
+        href: 'https://example.org/maps?a=1&b=2',
+        label: 'Example'
+      }
+    ])
   })
 })


### PR DESCRIPTION
## Summary

Hardens attribution rich text handling found during review:

- validate fallback attribution links through the safe-href policy
- append and dedupe repeated attribution rows within a scope
- decode numeric, hex, and common named HTML entities
- decode entity-escaped href values before validation/storage
- add focused rich text tests for entity-decoded hrefs

## Stack

This is a follow-up PR in the `new-viewer` stack. Base: `viewer-failure-state-handling`.

Depends on #576.

## Validation

- `./node_modules/.pnpm/node_modules/.bin/vitest run apps/viewer/test/html.test.ts`
- `apps/viewer/node_modules/.bin/tsc --noEmit --pretty false -p apps/viewer/tsconfig.json`
- `apps/viewer/node_modules/.bin/svelte-check --tsconfig apps/viewer/tsconfig.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich text links and attributions now handle a wider range of URL and HTML entity formats, improving how link text is displayed.

* **Bug Fixes**
  * Fixed decoding for common HTML entities, including named and numeric forms.
  * Improved safe-link handling so encoded characters in URLs are interpreted correctly.
  * Attribution grouping now preserves multiple distinct entries instead of collapsing them into one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->