### PR TITLE
Add balanced random image queries

### DIFF
--- a/apis/annotations/src/routes/maps.ts
+++ b/apis/annotations/src/routes/maps.ts
@@ -1,10 +1,11 @@
 import { t } from 'elysia'
 
-import { generateRandomId } from '@allmaps/id/sync'
+import { generateAnnotation, type GeoreferencedMap } from '@allmaps/annotation'
 import { queryMaps } from '@allmaps/api-shared/db'
 import {
   needsElevatedLimitRole,
   normalizeMapsQueryParams,
+  queryRandom,
   setCacheControl
 } from '@allmaps/api-shared'
 import { createAuth } from '@allmaps/db/auth'
@@ -104,36 +105,34 @@ export function createMapsRoutes(
     )
     .get(
       '/maps/random',
-      ({ request, env, db, set }) => {
+      async ({ request, env, db, set }) => {
         setCacheControl(set, 'private-no-store')
-        const randomMapId = generateRandomId()
-
-        // Try maps with id > randomMapId first, fall back to id <= randomMapId
         const baseQuery = {
           ...normalizeMapsQueryParams(request),
           limit: 1
         }
-        const responseOptions = {
-          format: 'annotation' as const,
-          expectRows: true,
-          singular: true
-        }
+        const maps = await queryRandom(
+          1,
+          async (op, randomMapId, limit) =>
+            (await queryMaps(
+              env.PUBLIC_ANNOTATIONS_BASE_URL,
+              db,
+              {
+                ...baseQuery,
+                limit,
+                randomMapId,
+                randomMapIdOp: op
+              },
+              {
+                format: 'map',
+                expectRows: false,
+                singular: false
+              }
+            )) as GeoreferencedMap[],
+          'Maps not found'
+        )
 
-        try {
-          return queryMaps(
-            env.PUBLIC_ANNOTATIONS_BASE_URL,
-            db,
-            { ...baseQuery, randomMapId, randomMapIdOp: 'gt' },
-            responseOptions
-          )
-        } catch {
-          return queryMaps(
-            env.PUBLIC_ANNOTATIONS_BASE_URL,
-            db,
-            { ...baseQuery, randomMapId, randomMapIdOp: 'lte' },
-            responseOptions
-          )
-        }
+        return generateAnnotation(maps[0])
       },
       {
         query: mapsQuerySchema,

--- a/apis/rest/src/routes/canvases.ts
+++ b/apis/rest/src/routes/canvases.ts
@@ -7,6 +7,7 @@ import type { RestEnv } from '@allmaps/env/rest'
 import { createElysia, createBetterAuthPlugin } from '../elysia.js'
 import { queryCanvases, queryMaps } from '@allmaps/api-shared/db'
 import {
+  clampLimit,
   needsElevatedLimitRole,
   normalizeMapsQueryParams,
   queryRandom,
@@ -66,19 +67,26 @@ export function createCanvasesRoutes(
           ? await getLimitRole()
           : 'public'
         setCacheControl(set, 'private-no-store')
-        return queryRandom((op, randomId) =>
-          queryCanvases(
-            env.PUBLIC_REST_BASE_URL,
-            db,
-            {
-              georeferenced: query.georeferenced,
-              limit: query.limit,
-              randomCanvasId: randomId,
-              randomCanvasIdOp: op,
-              userRole
-            },
-            { expectRows: true, singular: false }
-          )
+        const limit = clampLimit(query.limit ?? 100, userRole)
+        return queryRandom(
+          limit,
+          async (op, randomId, queryLimit) => {
+            const canvases = await queryCanvases(
+              env.PUBLIC_REST_BASE_URL,
+              db,
+              {
+                georeferenced: query.georeferenced,
+                limit: queryLimit,
+                randomCanvasId: randomId,
+                randomCanvasIdOp: op,
+                userRole
+              },
+              { expectRows: false, singular: false }
+            )
+
+            return Array.isArray(canvases) ? canvases : [canvases]
+          },
+          'Canvases not found'
         )
       },
       {

--- a/apis/rest/src/routes/images.ts
+++ b/apis/rest/src/routes/images.ts
@@ -10,12 +10,15 @@ import { adminDetail } from '../openapi.js'
 import {
   queryImage,
   queryImages,
+  queryRandomImagesByOrganizationIds,
   createImage,
   createImageFromUrl,
   queryMaps,
   queryImageChecksums
 } from '@allmaps/api-shared/db'
 import {
+  ResponseError,
+  clampLimit,
   needsElevatedLimitRole,
   normalizeMapsQueryParams,
   queryRandom,
@@ -25,6 +28,13 @@ import {
 const imagesQuerySchema = t.Object({
   georeferenced: t.Optional(t.Boolean()),
   limit: t.Optional(t.Number())
+})
+
+const randomImagesQuerySchema = t.Object({
+  georeferenced: t.Optional(t.Boolean()),
+  limit: t.Optional(t.Number()),
+  organizationId: t.Optional(t.Array(t.String())),
+  limitPerOrganization: t.Optional(t.Integer({ minimum: 1 }))
 })
 
 const createImageBodySchema = t.Union([
@@ -86,28 +96,79 @@ export function createImagesRoutes(
     .get(
       '/images/random',
       async ({ env, db, query, set, getLimitRole }) => {
-        const userRole = needsElevatedLimitRole(query.limit)
+        const organizationIds = [...new Set(query.organizationId ?? [])]
+        const hasOrganizations = organizationIds.length > 0
+
+        if (hasOrganizations && query.limit !== undefined) {
+          throw new ResponseError(
+            'limit cannot be combined with organizationId',
+            400
+          )
+        }
+
+        if (!hasOrganizations && query.limitPerOrganization !== undefined) {
+          throw new ResponseError(
+            'limitPerOrganization requires organizationId',
+            400
+          )
+        }
+
+        const requestedLimitPerOrganization = query.limitPerOrganization ?? 1
+        const requestedLimit = hasOrganizations
+          ? organizationIds.length * requestedLimitPerOrganization
+          : query.limit
+        const userRole = needsElevatedLimitRole(requestedLimit)
           ? await getLimitRole()
           : 'public'
         setCacheControl(set, 'private-no-store')
-        return queryRandom((op, randomId) =>
-          queryImages(
+
+        if (hasOrganizations) {
+          const totalLimit = clampLimit(requestedLimit, userRole)
+          const limitPerOrganization = Math.floor(
+            totalLimit / organizationIds.length
+          )
+
+          if (limitPerOrganization < 1) {
+            throw new ResponseError('Too many organizationId parameters', 400)
+          }
+
+          return queryRandomImagesByOrganizationIds(
             env.PUBLIC_REST_BASE_URL,
             db,
             {
+              organizationIds,
               georeferenced: query.georeferenced,
-              limit: query.limit,
-              randomImageId: randomId,
-              randomImageIdOp: op,
+              limitPerOrganization,
               userRole
-            },
-            { expectRows: true, singular: false }
+            }
           )
+        }
+
+        const limit = clampLimit(query.limit ?? 100, userRole)
+        return queryRandom(
+          limit,
+          async (op, randomId, queryLimit) => {
+            const images = await queryImages(
+              env.PUBLIC_REST_BASE_URL,
+              db,
+              {
+                georeferenced: query.georeferenced,
+                limit: queryLimit,
+                randomImageId: randomId,
+                randomImageIdOp: op,
+                userRole
+              },
+              { expectRows: false, singular: false }
+            )
+
+            return Array.isArray(images) ? images : [images]
+          },
+          'Images not found'
         )
       },
       {
-        query: imagesQuerySchema,
-        detail: { summary: 'Get a random IIIF Image', tags: ['Images'] }
+        query: randomImagesQuerySchema,
+        detail: { summary: 'Get random IIIF Images', tags: ['Images'] }
       }
     )
     .get(

--- a/apis/rest/src/routes/manifests.ts
+++ b/apis/rest/src/routes/manifests.ts
@@ -14,6 +14,7 @@ import {
   queryMaps
 } from '@allmaps/api-shared/db'
 import {
+  clampLimit,
   needsElevatedLimitRole,
   normalizeMapsQueryParams,
   queryRandom,
@@ -86,19 +87,26 @@ export function createManifestsRoutes(
           ? await getLimitRole()
           : 'public'
         setCacheControl(set, 'private-no-store')
-        return queryRandom((op, randomId) =>
-          queryManifests(
-            env.PUBLIC_REST_BASE_URL,
-            db,
-            {
-              georeferenced: query.georeferenced,
-              limit: query.limit,
-              randomManifestId: randomId,
-              randomManifestIdOp: op,
-              userRole
-            },
-            { expectRows: true, singular: false }
-          )
+        const limit = clampLimit(query.limit ?? 100, userRole)
+        return queryRandom(
+          limit,
+          async (op, randomId, queryLimit) => {
+            const manifests = await queryManifests(
+              env.PUBLIC_REST_BASE_URL,
+              db,
+              {
+                georeferenced: query.georeferenced,
+                limit: queryLimit,
+                randomManifestId: randomId,
+                randomManifestIdOp: op,
+                userRole
+              },
+              { expectRows: false, singular: false }
+            )
+
+            return Array.isArray(manifests) ? manifests : [manifests]
+          },
+          'Manifests not found'
         )
       },
       {

--- a/packages/api-shared/src/db.ts
+++ b/packages/api-shared/src/db.ts
@@ -1,6 +1,7 @@
 export {
   queryImage,
   queryImages,
+  queryRandomImagesByOrganizationIds,
   queryCanvases,
   queryManifests,
   createImage,

--- a/packages/api-shared/src/queries/iiif.ts
+++ b/packages/api-shared/src/queries/iiif.ts
@@ -1,6 +1,7 @@
 import { sql, eq } from 'drizzle-orm'
 
 import { generateId, generateChecksum } from '@allmaps/id'
+import { generateRandomId } from '@allmaps/id/sync'
 import { fetchJson } from '@allmaps/stdlib'
 import { Manifest, Image } from '@allmaps/iiif-parser'
 
@@ -269,6 +270,7 @@ export async function queryImages(
   db: Db,
   params: {
     imageId?: string
+    imageIds?: string[]
     organizationId?: string
     georeferenced?: boolean
     limit?: number
@@ -298,6 +300,7 @@ export async function queryImages(
     where: {
       id: {
         eq: params.imageId,
+        in: params.imageIds,
         ...(params.randomImageIdOp === 'gt'
           ? { gt: params.randomImageId }
           : params.randomImageIdOp === 'lte'
@@ -364,8 +367,7 @@ export async function queryImages(
       }
     },
     orderBy: params.randomImageId
-      ? (images, { asc, desc }) =>
-          params.randomImageIdOp === 'gt' ? asc(images.id) : desc(images.id)
+      ? (images, { asc }) => asc(images.id)
       : undefined,
     limit: responseOptions.singular
       ? 1
@@ -379,8 +381,118 @@ export async function queryImages(
     throw new ResponseError(message, 404)
   }
 
-  const apiImages = rows.map((image) => fromDbImage(restBaseUrl, image))
+  const rowsById = new Map(rows.map((row) => [row.id, row]))
+  const orderedRows = params.imageIds
+    ? params.imageIds
+        .map((imageId) => rowsById.get(imageId))
+        .filter((row): row is DbImage => row !== undefined)
+    : rows
+  const apiImages = orderedRows.map((image) => fromDbImage(restBaseUrl, image))
   return responseOptions.singular ? apiImages[0] : apiImages
+}
+
+export async function queryRandomImagesByOrganizationIds(
+  restBaseUrl: string,
+  db: Db,
+  params: {
+    organizationIds: string[]
+    georeferenced?: boolean
+    limitPerOrganization: number
+    userRole?: UserRole
+  }
+) {
+  const requestedOrganizations = sql.join(
+    params.organizationIds.map(
+      (organizationId, organizationIndex) =>
+        sql`(
+          ${organizationId}::text,
+          ${generateRandomId()}::text,
+          ${organizationIndex}::integer
+        )`
+    ),
+    sql`, `
+  )
+  const georeferencedFilter =
+    params.georeferenced === undefined
+      ? sql``
+      : params.georeferenced
+        ? sql`AND EXISTS (
+            SELECT 1
+            FROM ${schema.maps} AS map
+            WHERE map.image_id = image.id AND map.latest = true
+          )`
+        : sql`AND NOT EXISTS (
+            SELECT 1
+            FROM ${schema.maps} AS map
+            WHERE map.image_id = image.id AND map.latest = true
+          )`
+
+  const candidateResult = await db.execute<{ id: string }>(sql`
+    WITH requested_organizations (
+      organization_id,
+      random_id,
+      organization_index
+    ) AS (
+      VALUES ${requestedOrganizations}
+    )
+    SELECT random_image.id
+    FROM requested_organizations AS requested_organization
+    CROSS JOIN LATERAL (
+      SELECT candidate.id, candidate.wrap
+      FROM (
+        (
+          SELECT image.id, 0 AS wrap
+          FROM ${schema.images} AS image
+          INNER JOIN ${schema.organizationUrls} AS organization_url
+            ON organization_url.url = image.domain
+          WHERE
+            organization_url.organization_id = requested_organization.organization_id
+            AND image.id > requested_organization.random_id
+            ${georeferencedFilter}
+          ORDER BY image.id
+          LIMIT ${params.limitPerOrganization}
+        )
+        UNION ALL
+        (
+          SELECT image.id, 1 AS wrap
+          FROM ${schema.images} AS image
+          INNER JOIN ${schema.organizationUrls} AS organization_url
+            ON organization_url.url = image.domain
+          WHERE
+            organization_url.organization_id = requested_organization.organization_id
+            AND image.id <= requested_organization.random_id
+            ${georeferencedFilter}
+          ORDER BY image.id
+          LIMIT ${params.limitPerOrganization}
+        )
+      ) AS candidate
+      ORDER BY candidate.wrap, candidate.id
+      LIMIT ${params.limitPerOrganization}
+    ) AS random_image
+    ORDER BY
+      requested_organization.organization_index,
+      random_image.wrap,
+      random_image.id
+  `)
+  const candidateRows = Array.isArray(candidateResult)
+    ? candidateResult
+    : candidateResult.rows
+  const imageIds = candidateRows.map(({ id }) => id)
+
+  if (imageIds.length === 0) {
+    throw new ResponseError('Images not found', 404)
+  }
+
+  return queryImages(
+    restBaseUrl,
+    db,
+    {
+      imageIds,
+      limit: imageIds.length,
+      userRole: params.userRole
+    },
+    { expectRows: true, singular: false }
+  )
 }
 
 export async function queryCanvases(
@@ -484,10 +596,7 @@ export async function queryCanvases(
       }
     },
     orderBy: params.randomCanvasId
-      ? (canvases, { asc, desc }) =>
-          params.randomCanvasIdOp === 'gt'
-            ? asc(canvases.id)
-            : desc(canvases.id)
+      ? (canvases, { asc }) => asc(canvases.id)
       : undefined,
     limit: responseOptions.singular
       ? 1
@@ -611,10 +720,7 @@ export async function queryManifests(
       }
     },
     orderBy: params.randomManifestId
-      ? (manifests, { asc, desc }) =>
-          params.randomManifestIdOp === 'gt'
-            ? asc(manifests.id)
-            : desc(manifests.id)
+      ? (manifests, { asc }) => asc(manifests.id)
       : undefined,
     limit: responseOptions.singular
       ? 1

--- a/packages/api-shared/src/queries/maps.ts
+++ b/packages/api-shared/src/queries/maps.ts
@@ -243,7 +243,7 @@ export async function queryMaps(
     },
     orderBy: (maps, { asc, desc }) => {
       if (params.randomMapId) {
-        return params.randomMapIdOp === 'gt' ? asc(maps.id) : desc(maps.id)
+        return asc(maps.id)
       } else if (isGeospatialQuery) {
         return desc(maps.scale)
       } else {

--- a/packages/api-shared/src/shared/random.ts
+++ b/packages/api-shared/src/shared/random.ts
@@ -1,12 +1,23 @@
 import { generateRandomId } from '@allmaps/id/sync'
 
+import { ResponseError } from './errors.js'
+
 export async function queryRandom<T>(
-  queryFn: (op: 'gt' | 'lte', randomId: string) => Promise<T>
-): Promise<T> {
+  limit: number,
+  queryFn: (op: 'gt' | 'lte', randomId: string, limit: number) => Promise<T[]>,
+  notFoundMessage = 'Not found'
+): Promise<T[]> {
   const randomId = generateRandomId()
-  try {
-    return await queryFn('gt', randomId)
-  } catch {
-    return await queryFn('lte', randomId)
+
+  const rowsAfterRandomId = await queryFn('gt', randomId, limit)
+  const remainingLimit = limit - rowsAfterRandomId.length
+  const rowsBeforeRandomId =
+    remainingLimit > 0 ? await queryFn('lte', randomId, remainingLimit) : []
+  const rows = [...rowsAfterRandomId, ...rowsBeforeRandomId]
+
+  if (rows.length === 0) {
+    throw new ResponseError(notFoundMessage, 404)
   }
+
+  return rows
 }

--- a/packages/db/drizzle/20260819150756_clear_nightcrawler/migration.sql
+++ b/packages/db/drizzle/20260819150756_clear_nightcrawler/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "images_domain_id_idx" ON "iiif"."images" ("domain","id");

--- a/packages/db/drizzle/20260819150756_clear_nightcrawler/snapshot.json
+++ b/packages/db/drizzle/20260819150756_clear_nightcrawler/snapshot.json
@@ -1,0 +1,3186 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "97add02a-c646-4680-a48f-07321fde7e6c",
+  "prevIds": [
+    "92995a07-c4c9-4c6b-8c82-fac841587e14"
+  ],
+  "ddl": [
+    {
+      "name": "iiif",
+      "entityType": "schemas"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "canvases",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "canvases_images",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "images",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "manifests",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "manifests_canvases",
+      "entityType": "tables",
+      "schema": "iiif"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "list_items",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "lists",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "maps",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organization_urls",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ops",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "snapshots",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "homepage",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "display_collections",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "full_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_anonymous",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"canvases\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"images\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "embedded",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uri",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "((regexp_match(\"iiif\".\"manifests\".\"uri\", '^(?:https?://)(?:[^@/\n]+@)?([^:/\n]+)'))[1])",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "manifest_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "list_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "map_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canvas_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "manifest_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "deletable",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_checksum",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "latest",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "geometry(Polygon)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_mask",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "geometry(Polygon,4326)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "geo_mask",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "CASE WHEN \"maps\".\"geo_mask\" IS NOT NULL THEN ST_Area(geography(\"maps\".\"geo_mask\")) ELSE NULL END",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "area",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "CASE WHEN ST_Area(geography(\"maps\".\"geo_mask\")) > 0 THEN sqrt(ST_Area(\"maps\".\"resource_mask\") / ST_Area(geography(\"maps\".\"geo_mask\"))) ELSE NULL END",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "scale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operation",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "doc_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "type": "timestamp(6) with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"slug\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_slug_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_canvas_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_image_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "canvas_to_images_composite_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "images_domain_index",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "images_domain_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_domain_index",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_manifest_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_canvas_id_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "manifests_to_canvases_composite_idx",
+      "entityType": "indexes",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_checksum",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "map_version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"map_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_map_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"image_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_image_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "canvas_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"canvas_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_canvas_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "list_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "manifest_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"manifest_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "list_items_list_manifest_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "checksum",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_checksum_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_image_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "image_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"latest\" = true",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_latest_image_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "latest",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_latest_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "maps_updated_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "geo_mask",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "GIST",
+      "concurrently": false,
+      "name": "maps_geo_mask_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_urls_organization_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "url",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_urls_url_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "canvases_images_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "canvases_images_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "manifest_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "manifests",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "manifests_canvases_manifest_id_manifests_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "manifests_canvases_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "list_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_list_id_lists_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "canvas_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "canvases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_canvas_id_canvases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "manifest_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "manifests",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_manifest_id_manifests_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "map_id",
+        "map_image_id",
+        "map_checksum",
+        "map_version"
+      ],
+      "schemaTo": "public",
+      "tableTo": "maps",
+      "columnsTo": [
+        "id",
+        "image_id",
+        "checksum",
+        "version"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "list_items_DOUrIXsmsloB_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "lists_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "image_id"
+      ],
+      "schemaTo": "iiif",
+      "tableTo": "images",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "maps_image_id_images_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "organization_urls_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "columns": [
+        "canvas_id",
+        "image_id"
+      ],
+      "nameExplicit": false,
+      "name": "canvases_images_pkey",
+      "entityType": "pks",
+      "schema": "iiif",
+      "table": "canvases_images"
+    },
+    {
+      "columns": [
+        "manifest_id",
+        "canvas_id"
+      ],
+      "nameExplicit": false,
+      "name": "manifests_canvases_pkey",
+      "entityType": "pks",
+      "schema": "iiif",
+      "table": "manifests_canvases"
+    },
+    {
+      "columns": [
+        "id",
+        "image_id",
+        "checksum",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "maps_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "maps"
+    },
+    {
+      "columns": [
+        "organization_id",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "organization_urls_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "organization_urls"
+    },
+    {
+      "columns": [
+        "collection",
+        "doc_id",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "ops_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "ops"
+    },
+    {
+      "columns": [
+        "collection",
+        "doc_id"
+      ],
+      "nameExplicit": false,
+      "name": "snapshots_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "snapshots"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "public",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "public",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "public",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "public",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "canvases_pkey",
+      "schema": "iiif",
+      "table": "canvases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "images_pkey",
+      "schema": "iiif",
+      "table": "images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "manifests_pkey",
+      "schema": "iiif",
+      "table": "manifests",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "lists_pkey",
+      "schema": "public",
+      "table": "lists",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_urls_url_key",
+      "schema": "public",
+      "table": "organization_urls",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"slug\" ~ '^[a-z](?:[a-z0-9-]*[a-z0-9])?$'",
+      "name": "organizations_slug_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "value": "\"slug\" IS NULL OR \"slug\" ~ '^[a-z](?:[a-z0-9-]*[a-z0-9])?$'",
+      "name": "users_slug_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "value": "\n      (\n        num_nonnulls(\"image_id\", \"canvas_id\", \"manifest_id\") = 1\n        AND\n        \"map_id\" IS NULL AND \"map_version\" IS NULL AND \"map_image_id\" IS NULL AND \"map_checksum\" IS NULL\n      ) OR (\n        num_nonnulls(\"image_id\", \"canvas_id\", \"manifest_id\") = 0\n        AND\n        \"map_id\" IS NOT NULL AND \"map_version\" IS NOT NULL AND \"map_image_id\" IS NOT NULL AND \"map_checksum\" IS NOT NULL\n      )",
+      "name": "single_foreign_key",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "list_items"
+    },
+    {
+      "definition": "select \"id\", \"image_id\", \"checksum\", \"image_checksum\", \"version\", \"latest\", \"created_at\", \"updated_at\", \"data\", \"resource_mask\", \"geo_mask\", \"area\", \"scale\" from \"maps\" where \"maps\".\"latest\" = true",
+      "with": null,
+      "withNoData": null,
+      "using": null,
+      "tablespace": null,
+      "materialized": false,
+      "name": "maps_latest",
+      "entityType": "views",
+      "schema": "public"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/schema/iiif.ts
+++ b/packages/db/src/schema/iiif.ts
@@ -37,7 +37,10 @@ export const images = iiifSchema.table(
     createdAt: createTimestamp('created_at'),
     updatedAt: createTimestamp('updated_at')
   },
-  (table) => [index().on(table.domain)]
+  (table) => [
+    index().on(table.domain),
+    index('images_domain_id_idx').on(table.domain, table.id)
+  ]
 )
 
 export const canvases = iiifSchema.table('canvases', {


### PR DESCRIPTION
## Summary

- fill random collection results across the hash-ID wrap boundary
- add balanced random image sampling by organization with optional georeferencing filters
- add the composite image lookup index and validate positive per-organization limits

## Validation

- `pnpm --filter @allmaps/api-shared run types`
- `pnpm --filter @allmaps/db run types`
- `pnpm exec tsc --noEmit` in `apis/rest` and `apis/annotations`
- `pnpm exec prettier --check src/routes/images.ts` in `apis/rest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Random image requests can now target specific organizations and return balanced results.
  - Random map, canvas, manifest, and image results support requested limits more consistently.
- **Bug Fixes**
  - Improved random selection and result ordering across media types.
  - Invalid image-request combinations now return clearer errors.
  - Empty random searches provide consistent “not found” responses.
  - Random image responses are no longer cached, helping ensure fresher results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->