### PR TITLE
Add cubic sampling to WASM renderer

### DIFF
--- a/packages/render-wasm/src/interpolation.rs
+++ b/packages/render-wasm/src/interpolation.rs
@@ -40,3 +40,94 @@ pub fn sample_bilinear(
 
     result
 }
+
+/// Sample a pixel using cubic convolution with a Catmull-Rom kernel.
+///
+/// Compared with bilinear interpolation this preserves more high-frequency
+/// detail, which is especially useful for text and linework in scanned maps.
+#[inline(always)]
+pub fn sample_cubic(
+    data: &[u8],
+    tile_width: u32,
+    tile_height: u32,
+    tile_point_x: f64,
+    tile_point_y: f64,
+) -> [f64; 4] {
+    let mut result = [0.0f64; 4];
+    let base_x = tile_point_x.floor() as i32;
+    let base_y = tile_point_y.floor() as i32;
+    let weights_x = [
+        cubic_weight(tile_point_x - (base_x - 1) as f64),
+        cubic_weight(tile_point_x - base_x as f64),
+        cubic_weight(tile_point_x - (base_x + 1) as f64),
+        cubic_weight(tile_point_x - (base_x + 2) as f64),
+    ];
+    let weights_y = [
+        cubic_weight(tile_point_y - (base_y - 1) as f64),
+        cubic_weight(tile_point_y - base_y as f64),
+        cubic_weight(tile_point_y - (base_y + 1) as f64),
+        cubic_weight(tile_point_y - (base_y + 2) as f64),
+    ];
+
+    for (y_index, dy) in (-1..=2).enumerate() {
+        let pixel_y = base_y + dy;
+        let clamped_y = pixel_y.max(0).min(tile_height as i32 - 1) as u32;
+
+        for (x_index, dx) in (-1..=2).enumerate() {
+            let pixel_x = base_x + dx;
+            let clamped_x = pixel_x.max(0).min(tile_width as i32 - 1) as u32;
+            let weight = weights_x[x_index] * weights_y[y_index];
+            let index = ((clamped_y * tile_width + clamped_x) * 4) as usize;
+
+            for channel in 0..4 {
+                result[channel] += data[index + channel] as f64 * weight;
+            }
+        }
+    }
+
+    result
+}
+
+#[inline(always)]
+fn cubic_weight(distance: f64) -> f64 {
+    let distance = distance.abs();
+    // Catmull-Rom is the Keys cubic convolution kernel with a = -0.5.
+    const A: f64 = -0.5;
+    let distance_squared = distance * distance;
+    let distance_cubed = distance_squared * distance;
+
+    if distance <= 1.0 {
+        (A + 2.0) * distance_cubed - (A + 3.0) * distance_squared + 1.0
+    } else if distance < 2.0 {
+        A * distance_cubed - 5.0 * A * distance_squared + 8.0 * A * distance - 4.0 * A
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sample_cubic;
+
+    #[test]
+    fn cubic_sampling_preserves_integer_pixels() {
+        let pixels = [
+            10, 20, 30, 255, 40, 50, 60, 255, 70, 80, 90, 255, 100, 110, 120, 255,
+        ];
+
+        assert_eq!(
+            sample_cubic(&pixels, 2, 2, 1.0, 1.0),
+            [100.0, 110.0, 120.0, 255.0]
+        );
+    }
+
+    #[test]
+    fn cubic_sampling_preserves_constant_colors() {
+        let pixels = [25, 50, 75, 255].repeat(16);
+        let color = sample_cubic(&pixels, 4, 4, 1.25, 2.5);
+
+        for (actual, expected) in color.iter().zip([25.0, 50.0, 75.0, 255.0]) {
+            assert!((actual - expected).abs() < 1e-9);
+        }
+    }
+}

--- a/packages/render-wasm/src/lib.rs
+++ b/packages/render-wasm/src/lib.rs
@@ -10,7 +10,9 @@ use image::{DynamicImage, ImageDecoder, ImageEncoder};
 use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
-use renderer::{render, render_into, render_triangles, render_triangles_into, DecodedTile};
+use renderer::{
+    render, render_into, render_triangles, render_triangles_into, DecodedTile, Interpolation,
+};
 use transforms::Transform;
 
 #[wasm_bindgen(start)]
@@ -125,6 +127,7 @@ pub struct RenderContext {
     output_pixels: Vec<u8>,
     output_width: u32,
     output_height: u32,
+    interpolation: Interpolation,
 }
 
 #[wasm_bindgen]
@@ -154,7 +157,15 @@ impl RenderContext {
             output_pixels,
             output_width,
             output_height,
+            interpolation: Interpolation::Bilinear,
         }
+    }
+
+    pub fn set_interpolation(&mut self, interpolation: &str) {
+        self.interpolation = match interpolation {
+            "cubic" => Interpolation::Cubic,
+            _ => Interpolation::Bilinear,
+        };
     }
 
     pub fn render_warped_tile_rgba(
@@ -221,6 +232,7 @@ impl RenderContext {
             &mut self.output_pixels,
             self.output_width,
             self.output_height,
+            self.interpolation,
             render_min_x,
             render_min_y,
             render_max_x,
@@ -288,6 +300,7 @@ impl RenderContext {
             &mut self.output_pixels,
             self.output_width,
             self.output_height,
+            self.interpolation,
             render_min_x,
             render_min_y,
             render_max_x,
@@ -297,6 +310,10 @@ impl RenderContext {
 
     pub fn encode_png(&self) -> Vec<u8> {
         encode_png(&self.output_pixels, self.output_width, self.output_height)
+    }
+
+    pub fn rgba(&self) -> Vec<u8> {
+        self.output_pixels.clone()
     }
 
     pub fn encode_webp(&self) -> Vec<u8> {

--- a/packages/render-wasm/src/renderer.rs
+++ b/packages/render-wasm/src/renderer.rs
@@ -1,4 +1,4 @@
-use crate::interpolation::sample_bilinear;
+use crate::interpolation::{sample_bilinear, sample_cubic};
 use crate::mask::point_in_polygon;
 use crate::transforms::Transform;
 
@@ -35,6 +35,27 @@ pub struct DecodedTile {
     pub height: u32,
     pub scale_factor: f64,
     bbox: BBox, // Cached bounding box for fast culling
+}
+
+#[derive(Clone, Copy)]
+pub enum Interpolation {
+    Bilinear,
+    Cubic,
+}
+
+#[inline(always)]
+fn sample_tile(
+    interpolation: Interpolation,
+    tile: &DecodedTile,
+    tile_x: f64,
+    tile_y: f64,
+) -> [f64; 4] {
+    match interpolation {
+        Interpolation::Bilinear => {
+            sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y)
+        }
+        Interpolation::Cubic => sample_cubic(&tile.rgba, tile.width, tile.height, tile_x, tile_y),
+    }
 }
 
 impl DecodedTile {
@@ -169,6 +190,7 @@ pub fn render(
         &mut output,
         output_width,
         output_height,
+        Interpolation::Bilinear,
         0,
         0,
         output_width,
@@ -188,6 +210,7 @@ pub fn render_into(
     output: &mut [u8],
     output_width: u32,
     output_height: u32,
+    interpolation: Interpolation,
     render_min_x: u32,
     render_min_y: u32,
     render_max_x: u32,
@@ -277,8 +300,7 @@ pub fn render_into(
                 continue;
             }
 
-            // Bilinear sample
-            let color = sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
+            let color = sample_tile(interpolation, tile, tile_x, tile_y);
 
             let idx = ((cy * output_width + cx) * 4) as usize;
             if color[3] <= 0.0 {
@@ -330,6 +352,7 @@ pub fn render_triangles(
         &mut output,
         output_width,
         output_height,
+        Interpolation::Bilinear,
         0,
         0,
         output_width,
@@ -349,6 +372,7 @@ pub fn render_triangles_into(
     output: &mut [u8],
     output_width: u32,
     output_height: u32,
+    interpolation: Interpolation,
     render_min_x: u32,
     render_min_y: u32,
     render_max_x: u32,
@@ -448,7 +472,7 @@ pub fn render_triangles_into(
                     continue;
                 }
 
-                let color = sample_bilinear(&tile.rgba, tile.width, tile.height, tile_x, tile_y);
+                let color = sample_tile(interpolation, tile, tile_x, tile_y);
                 let idx = ((cy * output_width + cx) * 4) as usize;
                 if color[3] <= 0.0 {
                     continue;

--- a/packages/render/src/renderers/WasmRenderer.ts
+++ b/packages/render/src/renderers/WasmRenderer.ts
@@ -158,6 +158,7 @@ type WasmModule = {
 }
 
 type WasmRenderContext = {
+  set_interpolation(interpolation: Interpolation): void
   render_warped_tile_rgba(
     jpeg_tiles: Uint8Array,
     tile_offsets: Uint32Array,
@@ -197,11 +198,13 @@ type WasmRenderContext = {
     render_max_y: number
   ): void
   encode_png(): Uint8Array
+  rgba(): Uint8Array
   encode_webp(): Uint8Array
   encode_jpeg(quality: number): Uint8Array
 }
 
-export type OutputFormat = 'png' | 'webp' | 'jpeg'
+export type OutputFormat = 'png' | 'webp' | 'jpeg' | 'rgba'
+export type Interpolation = 'bilinear' | 'cubic'
 
 /**
  * Class that renders WarpedMaps using WASM with raw JPEG tiles
@@ -213,12 +216,14 @@ export class WasmRenderer
 {
   wasmModule: WasmModule
   outputFormat: OutputFormat
+  interpolation: Interpolation
   backgroundColor?: [number, number, number]
 
   constructor(
     wasmModule: WasmModule,
     options?: Partial<BaseRenderOptions<TriangulatedWarpedMap>> & {
       outputFormat?: OutputFormat
+      interpolation?: Interpolation
       backgroundColor?: [number, number, number]
     }
   ) {
@@ -235,6 +240,7 @@ export class WasmRenderer
     )
     this.wasmModule = wasmModule
     this.outputFormat = options?.outputFormat || 'png'
+    this.interpolation = options?.interpolation || 'bilinear'
     this.backgroundColor = options?.backgroundColor
 
     // Note: WASM module should be initialized by the caller before passing to constructor
@@ -267,6 +273,7 @@ export class WasmRenderer
       backgroundBlue,
       Boolean(this.backgroundColor)
     )
+    renderContext.set_interpolation(this.interpolation)
 
     // Get canvas-to-geo transform (same for all maps)
     const geoToCanvas = viewport.projectedGeoToCanvasHomogeneousTransform
@@ -329,7 +336,9 @@ export class WasmRenderer
     }
 
     // Encode output based on format
-    if (this.outputFormat === 'webp') {
+    if (this.outputFormat === 'rgba') {
+      return renderContext.rgba()
+    } else if (this.outputFormat === 'webp') {
       return renderContext.encode_webp()
     } else if (this.outputFormat === 'jpeg') {
       return renderContext.encode_jpeg(85)

--- a/packages/render/src/renderers/WasmRenderer.ts
+++ b/packages/render/src/renderers/WasmRenderer.ts
@@ -203,7 +203,8 @@ type WasmRenderContext = {
   encode_jpeg(quality: number): Uint8Array
 }
 
-export type OutputFormat = 'png' | 'webp' | 'jpeg' | 'rgba'
+export type EncodedOutputFormat = 'png' | 'webp' | 'jpeg'
+export type OutputFormat = EncodedOutputFormat | 'rgba'
 export type Interpolation = 'bilinear' | 'cubic'
 
 /**

--- a/packages/render/src/wasm.ts
+++ b/packages/render/src/wasm.ts
@@ -1,1 +1,5 @@
-export { WasmRenderer, type OutputFormat } from './renderers/WasmRenderer.js'
+export {
+  WasmRenderer,
+  type Interpolation,
+  type OutputFormat
+} from './renderers/WasmRenderer.js'

--- a/packages/render/src/wasm.ts
+++ b/packages/render/src/wasm.ts
@@ -1,5 +1,6 @@
 export {
   WasmRenderer,
+  type EncodedOutputFormat,
   type Interpolation,
   type OutputFormat
 } from './renderers/WasmRenderer.js'

--- a/workers/preview/src/shared/options.ts
+++ b/workers/preview/src/shared/options.ts
@@ -14,7 +14,7 @@ import {
 
 import type { QueryOptions, Color } from './types.js'
 import type { TransformationType } from '@allmaps/transform'
-import type { OutputFormat } from '@allmaps/render/wasm'
+import type { EncodedOutputFormat } from '@allmaps/render/wasm'
 
 // TODO: simplify when this will be aligned with TransformationOptions from @allmaps/render
 export function optionsFromQuery(req: IRequest): Partial<QueryOptions> {
@@ -30,7 +30,7 @@ export function optionsFromQuery(req: IRequest): Partial<QueryOptions> {
   let width: number | undefined
   let height: number | undefined
   let background: string | undefined
-  let format: OutputFormat = 'png' // Default to PNG
+  let format: EncodedOutputFormat = 'png' // Default to PNG
 
   // Extract format from URL path (e.g., /maps/123.jpg -> 'jpeg')
   const path = req.url ? new URL(req.url).pathname : ''

--- a/workers/preview/src/shared/types.ts
+++ b/workers/preview/src/shared/types.ts
@@ -1,5 +1,5 @@
 import type { TransformationType } from '@allmaps/transform'
-import type { OutputFormat } from '@allmaps/render/wasm'
+import type { EncodedOutputFormat } from '@allmaps/render/wasm'
 import type { PreviewEnv } from '@allmaps/env/preview'
 
 // TODO: align this with TransformationOptions from @allmaps/render
@@ -13,7 +13,7 @@ export type QueryOptions = TransformationOptions & {
   width: number
   height: number
   background: string
-  format: OutputFormat
+  format: EncodedOutputFormat
   // TODO: these options are specific to Allmaps Here, move them to a separate type
   color: Color
   from: [number, number]

--- a/workers/preview/src/shared/warped-map-wasm.ts
+++ b/workers/preview/src/shared/warped-map-wasm.ts
@@ -109,7 +109,9 @@ export async function generateWarpedMapImage(
     return webp(imageBuffer)
   } else if (format === 'jpeg') {
     return jpeg(imageBuffer)
-  } else {
+  } else if (format === 'png') {
     return png(imageBuffer)
   }
+
+  throw new Error(`Unsupported preview output format: ${format}`)
 }

--- a/workers/preview/src/shared/warped-map-wasm.ts
+++ b/workers/preview/src/shared/warped-map-wasm.ts
@@ -66,7 +66,8 @@ export async function generateWarpedMapImage(
     createRTree: false,
     transformationType,
     outputFormat: format,
-    backgroundColor
+    backgroundColor,
+    interpolation: 'cubic'
   })
 
   renderer.addGeoreferenceAnnotation(annotation)

--- a/workers/tileserver/src/lib/warped-tile-response-wasm.ts
+++ b/workers/tileserver/src/lib/warped-tile-response-wasm.ts
@@ -48,7 +48,8 @@ export async function createWarpedTileResponseWasm(
     fetchFn: cachedFetch,
     createRTree: false,
     transformationType,
-    outputFormat: format
+    outputFormat: format,
+    interpolation: 'cubic'
   })
 
   for (const georeferencedMap of georeferencedMaps) {

--- a/workers/tileserver/src/lib/warped-tile-response-wasm.ts
+++ b/workers/tileserver/src/lib/warped-tile-response-wasm.ts
@@ -1,7 +1,7 @@
 import { png, webp } from 'itty-router'
 
 import { Viewport } from '@allmaps/render'
-import { WasmRenderer, type OutputFormat } from '@allmaps/render/wasm'
+import { WasmRenderer } from '@allmaps/render/wasm'
 import { bboxToRectangle } from '@allmaps/stdlib'
 
 import { xyzTileToProjectedGeoBbox } from './geo.js'
@@ -23,6 +23,7 @@ import wasmFile from '../../../../packages/render-wasm/pkg/allmaps_render_wasm_b
 await wasmInit({ module_or_path: wasmFile })
 
 const TILE_WIDTH = 256
+type TileOutputFormat = 'png' | 'webp'
 
 export async function createWarpedTileResponseWasm(
   env: WorkerEnv,
@@ -30,7 +31,7 @@ export async function createWarpedTileResponseWasm(
   options: TransformationOptions,
   { x, y, z }: XYZTile,
   resolution: TileResolution = 'normal',
-  format: OutputFormat = 'png'
+  format: TileOutputFormat = 'png'
 ): Promise<Response> {
   if (!(x >= 0 && y >= 0 && z >= 0)) {
     throw new Error('x, y and z must be positive integers')
@@ -67,5 +68,11 @@ export async function createWarpedTileResponseWasm(
 
   const imageBuffer = await renderer.render(viewport)
 
-  return format === 'webp' ? webp(imageBuffer) : png(imageBuffer)
+  if (format === 'webp') {
+    return webp(imageBuffer)
+  } else if (format === 'png') {
+    return png(imageBuffer)
+  }
+
+  throw new Error(`Unsupported tile output format: ${format}`)
 }


### PR DESCRIPTION
## Summary
- add configurable bilinear and Catmull-Rom cubic interpolation to the WASM renderer
- expose raw RGBA output from the render context
- enable cubic interpolation for preview and tileserver output
- add Rust tests for cubic sampling invariants

## Tests
- cargo test (packages/render-wasm)
- pnpm --filter @allmaps/render run types
- pnpm --filter @allmaps/preview run types
- pnpm --filter @allmaps/tileserver run types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cubic interpolation for smoother image and tile rendering.
  * Added interpolation configuration for WASM-based rendering.
  * Added raw RGBA output support alongside PNG, WebP, and JPEG formats.
  * Added access to the renderer’s current RGBA pixel data.
* **Bug Fixes**
  * Improved edge handling during cubic pixel sampling to preserve image colors.
  * Unsupported output formats are now rejected instead of being silently treated as PNG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->