### PR TITLE
Adjust mobile controls and improve loading indicators

### DIFF
--- a/apps/viewer/src/lib/components/controls/Control.svelte
+++ b/apps/viewer/src/lib/components/controls/Control.svelte
@@ -54,8 +54,8 @@
   aria-pressed={isButton ? pressed : undefined}
   class={[
     'inline-flex items-center justify-center transition-colors',
-    size === 'normal' && 'size-5 pointer-coarse:size-9 pointer-coarse:p-1',
-    size === 'large' && 'size-7 pointer-coarse:size-10 pointer-coarse:p-1',
+    size === 'normal' && 'size-5 pointer-coarse:size-7 pointer-coarse:p-1',
+    size === 'large' && 'size-7 pointer-coarse:size-9 pointer-coarse:p-1',
     label && 'gap-2 font-medium sm:h-auto sm:w-auto sm:px-2 sm:py-1',
     variant === 'round' ? 'rounded-full' : 'rounded',
     isButton

--- a/apps/viewer/src/lib/components/input/examples.ts
+++ b/apps/viewer/src/lib/components/input/examples.ts
@@ -89,12 +89,12 @@ export default [
   //   url: 'https://annotations.allmaps.org/images/7f2494dd1ad9ed7a',
   //   allmapsId: 'images/7f2494dd1ad9ed7a'
   // },
-  {
-    title: 'Phnom-Penh',
-    organization: 'Bibliothèque nationale de France',
-    url: 'https://annotations.allmaps.org/maps/86029c1bf591ecd8',
-    allmapsId: 'maps/86029c1bf591ecd8'
-  },
+  // {
+  //   title: 'Phnom-Penh',
+  //   organization: 'Bibliothèque nationale de France',
+  //   url: 'https://annotations.allmaps.org/maps/86029c1bf591ecd8',
+  //   allmapsId: 'maps/86029c1bf591ecd8'
+  // },
   // {
   //   title: 'Plymouth',
   //   organization: 'National Library of Scotland',

--- a/apps/viewer/src/lib/components/map/Map.svelte
+++ b/apps/viewer/src/lib/components/map/Map.svelte
@@ -735,6 +735,7 @@
       return
     }
 
+    uiState.tilesLoading = true
     previousView = view
 
     const mapRenderResults =


### PR DESCRIPTION
This pull request makes minor adjustments to the viewer's UI controls and map loading state, as well as commenting out a sample map entry in the input examples. The most notable changes are a tweak to control button sizing for touch devices and the addition of a loading state indicator for map tiles.

**UI and UX improvements:**

* Adjusted the sizing of buttons in the `Control.svelte` component for pointer-coarse (touch) input: "normal" size now uses `pointer-coarse:size-7` (was `size-9`), and "large" size uses `pointer-coarse:size-9` (was `size-10`). This makes touch targets slightly smaller and more consistent. (`apps/viewer/src/lib/components/controls/Control.svelte`)
* Set `uiState.tilesLoading = true` at the start of the map rendering process to indicate when map tiles are loading, improving feedback for users. (`apps/viewer/src/lib/components/map/Map.svelte`)

**Content/example management:**

* Commented out the "Phnom-Penh" map example from the input examples list, likely to temporarily remove it from the UI. (`apps/viewer/src/lib/components/input/examples.ts`)