### PR TITLE
cleanup

### DIFF
--- a/apps/viewer/eslint.config.js
+++ b/apps/viewer/eslint.config.js
@@ -1,27 +1,22 @@
 import prettier from 'eslint-config-prettier'
-import { fileURLToPath } from 'node:url'
-import { includeIgnoreFile } from '@eslint/compat'
+import path from 'node:path'
 import js from '@eslint/js'
 import svelte from 'eslint-plugin-svelte'
-import { defineConfig } from 'eslint/config'
+import { defineConfig, includeIgnoreFile } from 'eslint/config'
 import globals from 'globals'
 import ts from 'typescript-eslint'
-import svelteConfig from './svelte.config.js'
 
-const gitignorePath = fileURLToPath(
-  new URL('./../../.gitignore', import.meta.url)
-)
+const gitignorePath = path.resolve(import.meta.dirname, '../../.gitignore')
 
 export default defineConfig(
   includeIgnoreFile(gitignorePath),
   js.configs.recommended,
-  ...ts.configs.recommended,
-  ...svelte.configs.recommended,
+  ts.configs.recommended,
+  svelte.configs.recommended,
   prettier,
-  ...svelte.configs.prettier,
+  svelte.configs.prettier,
   {
     languageOptions: { globals: { ...globals.browser, ...globals.node } },
-
     rules: {
       // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
       // see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
@@ -34,10 +29,11 @@ export default defineConfig(
       parserOptions: {
         projectService: true,
         extraFileExtensions: ['.svelte'],
-        parser: ts.parser,
-        svelteConfig
+        parser: ts.parser
       }
-    },
+    }
+  },
+  {
     rules: {
       'svelte/prefer-svelte-reactivity': 'warn',
       'svelte/no-navigation-without-resolve': 'warn'


### PR DESCRIPTION
This pull request updates the ESLint configuration in `apps/viewer/eslint.config.js` to modernize imports, improve compatibility, and simplify the configuration structure. The main changes focus on using updated APIs, cleaning up how configuration files are resolved, and streamlining the way recommended configs are included.

**Configuration modernization and simplification:**

* Replaced the use of `fileURLToPath` and `new URL` with `path.resolve` and `import.meta.dirname` to determine the `.gitignore` path, improving compatibility and clarity.
* Updated imports to use `defineConfig` and `includeIgnoreFile` directly from `eslint/config`, and removed unnecessary spread operators when including recommended configs for TypeScript and Svelte.
* Removed the unused import of `svelteConfig` and its reference in the parser options, simplifying the configuration.
* Cleaned up the ESLint rules and parser options sections for better readability and maintainability.

These changes make the ESLint configuration more robust and easier to maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality and linting configuration for improved compatibility and consistency.
  * Simplified project configuration without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->