### PR TITLE
Add organization status tooltips

### DIFF
--- a/apps/console/src/lib/components/StatusIconTooltip.svelte
+++ b/apps/console/src/lib/components/StatusIconTooltip.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { Tooltip } from 'bits-ui'
+
+  import type { Snippet } from 'svelte'
+
+  let {
+    label,
+    imageUrl,
+    imageAlt = '',
+    showLabel = true,
+    children
+  }: {
+    label: string
+    imageUrl?: string
+    imageAlt?: string
+    showLabel?: boolean
+    children: Snippet
+  } = $props()
+</script>
+
+<Tooltip.Root>
+  <Tooltip.Trigger
+    aria-label={label}
+    class="inline-flex rounded-sm focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:outline-none"
+  >
+    {@render children()}
+  </Tooltip.Trigger>
+
+  <Tooltip.Portal>
+    <Tooltip.Content
+      side="top"
+      sideOffset={6}
+      class="z-50 max-w-80 rounded bg-gray-900 px-2 py-1 font-sans text-xs text-white shadow-sm"
+    >
+      {#if imageUrl}
+        <div
+          class:mb-1.5={showLabel}
+          class="flex h-20 w-40 items-center justify-center overflow-hidden rounded bg-white p-2"
+        >
+          <img
+            src={imageUrl}
+            alt={imageAlt}
+            class="max-h-full max-w-full object-contain"
+            loading="lazy"
+            referrerpolicy="no-referrer"
+          />
+        </div>
+      {/if}
+      {#if showLabel}
+        <span class="break-all">{label}</span>
+      {/if}
+      <Tooltip.Arrow class="fill-gray-900" />
+    </Tooltip.Content>
+  </Tooltip.Portal>
+</Tooltip.Root>

--- a/apps/console/src/routes/organizations/+page.svelte
+++ b/apps/console/src/routes/organizations/+page.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import { replaceState } from '$app/navigation'
   import { page } from '$app/state'
-  import { GpsFix as GpsFixIcon } from 'phosphor-svelte'
+  import { Tooltip } from 'bits-ui'
+  import {
+    GpsFix as GpsFixIcon,
+    Image as ImageIcon,
+    Stack as StackIcon
+  } from 'phosphor-svelte'
 
   import SearchFilter from '$lib/components/SearchFilter.svelte'
   import DataTable from '$lib/components/DataTable.svelte'
+  import StatusIconTooltip from '$lib/components/StatusIconTooltip.svelte'
   import { getOrganizationId, getUserId } from '$lib/organizations.js'
   import {
     organizationPlanDetails,
@@ -276,15 +282,49 @@
                   >
                     {organization.name}
                   </a>
-                  {#if organization.location}
-                    <span title="Has location" class="text-blue-500">
-                      <GpsFixIcon
-                        size="14"
-                        weight="bold"
-                        aria-label="Has location"
-                      />
-                    </span>
-                  {/if}
+                  <Tooltip.Provider delayDuration={200}>
+                    <div class="flex items-center gap-1">
+                      {#if organization.location}
+                        <StatusIconTooltip
+                          label={`Location: ${organization.location.coordinates[1]}, ${organization.location.coordinates[0]}`}
+                        >
+                          <GpsFixIcon
+                            size="14"
+                            weight="bold"
+                            class="text-blue-500"
+                            aria-hidden="true"
+                          />
+                        </StatusIconTooltip>
+                      {/if}
+                      {#if organization.displayCollections}
+                        <StatusIconTooltip
+                          label="Collections are visible in public discovery"
+                        >
+                          <StackIcon
+                            size="14"
+                            weight="bold"
+                            class="text-green-600"
+                            aria-hidden="true"
+                          />
+                        </StatusIconTooltip>
+                      {/if}
+                      {#if organization.logo}
+                        <StatusIconTooltip
+                          label={`Logo URL: ${organization.logo}`}
+                          imageUrl={organization.logo}
+                          imageAlt={`${organization.name} logo`}
+                          showLabel={false}
+                        >
+                          <ImageIcon
+                            size="14"
+                            weight="bold"
+                            class="text-purple-500"
+                            aria-hidden="true"
+                          />
+                        </StatusIconTooltip>
+                      {/if}
+                    </div>
+                  </Tooltip.Provider>
                 </div>
               </td>
               <td class="px-3 py-2 @lg:px-4 @lg:py-3 whitespace-nowrap">


### PR DESCRIPTION
## Summary

- add location, public-discovery, and logo status icons to the console organization list
- replace the location title attribute with accessible Bits UI tooltips
- show exact coordinates for locations and a constrained logo preview for configured logo URLs
- add a reusable status-icon tooltip component with keyboard-focus support

## Why

The organization list exposed location status only through a small icon and native title text. The additional indicators make collection visibility and logo configuration scannable while the tooltips provide useful, accessible detail without adding table columns.

## Validation

- `pnpm run check` in `apps/console`
- ESLint and Prettier checks for the changed files
- live browser verification of all three keyboard-accessible tooltips
- verified the logo preview stays within a 160 × 80 px container