### PR TITLE
Return complete maps for IIIF resources

### DIFF
--- a/apis/annotations/src/routes/canvases.ts
+++ b/apis/annotations/src/routes/canvases.ts
@@ -1,17 +1,13 @@
 import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
-import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
+import { setCacheControl } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
-
-const querySchema = t.Object({
-  limit: t.Optional(t.Number())
-})
 
 export function createCanvasesRoutes(
   env: AnnotationsEnv,
@@ -21,29 +17,23 @@ export function createCanvasesRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/canvases/:canvasId',
-      async ({ request, env, db, params, query, set, getLimitRole }) => {
-        const userRole = needsElevatedLimitRole(query.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-medium' : 'private-no-store'
-        )
+      ({ request, env, db, params, set }) => {
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          { canvasId: params.canvasId, limit: query.limit, userRole },
+          { canvasId: params.canvasId },
           {
             id: request.url,
             format: 'annotation',
             expectRows: true,
-            singular: false
+            singular: false,
+            resultScope: 'complete'
           }
         )
       },
       {
         params: t.Object({ canvasId: t.String() }),
-        query: querySchema,
         detail: {
           summary: 'Get Georeference Annotations for a single IIIF Canvas',
           tags: ['Canvases']

--- a/apis/annotations/src/routes/images.ts
+++ b/apis/annotations/src/routes/images.ts
@@ -1,17 +1,11 @@
-import { t } from 'elysia'
-
 import { queryMaps } from '@allmaps/api-shared/db'
-import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
+import { setCacheControl } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia, createBetterAuthPlugin, RegExpRoute } from '../elysia.js'
-
-const querySchema = t.Object({
-  limit: t.Optional(t.Number())
-})
 
 // Matches: imageId  OR  imageId@imageChecksum  OR  imageId.geojson etc.
 const imageRoute = new RegExpRoute<{
@@ -31,18 +25,11 @@ export function createImagesRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       `/images/${imageRoute.path}`,
-      async ({ request, env, db, params, query, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const { imageId, imageChecksum, ext } = imageRoute.parse(params)
-        const userRole = needsElevatedLimitRole(query.limit)
-          ? await getLimitRole()
-          : 'public'
         setCacheControl(
           set,
-          userRole === 'public'
-            ? imageChecksum
-              ? 'public-immutable'
-              : 'public-medium'
-            : 'private-no-store'
+          imageChecksum ? 'public-immutable' : 'public-medium'
         )
         const format = ext === 'geojson' ? 'geojson' : 'annotation'
         return queryMaps(
@@ -50,16 +37,19 @@ export function createImagesRoutes(
           db,
           {
             imageId,
-            ...(imageChecksum ? { imageChecksum } : {}),
-            limit: query.limit,
-            userRole
+            ...(imageChecksum ? { imageChecksum } : {})
           },
-          { id: request.url, format, expectRows: true, singular: false }
+          {
+            id: request.url,
+            format,
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {
         params: imageRoute.params,
-        query: querySchema,
         detail: {
           summary:
             'Get Georeference Annotations for a single IIIF Image (with optional version)',

--- a/apis/annotations/src/routes/manifests.ts
+++ b/apis/annotations/src/routes/manifests.ts
@@ -1,17 +1,13 @@
 import { t } from 'elysia'
 
 import { queryMaps } from '@allmaps/api-shared/db'
-import { needsElevatedLimitRole, setCacheControl } from '@allmaps/api-shared'
+import { setCacheControl } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
 
 import type { BetterAuthContext } from '@allmaps/db/auth'
 import type { AnnotationsEnv } from '@allmaps/env/annotations'
 
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
-
-const querySchema = t.Object({
-  limit: t.Optional(t.Number())
-})
 
 export function createManifestsRoutes(
   env: AnnotationsEnv,
@@ -21,29 +17,23 @@ export function createManifestsRoutes(
     .use(createBetterAuthPlugin(betterAuth))
     .get(
       '/manifests/:manifestId',
-      async ({ request, env, db, params, query, set, getLimitRole }) => {
-        const userRole = needsElevatedLimitRole(query.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-medium' : 'private-no-store'
-        )
+      ({ request, env, db, params, set }) => {
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
-          { manifestId: params.manifestId, limit: query.limit, userRole },
+          { manifestId: params.manifestId },
           {
             id: request.url,
             format: 'annotation',
             expectRows: true,
-            singular: false
+            singular: false,
+            resultScope: 'complete'
           }
         )
       },
       {
         params: t.Object({ manifestId: t.String() }),
-        query: querySchema,
         detail: {
           summary: 'Get Georeference Annotations for a single IIIF Manifest',
           tags: ['Manifests']

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -19,7 +19,6 @@ const canvasesQuerySchema = t.Object({
 })
 
 const mapsQuerySchema = t.Object({
-  limit: t.Optional(t.Number()),
   imageServiceDomain: t.Optional(t.String()),
   manifestDomain: t.Optional(t.String()),
   intersects: t.Optional(t.Array(t.Number())),
@@ -106,24 +105,22 @@ export function createCanvasesRoutes(
     )
     .get(
       '/canvases/:canvasId/maps',
-      async ({ request, env, db, params, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const queryParams = normalizeMapsQueryParams(request)
-        const userRole = needsElevatedLimitRole(queryParams.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-short' : 'private-no-store'
-        )
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           {
             ...queryParams,
-            canvasId: params.canvasId,
-            userRole
+            canvasId: params.canvasId
           },
-          { format: 'map', expectRows: true, singular: false }
+          {
+            format: 'map',
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {
@@ -137,24 +134,22 @@ export function createCanvasesRoutes(
     )
     .get(
       '/canvases/:canvasId/maps.geojson',
-      async ({ request, env, db, params, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const queryParams = normalizeMapsQueryParams(request)
-        const userRole = needsElevatedLimitRole(queryParams.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-short' : 'private-no-store'
-        )
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           {
             ...queryParams,
-            canvasId: params.canvasId,
-            userRole
+            canvasId: params.canvasId
           },
-          { format: 'geojson', expectRows: true, singular: false }
+          {
+            format: 'geojson',
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -35,7 +35,6 @@ const createImageBodySchema = t.Union([
 type CreateImageBody = { url: string } | { url: string }[]
 
 const mapsQuerySchema = t.Object({
-  limit: t.Optional(t.Number()),
   imageServiceDomain: t.Optional(t.String()),
   manifestDomain: t.Optional(t.String()),
   intersects: t.Optional(t.Array(t.Number())),
@@ -142,24 +141,22 @@ export function createImagesRoutes(
     )
     .get(
       '/images/:imageId/maps',
-      async ({ request, env, db, params, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const queryParams = normalizeMapsQueryParams(request)
-        const userRole = needsElevatedLimitRole(queryParams.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-short' : 'private-no-store'
-        )
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           {
             ...queryParams,
-            imageId: params.imageId,
-            userRole
+            imageId: params.imageId
           },
-          { format: 'map', expectRows: true, singular: false }
+          {
+            format: 'map',
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {
@@ -173,24 +170,22 @@ export function createImagesRoutes(
     )
     .get(
       '/images/:imageId/maps.geojson',
-      async ({ request, env, db, params, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const queryParams = normalizeMapsQueryParams(request)
-        const userRole = needsElevatedLimitRole(queryParams.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-short' : 'private-no-store'
-        )
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           {
             ...queryParams,
-            imageId: params.imageId,
-            userRole
+            imageId: params.imageId
           },
-          { format: 'geojson', expectRows: true, singular: false }
+          {
+            format: 'geojson',
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {

--- a/apis/rest/src/routes/manifests.ts
+++ b/apis/rest/src/routes/manifests.ts
@@ -21,7 +21,6 @@ import {
 } from '@allmaps/api-shared'
 
 const mapsQuerySchema = t.Object({
-  limit: t.Optional(t.Number()),
   imageServiceDomain: t.Optional(t.String()),
   manifestDomain: t.Optional(t.String()),
   intersects: t.Optional(t.Array(t.Number())),
@@ -129,24 +128,22 @@ export function createManifestsRoutes(
     )
     .get(
       '/manifests/:manifestId/maps',
-      async ({ request, env, db, params, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const queryParams = normalizeMapsQueryParams(request)
-        const userRole = needsElevatedLimitRole(queryParams.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-short' : 'private-no-store'
-        )
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           {
             ...queryParams,
-            manifestId: params.manifestId,
-            userRole
+            manifestId: params.manifestId
           },
-          { format: 'map', expectRows: true, singular: false }
+          {
+            format: 'map',
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {
@@ -160,24 +157,22 @@ export function createManifestsRoutes(
     )
     .get(
       '/manifests/:manifestId/maps.geojson',
-      async ({ request, env, db, params, set, getLimitRole }) => {
+      ({ request, env, db, params, set }) => {
         const queryParams = normalizeMapsQueryParams(request)
-        const userRole = needsElevatedLimitRole(queryParams.limit)
-          ? await getLimitRole()
-          : 'public'
-        setCacheControl(
-          set,
-          userRole === 'public' ? 'public-short' : 'private-no-store'
-        )
+        setCacheControl(set, 'public-medium')
         return queryMaps(
           env.PUBLIC_ANNOTATIONS_BASE_URL,
           db,
           {
             ...queryParams,
-            manifestId: params.manifestId,
-            userRole
+            manifestId: params.manifestId
           },
-          { format: 'geojson', expectRows: true, singular: false }
+          {
+            format: 'geojson',
+            expectRows: true,
+            singular: false,
+            resultScope: 'complete'
+          }
         )
       },
       {

--- a/packages/api-shared/src/queries/maps.ts
+++ b/packages/api-shared/src/queries/maps.ts
@@ -78,7 +78,8 @@ export async function queryMaps(
   const defaultResponseOptions: ResponseOptions = {
     format: 'map',
     expectRows: false,
-    singular: true
+    singular: true,
+    resultScope: 'bounded'
   }
 
   responseOptions = {
@@ -251,7 +252,9 @@ export async function queryMaps(
     },
     limit: responseOptions.singular
       ? 1
-      : clampLimit(params.limit, params.userRole)
+      : responseOptions.resultScope === 'complete'
+        ? undefined
+        : clampLimit(params.limit, params.userRole)
   })
 
   if (responseOptions.expectRows && rows.length === 0) {

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -70,6 +70,7 @@ export type ResponseOptions = {
   format: ResponseFormat
   expectRows: boolean
   singular: boolean
+  resultScope: 'bounded' | 'complete'
   id?: string
 }
 


### PR DESCRIPTION
## Summary

- distinguish bounded collection queries from complete resource responses
- return all maps for manifest, canvas, and image Annotation API routes
- return all matching maps from the corresponding REST and GeoJSON resource routes
- remove limit-role handling and limit parameters from complete-resource endpoints

## Why

Identifier-scoped IIIF resource endpoints represent a complete set of associated maps. Applying the shared collection limit could silently truncate those responses and produce incomplete rendered manifests, canvases, or images.

## Validation

- `pnpm --filter "@allmaps/api-shared" run types`
- `pnpm exec tsc --noEmit -p apis/annotations/tsconfig.json`
- `pnpm exec tsc --noEmit -p apis/rest/tsconfig.json`
- ESLint and Prettier checks for changed files

Route-level tests are intentionally deferred to a follow-up covering all API routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Canvas, image, and manifest map and GeoJSON endpoints now return complete annotation results instead of limiting responses.
  * Removed support for the `limit` query parameter from these endpoints.
  * Results now consistently use public caching behavior, improving predictable access and cache performance.
  * Updated response handling to clearly distinguish complete results from bounded result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->