### PR TITLE
handle legacy JSONB map values

### DIFF
--- a/apis/live/src/sharedb/sharedb.ts
+++ b/apis/live/src/sharedb/sharedb.ts
@@ -21,7 +21,7 @@ import {
 import { isGcpsValid, isResourceMaskValid } from '../shared/validate.js'
 import ShareDbPostgresDb from './postgres.js'
 
-import { DbMapsSchema } from '@allmaps/db/maps'
+import { DbMap3Schema, DbMapsSchema } from '@allmaps/db/maps'
 
 import type { Polygon } from 'geojson'
 import type { WebSocket } from 'ws'
@@ -271,7 +271,8 @@ export default class AllmapsShareDB {
         )
 
       // Then, insert new maps
-      for (const map of dbMaps3) {
+      for (const unvalidatedMap of dbMaps3) {
+        const map = DbMap3Schema.parse(unvalidatedMap)
         const checksum = await generateChecksum(map)
 
         const mapId = map.id

--- a/packages/api-shared/src/index.ts
+++ b/packages/api-shared/src/index.ts
@@ -1,6 +1,7 @@
 export { generateFeature, generateFeatureCollection } from './shared/geojson.js'
 export {
   fromDbRow,
+  parseStoredDbMap,
   toDbMap3,
   getCompleteGcps,
   dbMapToDbMap3,

--- a/packages/api-shared/src/shared/maps.ts
+++ b/packages/api-shared/src/shared/maps.ts
@@ -136,10 +136,14 @@ function createUrlFactory(annotationsBaseUrl: string) {
   }
 }
 
-function getAllmaps(dbRow: DbRow, urls: ReturnType<typeof createUrlFactory>) {
+function getAllmaps(
+  dbRow: DbRow,
+  mapId: string,
+  urls: ReturnType<typeof createUrlFactory>
+) {
   return {
-    id: urls.map(dbRow.map.id),
-    version: urls.map(dbRow.map.id, dbRow.checksum),
+    id: urls.map(mapId),
+    version: urls.map(mapId, dbRow.checksum),
     image: dbRow.image
       ? {
           id: urls.image(dbRow.image.id),
@@ -331,12 +335,12 @@ export function fromDbRow(dbRow: DbRow, annotationsBaseUrl: string): ApiMap {
   const partOf = getPartOf(dbRow)
   const provider = getProvider(dbRow)
 
-  const dbMap = DbMapSchema.parse(dbRow.map)
+  const dbMap = parseStoredDbMap(dbRow.map)
   const map = dbMapToDbMap3(dbMap)
 
   return {
     '@context': 'https://schemas.allmaps.org/map/2/context.json',
-    id: urls.map(dbRow.map.id),
+    id: urls.map(dbMap.id),
     type: 'GeoreferencedMap',
     created: dbRow.createdAt.toISOString(),
     modified: dbRow.updatedAt.toISOString(),
@@ -356,6 +360,12 @@ export function fromDbRow(dbRow: DbRow, annotationsBaseUrl: string): ApiMap {
       map.resourceCrs,
       annotationsBaseUrl
     ),
-    _allmaps: getAllmaps(dbRow, urls)
+    _allmaps: getAllmaps(dbRow, dbMap.id, urls)
   }
+}
+
+export function parseStoredDbMap(value: unknown): DbMap {
+  const parsedValue = typeof value === 'string' ? JSON.parse(value) : value
+
+  return DbMapSchema.parse(parsedValue)
 }


### PR DESCRIPTION
## Summary

- decode legacy map rows stored as JSONB strings before validating them
- use the decoded map ID throughout REST API responses
- validate version 3 maps at the Live API persistence boundary

## Root cause

Older Drizzle/Neon JSONB handling stored some map objects as JSONB scalar strings. The newer reader returns that actual string, which the strict `DbMapSchema` correctly rejects as a non-object. Current `develop` already resolves the updated Drizzle, Neon, and Postgres versions; this change keeps reads compatible with legacy rows and makes the application write boundary explicit.

## Impact

The REST API can serve both correctly stored JSONB objects and legacy string-encoded maps. New Live API persistence attempts must pass `DbMap3Schema` before reaching Drizzle.

## Validation

- `pnpm --filter @allmaps/api-shared run types`
- `pnpm --filter @allmaps/api-live run types`
- ESLint on the three changed files
- focused runtime checks for object and legacy-string parsing, invalid values, and generated map URLs
- clean `pnpm install --frozen-lockfile`; verified Drizzle ORM `1.0.0-rc.4-5d5b77c`, Neon `1.1.0`, and Postgres `3.4.9`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of saved map data before it is persisted.
  * Improved handling of stored map data across supported formats.
  * Ensured map identifiers and version links are generated consistently from validated map information.

* **Refactor**
  * Centralized map parsing and validation for more reliable data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->