### PR TITLE
Add contributor organization plan

### DIFF
--- a/apis/rest/src/routes/organizations.ts
+++ b/apis/rest/src/routes/organizations.ts
@@ -26,6 +26,7 @@ import {
   queryManifests
 } from '@allmaps/api-shared/db'
 import {
+  ORGANIZATION_PLANS,
   needsElevatedLimitRole,
   normalizeOrganizationsQueryParams,
   setCacheControl
@@ -39,7 +40,26 @@ const OrganizationBody = t.Object({
   slug: t.String(),
   logo: t.Optional(t.Nullable(t.String())),
   homepage: t.Optional(t.Nullable(t.String())),
-  plan: t.Optional(t.Nullable(t.UnionEnum(['supporter', 'innovator']))),
+  plan: t.Optional(t.Nullable(t.UnionEnum(ORGANIZATION_PLANS))),
+  displayCollections: t.Optional(t.Boolean()),
+  location: t.Optional(
+    t.Nullable(
+      t.Object({
+        type: t.Literal('Point'),
+        coordinates: t.Tuple([t.Number(), t.Number()])
+      })
+    )
+  ),
+  domains: t.Optional(t.Array(t.String()))
+})
+
+const UpdateOrganizationBody = t.Object({
+  name: t.Optional(t.String()),
+  slug: t.Optional(t.String()),
+  logo: t.Optional(t.Nullable(t.String())),
+  homepage: t.Optional(t.Nullable(t.String())),
+  plan: t.Optional(t.Nullable(t.UnionEnum(ORGANIZATION_PLANS))),
+  displayCollections: t.Optional(t.Boolean()),
   location: t.Optional(
     t.Nullable(
       t.Object({
@@ -65,12 +85,13 @@ type CreateIiifBody = { url: string } | { url: string }[]
 
 const organizationMutationDetail = {
   security: [{ sessionCookie: [] }],
-  'x-badges': [{ name: 'Admin or paid organization member', color: '#df0' }]
+  'x-badges': [{ name: 'Admin or organization plan member', color: '#df0' }]
 }
 
 const organizationsQuerySchema = t.Object({
   limit: t.Optional(t.Number()),
-  plan: t.Optional(t.Array(t.UnionEnum(['supporter', 'innovator'])))
+  plan: t.Optional(t.Array(t.UnionEnum(ORGANIZATION_PLANS))),
+  displayCollections: t.Optional(t.Boolean())
 })
 
 async function createIiifFromBody<T>(
@@ -294,7 +315,7 @@ export function createOrganizationsRoutes(
           id: params.organizationId
         })
 
-        if (userRole !== 'admin' && userRole !== 'paidOrganizationMember') {
+        if (userRole !== 'admin' && userRole !== 'organizationPlanMember') {
           return status(403, { error: 'Forbidden' })
         }
 
@@ -408,7 +429,7 @@ export function createOrganizationsRoutes(
           id: params.organizationId
         })
 
-        if (userRole !== 'admin' && userRole !== 'paidOrganizationMember') {
+        if (userRole !== 'admin' && userRole !== 'organizationPlanMember') {
           return status(403, { error: 'Forbidden' })
         }
 
@@ -570,7 +591,7 @@ export function createOrganizationsRoutes(
       {
         admin: true,
         params: t.Object({ organizationId: t.String() }),
-        body: t.Partial(OrganizationBody),
+        body: UpdateOrganizationBody,
         detail: {
           summary: 'Update an organization',
           tags: ['Organizations'],

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -41,6 +41,7 @@
     "wrangler": "catalog:"
   },
   "dependencies": {
+    "@allmaps/api-shared": "workspace:^",
     "@allmaps/env": "workspace:^",
     "@allmaps/tailwind": "workspace:^",
     "@allmaps/ui": "workspace:^",

--- a/apps/console/src/lib/organization-plans.ts
+++ b/apps/console/src/lib/organization-plans.ts
@@ -1,0 +1,40 @@
+import {
+  ORGANIZATION_PLANS,
+  type OrganizationPlan
+} from '@allmaps/api-shared/tiers'
+
+export { ORGANIZATION_PLANS }
+export type { OrganizationPlan }
+
+export const organizationPlanDetails = {
+  contributor: {
+    label: 'Contributor',
+    icon: '🤝',
+    class: 'bg-blue-100 text-blue-700'
+  },
+  supporter: {
+    label: 'Supporter',
+    icon: '🌱',
+    class: 'bg-green-100 text-green-700'
+  },
+  innovator: {
+    label: 'Innovator',
+    icon: '🚀',
+    class: 'bg-purple-100 text-purple-700'
+  }
+} satisfies Record<
+  OrganizationPlan,
+  { label: string; icon: string; class: string }
+>
+
+export const organizationPlanItems = [
+  { value: '', label: '— No plan' },
+  ...ORGANIZATION_PLANS.map((plan) => ({
+    value: plan,
+    label: `${organizationPlanDetails[plan].icon} ${organizationPlanDetails[plan].label}`
+  }))
+]
+
+export const organizationPlanOrder = Object.fromEntries(
+  ORGANIZATION_PLANS.map((plan, index) => [plan, index + 1])
+) as Record<OrganizationPlan, number>

--- a/apps/console/src/lib/select-items.ts
+++ b/apps/console/src/lib/select-items.ts
@@ -1,9 +1,3 @@
-export const planItems = [
-  { value: '', label: '— No plan' },
-  { value: 'supporter', label: '🌱 Supporter' },
-  { value: 'innovator', label: '🚀 Innovator' }
-]
-
 export const userRoleItems = [
   { value: 'user', label: '👤 User' },
   { value: 'admin', label: '🛡️ Admin' }

--- a/apps/console/src/lib/types.ts
+++ b/apps/console/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { OrganizationPlan } from '$lib/organization-plans.js'
+
 export type Organization = {
   id: string
   name: string
@@ -10,7 +12,8 @@ export type Organization = {
   } | null
   createdAt: string
   domains: string[]
-  plan: 'supporter' | 'innovator' | null
+  plan: OrganizationPlan | null
+  displayCollections: boolean
   users?: {
     role: string
     createdAt: string

--- a/apps/console/src/routes/organizations/+page.svelte
+++ b/apps/console/src/routes/organizations/+page.svelte
@@ -6,6 +6,10 @@
   import SearchFilter from '$lib/components/SearchFilter.svelte'
   import DataTable from '$lib/components/DataTable.svelte'
   import { getOrganizationId, getUserId } from '$lib/organizations.js'
+  import {
+    organizationPlanDetails,
+    organizationPlanOrder
+  } from '$lib/organization-plans.js'
   import { routes } from '$lib/routes.js'
   import {
     getSearchField,
@@ -31,8 +35,6 @@
 
   let sortBy = $state(getSortField(page.url, organizationSortFields, 'plan'))
   let sortDir = $state(getSortDirection(page.url, 'desc'))
-
-  const planOrder: Record<string, number> = { supporter: 1, innovator: 2 }
 
   function replaceTableState({
     nextSearchValue = searchValue,
@@ -130,8 +132,8 @@
         av = new Date(a.createdAt).getTime()
         bv = new Date(b.createdAt).getTime()
       } else if (sortBy === 'plan') {
-        av = planOrder[a.plan ?? ''] ?? 0
-        bv = planOrder[b.plan ?? ''] ?? 0
+        av = a.plan ? organizationPlanOrder[a.plan] : 0
+        bv = b.plan ? organizationPlanOrder[b.plan] : 0
       } else {
         av = a[sortBy] ?? ''
         bv = b[sortBy] ?? ''
@@ -286,17 +288,14 @@
                 </div>
               </td>
               <td class="px-3 py-2 @lg:px-4 @lg:py-3 whitespace-nowrap">
-                {#if organization.plan === 'supporter'}
+                {#if organization.plan}
+                  {@const planDetails =
+                    organizationPlanDetails[organization.plan]}
                   <span
-                    class="rounded px-2 py-0.5 font-sans text-xs font-medium bg-green-100 text-green-700"
+                    class="rounded px-2 py-0.5 font-sans text-xs font-medium {planDetails.class}"
                   >
-                    🌱 Supporter
-                  </span>
-                {:else if organization.plan === 'innovator'}
-                  <span
-                    class="rounded px-2 py-0.5 font-sans text-xs font-medium bg-purple-100 text-purple-700"
-                  >
-                    🚀 Innovator
+                    {planDetails.icon}
+                    {planDetails.label}
                   </span>
                 {:else}
                   <span class="font-sans text-xs text-gray-300">—</span>

--- a/apps/console/src/routes/organizations/[organizationId]/+page.svelte
+++ b/apps/console/src/routes/organizations/[organizationId]/+page.svelte
@@ -5,7 +5,8 @@
 
   import AppSelect from '$lib/components/AppSelect.svelte'
   import { CONSOLE_LIST_LIMIT } from '$lib/limits.js'
-  import { planItems, orgMemberRoleItems } from '$lib/select-items'
+  import { organizationPlanItems } from '$lib/organization-plans.js'
+  import { orgMemberRoleItems } from '$lib/select-items'
   import { getUserId } from '$lib/organizations.js'
   import { routes } from '$lib/routes.js'
   import {
@@ -16,6 +17,7 @@
     updateOrganizationMemberRole
   } from '../organizations.remote.js'
   import { getUsers } from '../../users/users.remote.js'
+  import type { OrganizationPlan } from '$lib/organization-plans.js'
   import type { ConsoleUser, Organization } from '$lib/types.js'
   import type { PageProps } from './$types.js'
 
@@ -26,7 +28,8 @@
   let editOrgName = $state('')
   let editOrgSlug = $state('')
   let editHomepage = $state('')
-  let editPlan = $state<'supporter' | 'innovator' | ''>('')
+  let editPlan = $state<OrganizationPlan | ''>('')
+  let editDisplayCollections = $state(false)
   let editLocation = $state('')
   let editDomains = $state<string[]>([])
   let error = $state<string | null>(null)
@@ -111,6 +114,7 @@
     editOrgSlug = nextOrganization.slug
     editHomepage = nextOrganization.homepage ?? ''
     editPlan = nextOrganization.plan ?? ''
+    editDisplayCollections = nextOrganization.displayCollections
     editLocation = nextOrganization.location
       ? [
           nextOrganization.location.coordinates[1],
@@ -128,6 +132,7 @@
     editOrgSlug = ''
     editHomepage = ''
     editPlan = ''
+    editDisplayCollections = false
     editLocation = ''
     editDomains = []
     initializedOrganizationId = null
@@ -343,9 +348,26 @@
         >
           Plan
         </label>
-        <AppSelect bind:value={editPlan} items={planItems} />
+        <AppSelect bind:value={editPlan} items={organizationPlanItems} />
         <input type="hidden" name="plan" value={editPlan} />
       </div>
+
+      <label class="flex items-start gap-3">
+        <input
+          type="checkbox"
+          name="displayCollections"
+          bind:checked={editDisplayCollections}
+          class="mt-1 size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+        />
+        <span>
+          <span class="block text-sm font-medium text-gray-700">
+            Display collections across Allmaps
+          </span>
+          <span class="block text-sm text-gray-500">
+            Include this organization's collections in public discovery views.
+          </span>
+        </span>
+      </label>
 
       <div>
         <label

--- a/apps/console/src/routes/organizations/organizations.remote.ts
+++ b/apps/console/src/routes/organizations/organizations.remote.ts
@@ -3,6 +3,7 @@ import { redirect } from '@sveltejs/kit'
 
 import { restFetch } from '$lib/server/rest.js'
 import { routes } from '$lib/routes.js'
+import { ORGANIZATION_PLANS } from '$lib/organization-plans.js'
 import { z } from 'zod'
 
 import type { Organization } from '$lib/types.js'
@@ -86,8 +87,12 @@ const updateOrganizationFormSchema = z.object({
     .trim()
     .transform((value) => value || null),
   plan: z
-    .union([z.enum(['supporter', 'innovator']), z.literal('')])
+    .union([z.enum(ORGANIZATION_PLANS), z.literal('')])
     .transform((value) => value || null),
+  displayCollections: z
+    .union([z.literal('true'), z.literal('on'), z.literal(true)])
+    .optional()
+    .transform(Boolean),
   location: z.string().transform(parseLocationInput),
   domains: z.string().transform((value) =>
     value

--- a/packages/api-shared/package.json
+++ b/packages/api-shared/package.json
@@ -16,6 +16,7 @@
     "./db": "./dist/db.js",
     "./elysia": "./dist/elysia.js",
     "./shared": "./dist/shared.js",
+    "./tiers": "./dist/shared/tiers.js",
     "./types": "./dist/types.js",
     "./projections": "./dist/projections.js"
   },

--- a/packages/api-shared/src/elysia/auth.ts
+++ b/packages/api-shared/src/elysia/auth.ts
@@ -8,10 +8,12 @@ import { ResponseError } from '../shared/errors.js'
 import { createElysia } from './app.js'
 import { setCacheControl } from './cache.js'
 import { redirect } from './response.js'
+import {
+  isOrganizationPlan,
+  ORGANIZATION_PLANS_WITH_ELEVATED_LIMITS
+} from '../shared/tiers.js'
 
 import type { UserRole } from '../shared/limits.js'
-
-const PAID_ORGANIZATION_PLANS = new Set(['supporter', 'innovator'])
 
 function copySetCookieHeader(
   response: Response,
@@ -111,9 +113,10 @@ export function createBetterAuthPlugin<TEnv = Record<string, unknown>>(
 
           if (
             membership?.plan &&
-            PAID_ORGANIZATION_PLANS.has(membership.plan)
+            isOrganizationPlan(membership.plan) &&
+            ORGANIZATION_PLANS_WITH_ELEVATED_LIMITS.has(membership.plan)
           ) {
-            return 'paidOrganizationMember'
+            return 'organizationPlanMember'
           }
 
           return 'user'

--- a/packages/api-shared/src/index.ts
+++ b/packages/api-shared/src/index.ts
@@ -13,12 +13,18 @@ export {
   DEFAULT_LIMIT,
   PUBLIC_MAX_LIMIT,
   USER_MAX_LIMIT,
-  PAID_ORGANIZATION_MEMBER_MAX_LIMIT,
+  ORGANIZATION_PLAN_MEMBER_MAX_LIMIT,
   ADMIN_MAX_LIMIT,
   clampLimit,
   needsElevatedLimitRole
 } from './shared/limits.js'
 export type { UserRole } from './shared/limits.js'
+export {
+  ORGANIZATION_PLANS,
+  ORGANIZATION_PLANS_WITH_ELEVATED_LIMITS,
+  isOrganizationPlan
+} from './shared/tiers.js'
+export type { OrganizationPlan } from './shared/tiers.js'
 export {
   normalizeMapsQueryParams,
   normalizeOrganizationsQueryParams

--- a/packages/api-shared/src/queries/organizations.ts
+++ b/packages/api-shared/src/queries/organizations.ts
@@ -25,6 +25,7 @@ type DbOrganization = {
   logo: string | null
   homepage: string | null
   plan: string | null
+  displayCollections: boolean
   location: OrganizationLocation | null
   createdAt: Date
   updatedAt?: Date
@@ -37,6 +38,7 @@ type DbOrganization = {
 type ListOrganizationsOptions = {
   limit?: number
   plans?: OrganizationPlan[]
+  displayCollections?: boolean
   userRole?: UserRole
 }
 
@@ -217,6 +219,7 @@ export function fromDbOrganization(
     logo: dbOrganization.logo,
     homepage: dbOrganization.homepage,
     plan: dbOrganization.plan,
+    displayCollections: dbOrganization.displayCollections,
     location: dbOrganization.location,
     createdAt: dbOrganization.createdAt,
     domains: dbOrganization.urls
@@ -247,13 +250,13 @@ export function fromDbOrganizationWithUsers(
   }
 }
 
-function getOrganizationPlanWhere(plans?: OrganizationPlan[]) {
-  if (plans && plans.length > 0) {
-    return {
-      plan: {
-        in: plans
-      }
-    }
+function getOrganizationsWhere(options: ListOrganizationsOptions) {
+  return {
+    plan:
+      options.plans && options.plans.length > 0
+        ? { in: options.plans }
+        : undefined,
+    displayCollections: options.displayCollections
   }
 }
 
@@ -303,7 +306,7 @@ export async function listOrganizations(
     with: {
       urls: true
     },
-    where: getOrganizationPlanWhere(options.plans),
+    where: getOrganizationsWhere(options),
     orderBy: (organizations, { asc }) => asc(organizations.name),
     limit: clampLimit(options.limit, options.userRole)
   })
@@ -323,7 +326,7 @@ export async function listOrganizationsWithUsers(
       with: {
         urls: true
       },
-      where: getOrganizationPlanWhere(options.plans),
+      where: getOrganizationsWhere(options),
       orderBy: (organizations, { asc }) => asc(organizations.name),
       limit: clampLimit(options.limit, options.userRole)
     }),
@@ -350,7 +353,7 @@ export async function listOrganizationsWithUsersByOrganizationIds(
       with: {
         urls: true
       },
-      where: getOrganizationPlanWhere(options.plans),
+      where: getOrganizationsWhere(options),
       orderBy: (organizations, { asc }) => asc(organizations.name),
       limit: clampLimit(options.limit, options.userRole)
     }),
@@ -447,7 +450,8 @@ export async function createOrganization(
     slug: string
     logo?: string | null
     homepage?: string | null
-    plan?: 'supporter' | 'innovator' | null
+    plan?: OrganizationPlan | null
+    displayCollections?: boolean
     location?: OrganizationLocation | null
     domains?: string[]
   }
@@ -471,6 +475,7 @@ export async function createOrganization(
       logo: data.logo ?? null,
       homepage: data.homepage ?? null,
       plan: data.plan ?? null,
+      displayCollections: data.displayCollections ?? false,
       location: data.location ?? null,
       createdAt: new Date()
     })
@@ -491,7 +496,8 @@ export async function updateOrganization(
     slug: string
     logo: string | null
     homepage: string | null
-    plan: 'supporter' | 'innovator' | null
+    plan: OrganizationPlan | null
+    displayCollections: boolean
     location: OrganizationLocation | null
   }>,
   domains?: string[]

--- a/packages/api-shared/src/shared/limits.ts
+++ b/packages/api-shared/src/shared/limits.ts
@@ -1,23 +1,19 @@
-export const DEFAULT_LIMIT = 50
+import { DEFAULT_LIMIT, MAX_LIMITS, PUBLIC_MAX_LIMIT } from './tiers.js'
 
-export const PUBLIC_MAX_LIMIT = 200
-export const USER_MAX_LIMIT = 400
-export const PAID_ORGANIZATION_MEMBER_MAX_LIMIT = 600
-export const ADMIN_MAX_LIMIT = 600
+import type { UserRole } from './tiers.js'
 
-export const PUBLIC_MAX_PAGES = 5
-export const USER_MAX_PAGES = 10
-export const PAID_ORGANIZATION_MEMBER_MAX_PAGES = undefined // no limit
-export const ADMIN_MAX_PAGES = undefined // no limit
-
-export type UserRole = 'public' | 'user' | 'paidOrganizationMember' | 'admin'
-
-const MAX_LIMITS: Record<UserRole, number> = {
-  public: PUBLIC_MAX_LIMIT,
-  user: USER_MAX_LIMIT,
-  admin: ADMIN_MAX_LIMIT,
-  paidOrganizationMember: PAID_ORGANIZATION_MEMBER_MAX_LIMIT
-}
+export {
+  ADMIN_MAX_LIMIT,
+  ADMIN_MAX_PAGES,
+  DEFAULT_LIMIT,
+  ORGANIZATION_PLAN_MEMBER_MAX_LIMIT,
+  ORGANIZATION_PLAN_MEMBER_MAX_PAGES,
+  PUBLIC_MAX_LIMIT,
+  PUBLIC_MAX_PAGES,
+  USER_MAX_LIMIT,
+  USER_MAX_PAGES
+} from './tiers.js'
+export type { UserRole } from './tiers.js'
 
 function getMaxLimitForRole(role: UserRole): number {
   return MAX_LIMITS[role]

--- a/packages/api-shared/src/shared/query-params.ts
+++ b/packages/api-shared/src/shared/query-params.ts
@@ -1,4 +1,5 @@
 import { ResponseError } from './errors.js'
+import { isOrganizationPlan } from './tiers.js'
 
 import type {
   ContainedBy,
@@ -34,8 +35,6 @@ const mapsQueryParamNames: Record<string, MapsQueryParamName> = {
   modifiedafter: 'modifiedAfter',
   modifiedbefore: 'modifiedBefore'
 }
-
-const organizationPlans = new Set<OrganizationPlan>(['supporter', 'innovator'])
 
 const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/
 const utcDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
@@ -98,8 +97,8 @@ function parseContainedBy(containedBy?: number[]): ContainedBy | undefined {
 }
 
 function parseOrganizationPlanParam(value: string) {
-  if (organizationPlans.has(value as OrganizationPlan)) {
-    return value as OrganizationPlan
+  if (isOrganizationPlan(value)) {
+    return value
   }
 
   throw new ResponseError(`Invalid query parameter plan: ${value}`, 400)
@@ -119,6 +118,15 @@ export function normalizeOrganizationsQueryParams(
         break
       case 'plan':
         plans.add(parseOrganizationPlanParam(value))
+        break
+      case 'displaycollections':
+        if (value !== 'true' && value !== 'false') {
+          throw new ResponseError(
+            `Invalid query parameter displayCollections: ${value}`,
+            400
+          )
+        }
+        params.displayCollections = value === 'true'
         break
     }
   }

--- a/packages/api-shared/src/shared/tiers.ts
+++ b/packages/api-shared/src/shared/tiers.ts
@@ -1,0 +1,35 @@
+export const ORGANIZATION_PLANS = [
+  'contributor',
+  'supporter',
+  'innovator'
+] as const
+
+export type OrganizationPlan = (typeof ORGANIZATION_PLANS)[number]
+
+export const ORGANIZATION_PLANS_WITH_ELEVATED_LIMITS =
+  new Set<OrganizationPlan>(ORGANIZATION_PLANS)
+
+export type UserRole = 'public' | 'user' | 'organizationPlanMember' | 'admin'
+
+export const DEFAULT_LIMIT = 50
+
+export const PUBLIC_MAX_LIMIT = 200
+export const USER_MAX_LIMIT = 400
+export const ORGANIZATION_PLAN_MEMBER_MAX_LIMIT = 600
+export const ADMIN_MAX_LIMIT = 600
+
+export const PUBLIC_MAX_PAGES = 5
+export const USER_MAX_PAGES = 10
+export const ORGANIZATION_PLAN_MEMBER_MAX_PAGES = undefined // no limit
+export const ADMIN_MAX_PAGES = undefined // no limit
+
+export const MAX_LIMITS: Record<UserRole, number> = {
+  public: PUBLIC_MAX_LIMIT,
+  user: USER_MAX_LIMIT,
+  organizationPlanMember: ORGANIZATION_PLAN_MEMBER_MAX_LIMIT,
+  admin: ADMIN_MAX_LIMIT
+}
+
+export function isOrganizationPlan(value: string): value is OrganizationPlan {
+  return ORGANIZATION_PLANS.includes(value as OrganizationPlan)
+}

--- a/packages/api-shared/src/types.ts
+++ b/packages/api-shared/src/types.ts
@@ -5,10 +5,12 @@ import type { LanguageString } from '@allmaps/iiif-parser'
 
 import type { DbMap } from '@allmaps/db'
 import type { UserRole } from './shared/limits.js'
+import type { OrganizationPlan } from './shared/tiers.js'
+
+export type { OrganizationPlan } from './shared/tiers.js'
 
 export type IntersectsWith = [number, number] | [number, number, number, number]
 export type ContainedBy = [number, number, number, number]
-export type OrganizationPlan = 'supporter' | 'innovator'
 export type OrganizationLocation = {
   type: 'Point'
   coordinates: [number, number]
@@ -17,6 +19,7 @@ export type OrganizationLocation = {
 export type OrganizationsQueryParams = {
   limit: number
   plans: OrganizationPlan[]
+  displayCollections: boolean
 }
 
 export type MapsQueryParams = {

--- a/packages/db/drizzle/20260818134939_add-organization-display-collections/migration.sql
+++ b/packages/db/drizzle/20260818134939_add-organization-display-collections/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "organizations" ADD COLUMN "display_collections" boolean DEFAULT false NOT NULL;
+
+UPDATE "organizations"
+SET "display_collections" = true
+WHERE "id" IN (
+  '669272abb8d042cf',
+  '0bcc9ac59b49a7f1',
+  '4518d5c2330a4e2d',
+  '90f909b0cba8e7ea',
+  '419dacef25f44964',
+  '7fb217695fea4770',
+  'bc8296fa46cc4727'
+);

--- a/packages/db/drizzle/20260818134939_add-organization-display-collections/snapshot.json
+++ b/packages/db/drizzle/20260818134939_add-organization-display-collections/snapshot.json
@@ -1,0 +1,3158 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "92995a07-c4c9-4c6b-8c82-fac841587e14",
+  "prevIds": [
+    "1157fe37-fc0e-4937-a5f9-e0f9608d012e"
+  ],
+  "ddl": [
+    {
+      "name": "iiif",
+      "entityType": "schemas"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "canvases",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "canvases_images",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "images",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "manifests",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "manifests_canvases",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "list_items",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "lists",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "maps",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organization_urls",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ops",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "snapshots",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "homepage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "display_collections",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "full_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_anonymous",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"canvases\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"images\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "embedded",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"manifests\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "manifest_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "list_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "manifest_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "deletable",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "latest",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "geometry(Polygon)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_mask",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "geometry(Polygon,4326)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "geo_mask",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "CASE WHEN \"maps\".\"geo_mask\" IS NOT NULL THEN ST_Area(geography(\"maps\".\"geo_mask\")) ELSE NULL END",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "area",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "CASE WHEN ST_Area(geography(\"maps\".\"geo_mask\")) > 0 THEN sqrt(ST_Area(\"maps\".\"resource_mask\") / ST_Area(geography(\"maps\".\"geo_mask\"))) ELSE NULL END",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "scale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operation",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"slug\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_canvas_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_image_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_composite_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "images_domain_index",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_domain_index",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_manifest_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_canvas_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_composite_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_checksum",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"map_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_map_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"image_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_image_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"canvas_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_canvas_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"manifest_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_manifest_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "checksum",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_checksum_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_image_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"latest\" = true",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_latest_image_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "latest",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_latest_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_updated_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "geo_mask",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "GIST",
+      "concurrently": false,
+      "name": "maps_geo_mask_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_urls_organization_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "url",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_urls_url_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "canvases_images_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "canvases_images_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "manifest_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "manifests",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "manifests_canvases_manifest_id_manifests_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "manifests_canvases_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "list_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_list_id_lists_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "manifest_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "manifests",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_manifest_id_manifests_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "map_id",
+        "map_image_id",
+        "map_checksum",
+        "map_version"
+      ],
+      "schemaTo": "public",
+      "tableTo": "maps",
+      "columnsTo": [
+        "id",
+        "image_id",
+        "checksum",
+        "version"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_DOUrIXsmsloB_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "lists_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "maps_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_urls_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "columns": [
+        "canvas_id",
+        "image_id"
+      ],
+      "nameExplicit": false,
+      "name": "canvases_images_pkey",
+      "entityType": "pks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "columns": [
+        "manifest_id",
+        "canvas_id"
+      ],
+      "nameExplicit": false,
+      "name": "manifests_canvases_pkey",
+      "entityType": "pks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "columns": [
+        "id",
+        "image_id",
+        "checksum",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "maps_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "columns": [
+        "organization_id",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "organization_urls_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "columns": [
+        "collection",
+        "doc_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "ops_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "columns": [
+        "collection",
+        "doc_id"
+      ],
+      "nameExplicit": false,
+      "name": "snapshots_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "public",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "public",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "public",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "public",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "canvases_pkey",
+      "schema": "iiif",
+      "table": "canvases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "images_pkey",
+      "schema": "iiif",
+      "table": "images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "manifests_pkey",
+      "schema": "iiif",
+      "table": "manifests",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "lists_pkey",
+      "schema": "public",
+      "table": "lists",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_urls_url_key",
+      "schema": "public",
+      "table": "organization_urls",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"slug\" ~ '^[a-z](?:[a-z0-9-]*[a-z0-9])?$'",
+      "name": "organizations_slug_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "value": "\"slug\" IS NULL OR \"slug\" ~ '^[a-z](?:[a-z0-9-]*[a-z0-9])?$'",
+      "name": "users_slug_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "value": "\n      (\n        num_nonnulls(\"image_id\", \"canvas_id\", \"manifest_id\") = 1\n        AND\n        \"map_id\" IS NULL AND \"map_version\" IS NULL AND \"map_image_id\" IS NULL AND \"map_checksum\" IS NULL\n      ) OR (\n        num_nonnulls(\"image_id\", \"canvas_id\", \"manifest_id\") = 0\n        AND\n        \"map_id\" IS NOT NULL AND \"map_version\" IS NOT NULL AND \"map_image_id\" IS NOT NULL AND \"map_checksum\" IS NOT NULL\n      )",
+      "name": "single_foreign_key",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "definition": "select \"id\", \"image_id\", \"checksum\", \"image_checksum\", \"version\", \"latest\", \"created_at\", \"updated_at\", \"data\", \"resource_mask\", \"geo_mask\", \"area\", \"scale\" from \"maps\" where \"maps\".\"latest\" = true",
+      "with": null,
+      "withNoData": null,
+      "using": null,
+      "tablespace": null,
+      "materialized": false,
+      "name": "maps_latest",
+      "entityType": "views",
+      "schema": "public"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -89,6 +89,11 @@ export function createAuth(env: BetterAuthEnv) {
                 required: false,
                 input: true
               },
+              displayCollections: {
+                type: 'boolean',
+                required: false,
+                input: true
+              },
               location: {
                 type: 'json',
                 required: false,

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -118,6 +118,7 @@ export const organizations = pgTable(
     metadata: text('metadata'),
     homepage: text('homepage'),
     plan: text('plan'),
+    displayCollections: boolean('display_collections').default(false).notNull(),
     location: jsonb('location').$type<OrganizationLocation>()
   },
   (table) => [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,9 @@ importers:
 
   apps/console:
     dependencies:
+      '@allmaps/api-shared':
+        specifier: workspace:^
+        version: link:../../packages/api-shared
       '@allmaps/env':
         specifier: workspace:^
         version: link:../../packages/env


### PR DESCRIPTION
## Summary

- add the contributor organization plan alongside the existing organization tiers
- centralize organization tier metadata and limits in the shared API package
- add an organization setting that controls whether collections appear in public discovery views
- expose plan and collection-visibility controls in the console
- add the database migration and shared types required by the new setting

## Why

Organizations need a contributor tier with explicit shared limits, plus control over whether their collections are included in public Allmaps discovery experiences. Keeping the tier definitions in the shared API package ensures the API and console use the same values.

## Validation

- `pnpm run check` in `apps/console`
- console changes exercised in the local organization editor

## Stack

This is the parent of #610. PR #610 remains stacked on this branch and contains the form-flicker and logo-preview commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization plan management with shared plan options and metadata.
  * Added a setting to control whether collections are displayed for an organization.
  * Organization lists can now be filtered by plan and collection visibility.
  * Updated organization forms to edit plan and collection visibility settings.

* **Bug Fixes**
  * Standardized plan validation and access limits across organization features.
  * Improved authorization for plan-based organization members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->