### PR TITLE
Decode legacy JSONB values across API responses

### DIFF
--- a/packages/api-shared/src/queries/iiif.ts
+++ b/packages/api-shared/src/queries/iiif.ts
@@ -7,6 +7,7 @@ import { Manifest, Image } from '@allmaps/iiif-parser'
 import { schema } from '@allmaps/db/schema'
 
 import { ResponseError, clampLimit } from '@allmaps/api-shared'
+import { parseStoredNullableLanguageString } from '../shared/stored-json.js'
 
 import type { LanguageString } from '@allmaps/iiif-parser'
 import type { Db } from '@allmaps/db'
@@ -127,6 +128,7 @@ function assertAllowedDomain(
 function fromDbManifest(restBaseUrl: string, dbManifest: DbManifest) {
   return {
     ...dbManifest,
+    label: parseStoredNullableLanguageString(dbManifest.label),
     organization: dbManifest.organizationUrl?.organization
       ? {
           id: `${restBaseUrl}/organizations/${dbManifest.organizationUrl.organization.id}`
@@ -162,9 +164,11 @@ function fromDbImage(restBaseUrl: string, dbImage: DbImage) {
     })),
     canvases: dbImage.canvases.map((canvas) => ({
       ...canvas,
+      label: parseStoredNullableLanguageString(canvas.label),
       id: `${restBaseUrl}/canvases/${canvas.id}`,
       manifests: canvas.manifests.map((manifest) => ({
         ...manifest,
+        label: parseStoredNullableLanguageString(manifest.label),
         id: `${restBaseUrl}/manifests/${manifest.id}`
       }))
     })),
@@ -175,6 +179,7 @@ function fromDbImage(restBaseUrl: string, dbImage: DbImage) {
 function fromDbCanvas(restBaseUrl: string, dbCanvas: DbCanvas) {
   return {
     ...dbCanvas,
+    label: parseStoredNullableLanguageString(dbCanvas.label),
     organization: dbCanvas.organizationUrl?.organization
       ? {
           id: `${restBaseUrl}/organizations/${dbCanvas.organizationUrl.organization.id}`
@@ -190,6 +195,7 @@ function fromDbCanvas(restBaseUrl: string, dbCanvas: DbCanvas) {
     })),
     manifests: dbCanvas.manifests.map((manifest) => ({
       ...manifest,
+      label: parseStoredNullableLanguageString(manifest.label),
       id: `${restBaseUrl}/manifests/${manifest.id}`
     })),
     organizationUrl: undefined

--- a/packages/api-shared/src/queries/lists.ts
+++ b/packages/api-shared/src/queries/lists.ts
@@ -9,6 +9,7 @@ import * as iiifSchema from '@allmaps/db/schema/iiif'
 
 import { ResponseError } from '@allmaps/api-shared'
 import { fromDbRow } from '../shared/maps.js'
+import { parseStoredNullableLanguageString } from '../shared/stored-json.js'
 
 import type { Annotation, AnnotationPage } from '@allmaps/annotation'
 import type { Db, DbOrTx } from '@allmaps/db'
@@ -157,7 +158,6 @@ async function queryListMapRows(
         columns: {
           id: true,
           uri: true,
-          data: true,
           embedded: true
         },
         with: {
@@ -377,8 +377,12 @@ export async function queryListWithItems(
       canvasId: item.canvasId,
       manifestId: item.manifestId,
       createdAt: item.createdAt,
-      canvasLabel: item.canvas?.label ?? null,
-      manifestLabel: item.manifest?.label ?? null
+      canvasLabel: parseStoredNullableLanguageString(
+        item.canvas?.label ?? null
+      ),
+      manifestLabel: parseStoredNullableLanguageString(
+        item.manifest?.label ?? null
+      )
     }))
   }
 }

--- a/packages/api-shared/src/queries/maps.ts
+++ b/packages/api-shared/src/queries/maps.ts
@@ -114,7 +114,6 @@ export async function queryMaps(
         columns: {
           id: true,
           uri: true,
-          data: true,
           embedded: true
         },
         with: {

--- a/packages/api-shared/src/shared/maps.ts
+++ b/packages/api-shared/src/shared/maps.ts
@@ -1,4 +1,5 @@
 import { generateId, generateChecksum, generateRandomId } from '@allmaps/id'
+import { z } from 'zod'
 
 import { toFixed } from './numbers.js'
 import {
@@ -30,6 +31,23 @@ import type {
 import type { ApiMap, DbRow } from '../types.js'
 
 const projectionsByDbId = getProjectionsByDbId()
+
+const LanguageStringSchema = z.record(
+  z.string(),
+  z.array(z.union([z.string(), z.number(), z.boolean()]))
+)
+
+function parseStoredJson(value: unknown) {
+  return typeof value === 'string' ? JSON.parse(value) : value
+}
+
+function parseStoredLanguageString(value: unknown) {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  return LanguageStringSchema.parse(parseStoredJson(value))
+}
 
 export function isGcpComplete(gcp: DbGcp3): gcp is CompleteDbGcp3 {
   return gcp.resource && gcp.geo ? true : false
@@ -109,12 +127,12 @@ function getPartOf(dbRow: DbRow) {
       {
         type: 'Canvas' as const,
         id: canvas.uri,
-        label: canvas.label || undefined,
+        label: parseStoredLanguageString(canvas.label),
         partOf: canvas.manifests.flatMap((manifest) => [
           {
             type: 'Manifest' as const,
             id: manifest.uri,
-            label: manifest.label || undefined
+            label: parseStoredLanguageString(manifest.label)
           }
         ])
       }
@@ -365,7 +383,5 @@ export function fromDbRow(dbRow: DbRow, annotationsBaseUrl: string): ApiMap {
 }
 
 export function parseStoredDbMap(value: unknown): DbMap {
-  const parsedValue = typeof value === 'string' ? JSON.parse(value) : value
-
-  return DbMapSchema.parse(parsedValue)
+  return DbMapSchema.parse(parseStoredJson(value))
 }

--- a/packages/api-shared/src/shared/maps.ts
+++ b/packages/api-shared/src/shared/maps.ts
@@ -1,7 +1,10 @@
 import { generateId, generateChecksum, generateRandomId } from '@allmaps/id'
-import { z } from 'zod'
 
 import { toFixed } from './numbers.js'
+import {
+  parseStoredJson,
+  parseStoredNullableLanguageString
+} from './stored-json.js'
 import {
   makeMapUrl,
   makeImageUrl,
@@ -31,27 +34,6 @@ import type {
 import type { ApiMap, DbRow } from '../types.js'
 
 const projectionsByDbId = getProjectionsByDbId()
-
-const LanguageStringSchema = z.record(
-  z.string(),
-  z.array(z.union([z.string(), z.number(), z.boolean()]))
-)
-
-function parseStoredJson(value: unknown) {
-  // TODO: Remove legacy string decoding after existing JSONB data is
-  // normalized and database constraints prevent encoded JSON strings.
-  return typeof value === 'string' ? JSON.parse(value) : value
-}
-
-function parseStoredLanguageString(value: unknown) {
-  if (value === null || value === undefined) {
-    return undefined
-  }
-
-  // TODO: Remove this runtime validation after existing labels are normalized
-  // and database constraints guarantee valid language-string objects.
-  return LanguageStringSchema.parse(parseStoredJson(value))
-}
 
 export function isGcpComplete(gcp: DbGcp3): gcp is CompleteDbGcp3 {
   return gcp.resource && gcp.geo ? true : false
@@ -131,12 +113,13 @@ function getPartOf(dbRow: DbRow) {
       {
         type: 'Canvas' as const,
         id: canvas.uri,
-        label: parseStoredLanguageString(canvas.label),
+        label: parseStoredNullableLanguageString(canvas.label) ?? undefined,
         partOf: canvas.manifests.flatMap((manifest) => [
           {
             type: 'Manifest' as const,
             id: manifest.uri,
-            label: parseStoredLanguageString(manifest.label)
+            label:
+              parseStoredNullableLanguageString(manifest.label) ?? undefined
           }
         ])
       }

--- a/packages/api-shared/src/shared/maps.ts
+++ b/packages/api-shared/src/shared/maps.ts
@@ -38,6 +38,8 @@ const LanguageStringSchema = z.record(
 )
 
 function parseStoredJson(value: unknown) {
+  // TODO: Remove legacy string decoding after existing JSONB data is
+  // normalized and database constraints prevent encoded JSON strings.
   return typeof value === 'string' ? JSON.parse(value) : value
 }
 
@@ -46,6 +48,8 @@ function parseStoredLanguageString(value: unknown) {
     return undefined
   }
 
+  // TODO: Remove this runtime validation after existing labels are normalized
+  // and database constraints guarantee valid language-string objects.
   return LanguageStringSchema.parse(parseStoredJson(value))
 }
 

--- a/packages/api-shared/src/shared/stored-json.ts
+++ b/packages/api-shared/src/shared/stored-json.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+import type { LanguageString } from '@allmaps/iiif-parser'
+
+const LanguageStringSchema = z.record(
+  z.string(),
+  z.array(z.union([z.string(), z.number(), z.boolean()]))
+)
+
+export function parseStoredJson(value: unknown) {
+  // TODO: Remove legacy string decoding after existing JSONB data is
+  // normalized and database constraints prevent encoded JSON strings.
+  return typeof value === 'string' ? JSON.parse(value) : value
+}
+
+export function parseStoredLanguageString(value: unknown): LanguageString {
+  // TODO: Remove this runtime validation after existing labels are normalized
+  // and database constraints guarantee valid language-string objects.
+  return LanguageStringSchema.parse(parseStoredJson(value))
+}
+
+export function parseStoredNullableLanguageString(
+  value: unknown
+): LanguageString | null {
+  return value === null || value === undefined
+    ? null
+    : parseStoredLanguageString(value)
+}

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -83,7 +83,6 @@ export type DbRow = {
   image: {
     id: string
     uri: string
-    data?: unknown
     embedded: boolean
     organizationUrl: {
       url: string


### PR DESCRIPTION
## Summary

- decode legacy JSON-encoded map data before schema validation
- decode and validate legacy JSON-encoded IIIF canvas and manifest labels
- apply label compatibility handling to map annotations, REST image/canvas/manifest responses, and list items
- centralize stored-JSON compatibility handling and document when it can be removed
- stop selecting unused raw `iiif.images.data` values on map and list queries

## Why

Some existing JSONB rows contain scalar strings whose contents are serialized JSON objects. Newer Drizzle versions correctly surface those database values as strings, which caused schema validation failures and could expose string labels in REST/list responses. The compatibility layer decodes those legacy values while retaining schema validation.

`iiif.images.data` and `iiif.manifests.data` also contain legacy scalar strings. Current API read paths only use `data IS NOT NULL` to derive the `fetched` flag and do not return or parse those payloads. Unused image-data selections have been removed; future payload consumers can use the centralized decoder until database cleanup is complete.

## Checks

- `pnpm --filter @allmaps/api-shared run types`
- `pnpm --filter @allmaps/api-rest exec tsc --noEmit`
- `pnpm --filter @allmaps/api-annotations exec tsc --noEmit`
- ESLint and Prettier on changed API-shared files
- focused runtime regression for encoded, decoded, nullable, and invalid stored JSON values

The repository-wide pre-commit hook was previously attempted, but stopped on the unrelated existing `@allmaps/components/projections` type-resolution error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of multilingual and nullable labels across manifests, canvases, images, lists, and map results.
  - Standardized parsing of stored JSON values, including legacy encoded data.
  - Improved consistency of “part of” metadata in map-related responses.
- **Performance**
  - Reduced unnecessary image data included in map and list query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->