### PR TITLE
Improve console organization forms

### DIFF
--- a/apps/console/src/lib/remote-form.ts
+++ b/apps/console/src/lib/remote-form.ts
@@ -1,0 +1,9 @@
+type SubmittableRemoteForm = {
+  submit: () => Promise<boolean>
+}
+
+export async function submitRemoteFormWithoutReset(
+  form: SubmittableRemoteForm
+) {
+  await form.submit()
+}

--- a/apps/console/src/routes/organizations/[organizationId]/+page.svelte
+++ b/apps/console/src/routes/organizations/[organizationId]/+page.svelte
@@ -28,6 +28,7 @@
 
   let editOrgName = $derived(organization.name)
   let editOrgSlug = $derived(organization.slug)
+  let editLogo = $derived(organization.logo ?? '')
   let editHomepage = $derived(organization.homepage ?? '')
   let editPlan = $derived<OrganizationPlan | ''>(organization.plan ?? '')
   let editDisplayCollections = $derived(organization.displayCollections)
@@ -41,6 +42,7 @@
   )
   let editDomains = $derived<string[]>([...(organization.domains ?? [])])
   let error = $state<string | null>(null)
+  let logoPreviewFailed = $state(false)
 
   let showAddMemberModal = $state(false)
   let newMemberEmail = $state('')
@@ -115,6 +117,25 @@
         )
       : userItems
   )
+
+  function getHttpUrl(value: string) {
+    try {
+      const url = new URL(value.trim())
+
+      return url.protocol === 'http:' || url.protocol === 'https:'
+        ? url.toString()
+        : null
+    } catch {
+      return null
+    }
+  }
+
+  const logoPreviewUrl = $derived(getHttpUrl(editLogo))
+
+  $effect.pre(() => {
+    void logoPreviewUrl
+    logoPreviewFailed = false
+  })
 
   $effect.pre(() => {
     // Reset transient UI state when navigating between organization routes.
@@ -319,6 +340,47 @@
           class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
           placeholder="https://example.com"
         />
+      </div>
+
+      <div>
+        <label
+          for="orgLogo"
+          class="block text-sm font-medium text-gray-700 mb-2"
+        >
+          Logo URL
+        </label>
+        <input
+          id="orgLogo"
+          type="url"
+          name="logo"
+          bind:value={editLogo}
+          pattern="https?://.*"
+          class="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="https://example.com/logo.svg"
+        />
+
+        {#if logoPreviewUrl && !logoPreviewFailed}
+          <div
+            class="mt-3 flex min-h-24 items-center justify-center rounded border border-gray-200 bg-gray-50 p-4"
+          >
+            <img
+              src={logoPreviewUrl}
+              alt={`${editOrgName || 'Organization'} logo preview`}
+              class="max-h-32 max-w-full object-contain"
+              loading="lazy"
+              referrerpolicy="no-referrer"
+              onerror={() => (logoPreviewFailed = true)}
+            />
+          </div>
+        {:else if logoPreviewUrl && logoPreviewFailed}
+          <p class="mt-2 text-sm text-red-600">
+            The logo could not be loaded from this URL.
+          </p>
+        {:else if editLogo.trim()}
+          <p class="mt-2 text-sm text-red-600">
+            Enter an absolute URL starting with http:// or https://.
+          </p>
+        {/if}
       </div>
 
       <div>

--- a/apps/console/src/routes/organizations/[organizationId]/+page.svelte
+++ b/apps/console/src/routes/organizations/[organizationId]/+page.svelte
@@ -6,6 +6,7 @@
   import AppSelect from '$lib/components/AppSelect.svelte'
   import { CONSOLE_LIST_LIMIT } from '$lib/limits.js'
   import { organizationPlanItems } from '$lib/organization-plans.js'
+  import { submitRemoteFormWithoutReset } from '$lib/remote-form.js'
   import { orgMemberRoleItems } from '$lib/select-items'
   import { getUserId } from '$lib/organizations.js'
   import { routes } from '$lib/routes.js'
@@ -18,22 +19,28 @@
   } from '../organizations.remote.js'
   import { getUsers } from '../../users/users.remote.js'
   import type { OrganizationPlan } from '$lib/organization-plans.js'
-  import type { ConsoleUser, Organization } from '$lib/types.js'
+  import type { ConsoleUser } from '$lib/types.js'
   import type { PageProps } from './$types.js'
 
   let { data }: PageProps = $props()
   const organizationId = $derived(data.organizationId)
   const organization = $derived(data.organization)
 
-  let editOrgName = $state('')
-  let editOrgSlug = $state('')
-  let editHomepage = $state('')
-  let editPlan = $state<OrganizationPlan | ''>('')
-  let editDisplayCollections = $state(false)
-  let editLocation = $state('')
-  let editDomains = $state<string[]>([])
+  let editOrgName = $derived(organization.name)
+  let editOrgSlug = $derived(organization.slug)
+  let editHomepage = $derived(organization.homepage ?? '')
+  let editPlan = $derived<OrganizationPlan | ''>(organization.plan ?? '')
+  let editDisplayCollections = $derived(organization.displayCollections)
+  let editLocation = $derived(
+    organization.location
+      ? [
+          organization.location.coordinates[1],
+          organization.location.coordinates[0]
+        ].join(', ')
+      : ''
+  )
+  let editDomains = $derived<string[]>([...(organization.domains ?? [])])
   let error = $state<string | null>(null)
-  let initializedOrganizationId = $state<string | null>(null)
 
   let showAddMemberModal = $state(false)
   let newMemberEmail = $state('')
@@ -109,33 +116,9 @@
       : userItems
   )
 
-  function initializeOrganizationForm(nextOrganization: Organization) {
-    editOrgName = nextOrganization.name
-    editOrgSlug = nextOrganization.slug
-    editHomepage = nextOrganization.homepage ?? ''
-    editPlan = nextOrganization.plan ?? ''
-    editDisplayCollections = nextOrganization.displayCollections
-    editLocation = nextOrganization.location
-      ? [
-          nextOrganization.location.coordinates[1],
-          nextOrganization.location.coordinates[0]
-        ].join(', ')
-      : ''
-    editDomains = nextOrganization.domains ?? []
-    initializedOrganizationId = organizationId
-  }
-
-  $effect(() => {
-    // eslint-disable-next-line
-    organizationId
-    editOrgName = ''
-    editOrgSlug = ''
-    editHomepage = ''
-    editPlan = ''
-    editDisplayCollections = false
-    editLocation = ''
-    editDomains = []
-    initializedOrganizationId = null
+  $effect.pre(() => {
+    // Reset transient UI state when navigating between organization routes.
+    void organizationId
     error = null
     showAddMemberModal = false
     newMemberEmail = ''
@@ -150,12 +133,6 @@
     showDeleteModal = false
     deleteConfirmName = ''
     isDeleting = false
-  })
-
-  $effect(() => {
-    if (initializedOrganizationId !== organizationId) {
-      initializeOrganizationForm(organization)
-    }
   })
 
   async function deleteOrganization() {
@@ -283,7 +260,10 @@
     </div>
   {/if}
 
-  <form {...updateOrganizationForm} class="bg-white rounded-lg shadow p-6">
+  <form
+    {...updateOrganizationForm.enhance(submitRemoteFormWithoutReset)}
+    class="bg-white rounded-lg shadow p-6"
+  >
     <input type="hidden" name="organizationId" value={organizationId} />
     <input type="hidden" name="domains" value={editDomains.join('\n')} />
     <div class="space-y-6">

--- a/apps/console/src/routes/organizations/new/+page.svelte
+++ b/apps/console/src/routes/organizations/new/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { submitRemoteFormWithoutReset } from '$lib/remote-form.js'
   import { routes } from '$lib/routes.js'
   import { createOrganizationForm } from '../organizations.remote.js'
 
@@ -19,7 +20,10 @@
   {/if}
 
   <div class="bg-white rounded-lg shadow p-6">
-    <form {...createOrganizationForm} class="space-y-4">
+    <form
+      {...createOrganizationForm.enhance(submitRemoteFormWithoutReset)}
+      class="space-y-4"
+    >
       <div>
         <label
           for="orgName"

--- a/apps/console/src/routes/organizations/organizations.remote.ts
+++ b/apps/console/src/routes/organizations/organizations.remote.ts
@@ -31,6 +31,22 @@ type UpdateOrganizationMemberRoleInput = OrganizationMemberInput & {
 }
 
 const organizationIdSchema = z.string()
+const httpUrlSchema = z
+  .string()
+  .trim()
+  .refine((value) => {
+    if (!value) {
+      return true
+    }
+
+    try {
+      const url = new URL(value)
+      return url.protocol === 'http:' || url.protocol === 'https:'
+    } catch {
+      return false
+    }
+  }, 'Use an absolute http(s) URL')
+  .transform((value) => value || null)
 const slugSchema = z
   .string()
   .trim()
@@ -82,10 +98,8 @@ const updateOrganizationFormSchema = z.object({
   organizationId: organizationIdSchema,
   name: z.string().trim().min(1),
   slug: slugSchema,
-  homepage: z
-    .string()
-    .trim()
-    .transform((value) => value || null),
+  logo: httpUrlSchema,
+  homepage: httpUrlSchema,
   plan: z
     .union([z.enum(ORGANIZATION_PLANS), z.literal('')])
     .transform((value) => value || null),

--- a/apps/console/src/routes/profile/lists/new/+page.svelte
+++ b/apps/console/src/routes/profile/lists/new/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createListForm } from '$lib/lists.remote.js'
+  import { submitRemoteFormWithoutReset } from '$lib/remote-form.js'
   import { routes } from '$lib/routes.js'
 </script>
 
@@ -9,7 +10,10 @@
   </div>
 
   <div class="bg-white rounded-lg shadow p-6">
-    <form {...createListForm} class="space-y-4">
+    <form
+      {...createListForm.enhance(submitRemoteFormWithoutReset)}
+      class="space-y-4"
+    >
       <div>
         <label for="name" class="block text-sm font-medium text-gray-700 mb-1">
           Name <span class="text-red-500">*</span>

--- a/apps/console/src/routes/users/[userId]/+page.svelte
+++ b/apps/console/src/routes/users/[userId]/+page.svelte
@@ -3,6 +3,7 @@
   import { Combobox } from 'bits-ui'
 
   import { getOrganizationId } from '$lib/organizations.js'
+  import { submitRemoteFormWithoutReset } from '$lib/remote-form.js'
   import { routes } from '$lib/routes.js'
 
   import UserLists from '$lib/components/UserLists.svelte'
@@ -15,7 +16,6 @@
   import { setUserRole, updateUserForm } from '../users.remote.js'
 
   import type { PageProps } from './$types'
-  import type { ConsoleUser } from '$lib/types.js'
 
   let { data }: PageProps = $props()
 
@@ -25,11 +25,13 @@
 
   const userOrganizations = $derived(user.organizations ?? [])
 
-  let editUserName = $state('')
-  let editUserSlug = $state('')
-  let editUserEmail = $state('')
-  let editUserBanned = $state(false)
-  let editUserRole = $state<'user' | 'admin'>('user')
+  let editUserName = $derived(user.name ?? '')
+  let editUserSlug = $derived(user.slug ?? '')
+  let editUserEmail = $derived(user.email ?? '')
+  let editUserBanned = $derived(user.banned ?? false)
+  let editUserRole = $derived<'user' | 'admin'>(
+    (user.role as 'user' | 'admin') ?? 'user'
+  )
   let isChangingRole = $state(false)
   let selectedOrganizationId = $state('')
   let organizationSearchValue = $state('')
@@ -37,7 +39,6 @@
   let isAddingToOrganization = $state(false)
   let removingOrganizationId = $state<string | null>(null)
   let error = $state<string | null>(null)
-  let initializedUserId = $state<string | null>(null)
 
   const slugPattern = String.raw`^[a-z](?:[a-z0-9\-]*[a-z0-9])?$`
   const userOrganizationIdSet = $derived(
@@ -69,24 +70,9 @@
       : organizationItems
   )
 
-  function initializeUserForm(nextUser: ConsoleUser) {
-    editUserName = nextUser.name || ''
-    editUserSlug = nextUser.slug || ''
-    editUserEmail = nextUser.email || ''
-    editUserBanned = nextUser.banned || false
-    editUserRole = (nextUser.role as 'user' | 'admin') || 'user'
-    initializedUserId = userId
-  }
-
-  $effect(() => {
-    // eslint-disable-next-line
-    userId
-    editUserName = ''
-    editUserSlug = ''
-    editUserEmail = ''
-    editUserBanned = false
-    editUserRole = 'user'
-    initializedUserId = null
+  $effect.pre(() => {
+    // Reset transient UI state when navigating between user routes.
+    void userId
     selectedOrganizationId = ''
     organizationSearchValue = ''
     selectedOrganizationRole = 'member'
@@ -94,12 +80,6 @@
     isAddingToOrganization = false
     removingOrganizationId = null
     error = null
-  })
-
-  $effect(() => {
-    if (initializedUserId !== userId) {
-      initializeUserForm(user)
-    }
   })
 
   async function changeRole() {
@@ -217,7 +197,10 @@
     </div>
   {/if}
 
-  <form {...updateUserForm} class="bg-white rounded-lg shadow p-6">
+  <form
+    {...updateUserForm.enhance(submitRemoteFormWithoutReset)}
+    class="bg-white rounded-lg shadow p-6"
+  >
     <input type="hidden" name="userId" value={userId} />
     <div class="space-y-6">
       <div>


### PR DESCRIPTION
## Summary

- prevent remote form submissions from briefly clearing console form fields before redirecting
- keep editable organization and user form state stable across route data updates
- add an organization logo URL field with inline preview and clear invalid/load-error feedback
- validate organization logo and homepage values as absolute HTTP(S) URLs

## Why

SvelteKit form enhancement resets the HTML form after a successful submission, before the server redirect completes. That made fields flash empty during navigation. The custom enhancement keeps the current values until navigation finishes. The organization form now also exposes the existing logo property in the console.

## Validation

- `pnpm run check` in `apps/console`
- ESLint and Prettier checks for the changed files
- live browser verification of field ordering, successful logo preview, invalid URL feedback, and failed-image feedback

## Stack

This PR is stacked on `org-contributor-plan`; its diff contains only the two commits from `fix-console-form-flicker`. The unrelated uncommitted console lint/tooling changes are not included.