### PR TITLE
Add browser-only IIIF test scenario

### DIFF
--- a/test/server/README.md
+++ b/test/server/README.md
@@ -101,6 +101,7 @@ GET /cors/manifests/3/combined/partial-linked-annotations.json
 GET /cors/manifests/3/combined/all-embedded-annotations-mixed-errors.json
 GET /cors/manifests/3/combined/mixed-embedded-annotation-errors.json
 GET /cors/manifests/3/combined/mixed-linked-annotation-errors.json
+GET /cors/manifests/3/combined/browser-only-iiif3-level2.json
 GET /cors/manifests/3/combined/too-many-requests-after-20s-iiif3-level2.json
 GET /cors/manifests/3/combined/mixed-too-many-requests-after-20s-iiif3-level2.json
 GET /cors/manifests/3/combined/image-services-iiif2-level0-level2.json

--- a/test/server/src/lib/components/Root.svelte
+++ b/test/server/src/lib/components/Root.svelte
@@ -665,6 +665,17 @@
                 link.label === 'Some image services return 500'
             )
           ),
+          createCombinedScenario(
+            'browser-only-manifest-and-image-services',
+            'Browser-only manifest and image services',
+            'The manifest, canvas JSON, image service info.jsons, and image requests require browser request headers and reject plain server-side fetches.',
+            findCombinedLink(
+              'cors',
+              (link) =>
+                link.resourceKind === 'IIIF Presentation 3.0 manifest' &&
+                link.label === 'Browser-only manifest and image services'
+            )
+          ),
           ...[401, 403, 404, 429, 500, 503].map((status) =>
             createCombinedScenario(
               `annotation-page-http-${status}`,

--- a/test/server/src/lib/server.ts
+++ b/test/server/src/lib/server.ts
@@ -20,9 +20,11 @@ import {
   withCors
 } from './responses.ts'
 import {
+  browserOnlyResponse,
   delay,
   delaySlowResource,
   getCombinedImageServiceBehavior,
+  isBrowserRequest,
   isSlowCombinedVariant,
   parseImageServiceBehavior,
   shouldReturnTooManyRequests,
@@ -469,6 +471,12 @@ function getCombinedManifestVariants(baseUrl: string) {
     createImageApiLink(
       '3',
       'level2',
+      'Browser-only manifest and image services',
+      `${baseUrl}/manifests/3/combined/browser-only-iiif3-level2.json`
+    ),
+    createImageApiLink(
+      '3',
+      'level2',
       'Slow manifest and resources',
       `${baseUrl}/manifests/3/combined/slow-iiif3-level2.json`
     ),
@@ -524,6 +532,7 @@ function isCombinedIiif3ManifestVariant(variant: string) {
       'all-embedded-annotations-mixed-errors',
       'mixed-embedded-annotation-errors',
       'mixed-linked-annotation-errors',
+      'browser-only-iiif3-level2',
       'image-500-iiif3-level2',
       'slow-iiif3-level2',
       'too-many-requests-after-20s-iiif3-level2',
@@ -585,6 +594,10 @@ function getCombinedManifestLabel(variant: string) {
 
   if (variant === 'image-500-iiif3-level2') {
     return 'Combined fixture images whose info.json files load but image requests return 500'
+  }
+
+  if (variant === 'browser-only-iiif3-level2') {
+    return 'Combined fixture images whose manifest and image services require browser request headers'
   }
 
   if (variant === 'slow-iiif3-level2') {
@@ -656,6 +669,7 @@ function getCombinedCanvasManifestVariant(variant: string, index: number) {
   }
 
   if (
+    variant === 'browser-only-iiif3-level2' ||
     variant === 'image-500-iiif3-level2' ||
     variant === 'slow-iiif3-level2' ||
     variant === 'too-many-requests-after-20s-iiif3-level2' ||
@@ -2061,6 +2075,10 @@ async function routeFixtureRequest(
       ? parseImageServiceBehavior(segments[4])
       : undefined
 
+    if (behavior === 'browser-only' && !isBrowserRequest(request)) {
+      return browserOnlyResponse(corsMode)
+    }
+
     await delaySlowResource(behavior)
 
     if (
@@ -2108,6 +2126,10 @@ async function routeFixtureRequest(
       ? parseImageServiceBehavior(segments[4])
       : undefined
     const image = getImage(segments[2 + offset])
+
+    if (behavior === 'browser-only' && !isBrowserRequest(request)) {
+      return browserOnlyResponse(corsMode)
+    }
 
     await delaySlowResource(behavior)
 
@@ -2381,6 +2403,13 @@ async function routeFixtureRequest(
         return textResponse('Unknown manifest canvas', corsMode, 404)
       }
 
+      if (
+        variant === 'browser-only-iiif3-level2' &&
+        !isBrowserRequest(request)
+      ) {
+        return browserOnlyResponse(corsMode)
+      }
+
       if (isSlowCombinedVariant(variant)) {
         await delay(slowResourceDelayMs)
       }
@@ -2401,6 +2430,13 @@ async function routeFixtureRequest(
 
       if (!isCombinedIiif3ManifestVariant(variant)) {
         return textResponse('Unknown manifest variant', corsMode, 404)
+      }
+
+      if (
+        variant === 'browser-only-iiif3-level2' &&
+        !isBrowserRequest(request)
+      ) {
+        return browserOnlyResponse(corsMode)
       }
 
       if (isSlowCombinedVariant(variant)) {

--- a/test/server/src/lib/server/behaviors.ts
+++ b/test/server/src/lib/server/behaviors.ts
@@ -4,6 +4,8 @@ import type { ImageServiceBehavior } from './image-api.ts'
 
 export const slowResourceDelayMs = 4_000
 const tooManyRequestsAfterMs = 20_000
+const allmapsViewerUserAgent = 'AllmapsViewer (+https://viewer.allmaps.org/)'
+const allmapsWorkerZone = 'allmaps.org'
 
 const imageServiceBehaviorStartedAt = new Map<string, number>()
 
@@ -15,6 +17,7 @@ export function parseImageServiceBehavior(
   }
 
   if (
+    behavior === 'browser-only' ||
     behavior === 'image-500' ||
     behavior === 'service-500' ||
     behavior === 'slow' ||
@@ -31,6 +34,10 @@ export function getCombinedImageServiceBehavior(
 ): ImageServiceBehavior | undefined {
   if (variant === 'image-500-iiif3-level2') {
     return 'image-500'
+  }
+
+  if (variant === 'browser-only-iiif3-level2') {
+    return 'browser-only'
   }
 
   if (variant === 'service-500-iiif3-level2') {
@@ -107,4 +114,29 @@ export function tooManyRequestsResponse(corsMode: CorsMode) {
   response.headers.set('retry-after', '20')
 
   return response
+}
+
+export function isBrowserRequest(request: Request) {
+  if (isViewerServerRequest(request)) {
+    return false
+  }
+
+  return (
+    request.headers.has('origin') ||
+    request.headers.has('sec-fetch-dest') ||
+    request.headers.has('sec-fetch-mode') ||
+    request.headers.has('sec-fetch-site') ||
+    request.headers.has('sec-fetch-user')
+  )
+}
+
+export function isViewerServerRequest(request: Request) {
+  return (
+    request.headers.get('user-agent') === allmapsViewerUserAgent ||
+    request.headers.get('cf-worker') === allmapsWorkerZone
+  )
+}
+
+export function browserOnlyResponse(corsMode: CorsMode) {
+  return textResponse('Browser request headers required', corsMode, 403)
 }

--- a/test/server/src/lib/server/image-api.ts
+++ b/test/server/src/lib/server/image-api.ts
@@ -28,6 +28,7 @@ export type ImageApiService = {
 }
 
 export type ImageServiceBehavior =
+  | 'browser-only'
   | 'image-500'
   | 'service-500'
   | 'slow'

--- a/test/server/test/generated-resources.test.ts
+++ b/test/server/test/generated-resources.test.ts
@@ -7,7 +7,7 @@ import { createCatalog, handleFixtureRequest } from '../src/lib/server.ts'
 type JsonObject = Record<string, unknown>
 
 type InfoExpectation = 'valid' | 'missing-dimensions' | 'bad-tiles'
-type ManifestExpectation = 'valid' | 'missing-image-service'
+type ManifestExpectation = 'valid' | 'missing-image-service' | 'browser-only'
 
 type Resource<T extends string> = {
   name: string
@@ -30,6 +30,17 @@ type AnnotationResource =
 const baseUrl = 'http://localhost:5506/cors'
 const catalog = createCatalog(new Request(`${baseUrl}/`), 'cors')
 const combinedAnnotationHttpErrorStatuses = [401, 403, 404, 429, 500, 503]
+const browserRequestHeaders = {
+  'sec-fetch-mode': 'cors'
+}
+const viewerServerRequestHeaders = {
+  ...browserRequestHeaders,
+  'user-agent': 'AllmapsViewer (+https://viewer.allmaps.org/)'
+}
+const cloudflareViewerServerRequestHeaders = {
+  ...browserRequestHeaders,
+  'cf-worker': 'allmaps.org'
+}
 
 function isJsonObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -45,14 +56,14 @@ function getFixturePath(href: string) {
   }
 }
 
-async function getFixtureResponse(href: string) {
+async function getFixtureResponse(href: string, headers?: HeadersInit) {
   const { corsMode, path } = getFixturePath(href)
 
-  return handleFixtureRequest(new Request(href), corsMode, path)
+  return handleFixtureRequest(new Request(href, { headers }), corsMode, path)
 }
 
-async function getJsonResource(href: string) {
-  const response = await getFixtureResponse(href)
+async function getJsonResource(href: string, headers?: HeadersInit) {
+  const response = await getFixtureResponse(href, headers)
   const text = await response.text()
 
   expect(response.status, href).toBe(200)
@@ -111,7 +122,9 @@ function getManifestResources(): Resource<ManifestExpectation>[] {
     ...catalog.combinedImages.manifests.map((link) => ({
       name: `combined ${link.label}`,
       href: link.href,
-      expectation: 'valid' as const
+      expectation: link.href.includes('/browser-only-')
+        ? ('browser-only' as const)
+        : ('valid' as const)
     })),
     ...catalog.images.flatMap((image) => [
       ...image.manifestResources.map((link) => ({
@@ -153,6 +166,10 @@ function isCombinedAnnotationHttpErrorResource(href: string) {
 
 function isSlowResource(href: string) {
   return href.includes('/slow-iiif3-level2')
+}
+
+function isBrowserOnlyResource(href: string) {
+  return href.includes('/browser-only-')
 }
 
 function getAnnotationItems(annotation: unknown) {
@@ -244,6 +261,42 @@ function getAnnotationImageServiceIds(annotation: unknown) {
   ]
 }
 
+function getFirstPaintingImageServiceId(manifest: unknown) {
+  if (!isJsonObject(manifest) || !Array.isArray(manifest.items)) {
+    throw new Error('Manifest has no canvases')
+  }
+
+  const canvas = manifest.items[0]
+
+  if (!isJsonObject(canvas) || !Array.isArray(canvas.items)) {
+    throw new Error('Manifest canvas has no annotation pages')
+  }
+
+  const annotationPage = canvas.items[0]
+
+  if (!isJsonObject(annotationPage) || !Array.isArray(annotationPage.items)) {
+    throw new Error('Canvas has no painting annotations')
+  }
+
+  const annotation = annotationPage.items[0]
+
+  if (!isJsonObject(annotation) || !isJsonObject(annotation.body)) {
+    throw new Error('Painting annotation has no image body')
+  }
+
+  const { service } = annotation.body
+
+  if (
+    !Array.isArray(service) ||
+    !isJsonObject(service[0]) ||
+    typeof service[0].id !== 'string'
+  ) {
+    throw new Error('Painting annotation has no image service')
+  }
+
+  return service[0].id
+}
+
 function collectAnnotationPagesFromManifest(
   manifest: unknown,
   name: string
@@ -307,7 +360,7 @@ async function getGeneratedAnnotationResources() {
   )
 
   for (const resource of getManifestResources()) {
-    if (isSlowResource(resource.href)) {
+    if (isSlowResource(resource.href) || isBrowserOnlyResource(resource.href)) {
       continue
     }
 
@@ -359,10 +412,17 @@ describe('generated IIIF manifests', () => {
   test.each(getManifestResources())(
     '$name',
     async ({ href, expectation }) => {
-      const data = await getJsonResource(href)
+      if (expectation === 'browser-only') {
+        expect((await getFixtureResponse(href)).status).toBe(403)
+      }
+
+      const data = await getJsonResource(
+        href,
+        expectation === 'browser-only' ? browserRequestHeaders : undefined
+      )
       const error = getParseError(() => IIIF.parse(data))
 
-      if (expectation === 'valid') {
+      if (expectation === 'valid' || expectation === 'browser-only') {
         expect(error).toBeUndefined()
       } else {
         expect(getIssuePaths(error)).toContain(
@@ -372,6 +432,69 @@ describe('generated IIIF manifests', () => {
     },
     20_000
   )
+
+  test('browser-only combined manifest, info.json, and image requests reject server-side requests', async () => {
+    const manifestHref = `${baseUrl}/manifests/3/combined/browser-only-iiif3-level2.json`
+    const canvasHref = `${baseUrl}/manifests/3/combined/browser-only-iiif3-level2.json/canvas/1`
+
+    expect((await getFixtureResponse(manifestHref)).status).toBe(403)
+    expect((await getFixtureResponse(canvasHref)).status).toBe(403)
+    expect(
+      (await getFixtureResponse(manifestHref, viewerServerRequestHeaders))
+        .status
+    ).toBe(403)
+    expect(
+      (await getFixtureResponse(canvasHref, viewerServerRequestHeaders)).status
+    ).toBe(403)
+    expect(
+      (
+        await getFixtureResponse(
+          manifestHref,
+          cloudflareViewerServerRequestHeaders
+        )
+      ).status
+    ).toBe(403)
+
+    const manifest = await getJsonResource(manifestHref, browserRequestHeaders)
+    const canvas = await getJsonResource(canvasHref, browserRequestHeaders)
+    const serviceId = getFirstPaintingImageServiceId(manifest)
+    const infoJsonHref = `${serviceId}/info.json`
+    const imageHref = `${serviceId}/full/64,/0/default.jpg`
+
+    expect(() => IIIF.parse(manifest)).not.toThrow()
+    expect(isJsonObject(canvas) && canvas.type).toBe('Canvas')
+    expect((await getFixtureResponse(infoJsonHref)).status).toBe(403)
+    expect((await getFixtureResponse(imageHref)).status).toBe(403)
+    expect(
+      (await getFixtureResponse(infoJsonHref, viewerServerRequestHeaders))
+        .status
+    ).toBe(403)
+    expect(
+      (await getFixtureResponse(imageHref, viewerServerRequestHeaders)).status
+    ).toBe(403)
+    expect(
+      (
+        await getFixtureResponse(
+          infoJsonHref,
+          cloudflareViewerServerRequestHeaders
+        )
+      ).status
+    ).toBe(403)
+    expect(
+      (
+        await getFixtureResponse(
+          imageHref,
+          cloudflareViewerServerRequestHeaders
+        )
+      ).status
+    ).toBe(403)
+    expect(
+      IIIF.parse(await getJsonResource(infoJsonHref, browserRequestHeaders))
+    ).toBeDefined()
+    expect(
+      (await getFixtureResponse(imageHref, browserRequestHeaders)).status
+    ).toBe(200)
+  })
 })
 
 describe('generated georeference annotations', () => {


### PR DESCRIPTION
## Summary

- add a combined IIIF Presentation 3 manifest and image-service scenario that requires browser request headers
- reject plain server-side, Allmaps Viewer user-agent, and Allmaps Cloudflare worker requests with a 403 response
- expose the scenario in the test-server catalog and documentation
- cover manifest, canvas, `info.json`, and image responses in the generated-resource tests

## Impact

The test server can now reproduce IIIF resources that work in browsers but reject server-side fetching. This makes it possible to exercise client fallback behavior deterministically.

## Validation

- `pnpm --filter "@allmaps/test-iiif-server" test` (403 tests passed)
- `pnpm run types` (43/43 tasks passed)