### PR TITLE
Polish viewer input and map menu copy

### DIFF
--- a/apps/viewer/src/lib/components/input/AnnotationInput.svelte
+++ b/apps/viewer/src/lib/components/input/AnnotationInput.svelte
@@ -38,7 +38,10 @@
     currentSourceValue
   }: Props = $props()
 
-  const placeholder = 'URL of a Georeference Annotation or IIIF Manifest'
+  const inputLabel = 'URL of a Georeference Annotation or IIIF Manifest'
+  const desktopPlaceholder = inputLabel
+  const smallScreenPlaceholder = 'Georeference Annotation or IIIF URL'
+  const smallScreenMediaQuery = '(max-width: 639px)'
   const JSON_VALIDATION_DEBOUNCE_MS = 300
   const COPY_FEEDBACK_DURATION_MS = 1500
   const inputId = $props.id()
@@ -73,6 +76,10 @@
   let copyFeedbackTimeout: ReturnType<typeof setTimeout> | undefined
   let mode = $state<Mode>('url')
   let hasSelectedInitialInput = $state(false)
+  let isSmallScreen = $state(false)
+  let placeholder = $derived(
+    isSmallScreen ? smallScreenPlaceholder : desktopPlaceholder
+  )
   let sourceValueForCopy = $derived(currentSourceValue ?? initialInputValue)
   let inputMatchesCurrentSource = $derived(inputValue === sourceValueForCopy)
   let visibleButton = $derived.by(() => {
@@ -85,6 +92,20 @@
     }
 
     return button
+  })
+
+  $effect(() => {
+    const mediaQuery = window.matchMedia(smallScreenMediaQuery)
+    const updateSmallScreen = () => {
+      isSmallScreen = mediaQuery.matches
+    }
+
+    updateSmallScreen()
+    mediaQuery.addEventListener('change', updateSmallScreen)
+
+    return () => {
+      mediaQuery.removeEventListener('change', updateSmallScreen)
+    }
   })
 
   $effect(() => {
@@ -439,7 +460,7 @@
       ondragleave={handleDragLeave}
       ondrop={handleDrop}
       {placeholder}
-      aria-label={placeholder}
+      aria-label={inputLabel}
       aria-invalid={error ? 'true' : undefined}
       aria-describedby={error ? errorId : undefined}
       aria-required="true"
@@ -461,7 +482,7 @@
       ondragleave={handleDragLeave}
       ondrop={handleDrop}
       {placeholder}
-      aria-label={placeholder}
+      aria-label={inputLabel}
       aria-invalid={error ? 'true' : undefined}
       aria-describedby={error ? errorId : undefined}
       aria-required="true"

--- a/apps/viewer/src/lib/components/menu/MapAnnotationMenuItems.svelte
+++ b/apps/viewer/src/lib/components/menu/MapAnnotationMenuItems.svelte
@@ -66,7 +66,7 @@
   <DropdownMenu.GroupHeading
     class="text-xs leading-snug bg-gray-100/50 p-2 mx-px rounded w-58"
   >
-    THis map's <a
+    This map's <a
       class="underline"
       href="https://iiif.io/api/extension/georef/"
       target="_blank"


### PR DESCRIPTION
## Summary

Adds small viewer UI polish:

- uses a shorter annotation input placeholder on small screens while keeping the full accessible label
- fixes a typo in the map annotation menu help text

## Stack

This is a follow-up PR in the `new-viewer` stack. Base: `viewer-attribution-rich-text-hardening`.

Depends on #577.

## Validation

- `./node_modules/.pnpm/node_modules/.bin/vitest run apps/viewer/test/html.test.ts`
- `apps/viewer/node_modules/.bin/tsc --noEmit --pretty false -p apps/viewer/tsconfig.json`
- `apps/viewer/node_modules/.bin/svelte-check --tsconfig apps/viewer/tsconfig.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the annotation input experience on smaller screens with more appropriate placeholder text.
  * Kept form accessibility labels stable across screen sizes for clearer screen reader support.
  * Fixed a capitalization typo in a map annotation menu heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->