### PR TITLE
normalize user slug to lower case

### DIFF
--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -64,7 +64,7 @@ export function createAuth(env: BetterAuthEnv) {
         clientId: env.GITHUB_CLIENT_ID,
         clientSecret: env.GITHUB_CLIENT_SECRET,
         mapProfileToUser: (profile) => ({
-          slug: profile.login
+          slug: profile.login.toLowerCase()
         })
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub profile slugs are now stored in lowercase for consistent profile identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->