### PR TITLE
Accept less strict IIIF canvas parsing

### DIFF
--- a/packages/iiif-parser/src/schemas/iiif.ts
+++ b/packages/iiif-parser/src/schemas/iiif.ts
@@ -27,10 +27,14 @@ export const ManifestSchema = z.union([Manifest2Schema, Manifest3Schema])
 export const CollectionSchema = z.union([Collection2Schema, Collection3Schema])
 
 export const IIIF1Schema = Image1Schema
+const DiscriminatedCanvas2Schema = Canvas2Schema.extend({
+  '@type': z.literal('sc:Canvas')
+})
+
 export const IIIF2Schema = z.discriminatedUnion('@type', [
   Collection2Schema,
   Manifest2Schema,
-  Canvas2Schema,
+  DiscriminatedCanvas2Schema,
   Image2Schema
 ])
 export const IIIF3Schema = z.discriminatedUnion('type', [

--- a/packages/iiif-parser/src/schemas/presentation.2.ts
+++ b/packages/iiif-parser/src/schemas/presentation.2.ts
@@ -110,7 +110,7 @@ export const Annotation2Schema = z.object({
 
 export const Canvas2Schema = z.object({
   '@id': z.string().url(),
-  '@type': z.literal('sc:Canvas'),
+  '@type': z.literal('sc:Canvas').optional(),
   width: z.number().int(),
   height: z.number().int(),
   images: Annotation2Schema.array().length(1),
@@ -126,8 +126,19 @@ export const Canvas2Schema = z.object({
   navPlace: NavPlaceSchema.optional()
 })
 
+const ManifestCanvas2Schema = Canvas2Schema.extend({
+  images: Annotation2Schema.array().max(1)
+})
+
 const Sequence2Schema = z.object({
-  canvases: Canvas2Schema.array().nonempty()
+  canvases: ManifestCanvas2Schema.array()
+    .nonempty()
+    .transform((canvases): z.infer<typeof Canvas2Schema>[] =>
+      canvases.filter((canvas) => canvas.images.length === 1)
+    )
+    .refine((canvases) => canvases.length > 0, {
+      error: 'At least one Canvas must contain an image'
+    })
 })
 
 export const Manifest2Schema = z.object({

--- a/packages/iiif-parser/test/input/manifest.2.loc-sanborn00996_001.json
+++ b/packages/iiif-parser/test/input/manifest.2.loc-sanborn00996_001.json
@@ -1,0 +1,200 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://www.loc.gov/item/sanborn00996_001/manifest.json",
+  "@type": "sc:Manifest",
+  "attribution": "Provided by the Library of Congress",
+  "description": "Jun 1886. 4 sheet(s).",
+  "label": "Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado.",
+  "logo": "https://loc.gov/static/images/logo-loc-new-branding.svg",
+  "metadata": [
+    {
+      "label": "APA Citation Style",
+      "value": "(1886) <cite>Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado</cite>. Sanborn Map Company, Jun. [Map] Retrieved from the Library of Congress, https://www.loc.gov/item/sanborn00996_001/."
+    },
+    {
+      "label": "MLA Citation Style",
+      "value": "<cite>Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado</cite>. Sanborn Map Company, Jun, 1886. Map. Retrieved from the Library of Congress, &lt;www.loc.gov/item/sanborn00996_001/&gt;."
+    },
+    {
+      "label": "Chicago Citation Style",
+      "value": "<cite>Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado</cite>. Sanborn Map Company, Jun, 1886. Map. https://www.loc.gov/item/sanborn00996_001/."
+    },
+    {
+      "label": "Contributors",
+      "value": ""
+    },
+    {
+      "label": "Created Published",
+      "value": ["Sanborn Map Company, Jun 1886"]
+    },
+    {
+      "label": "Original Format",
+      "value": ["map"]
+    },
+    {
+      "label": "Subjects",
+      "value": []
+    },
+    {
+      "label": "Online Format",
+      "value": ["image"]
+    },
+    {
+      "label": "Item Url",
+      "value": "https://www.loc.gov/item/sanborn00996_001/"
+    }
+  ],
+  "navDate": null,
+  "seeAlso": [],
+  "sequences": [
+    {
+      "@type": "sc:Sequence",
+      "canvases": [
+        {
+          "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0001",
+          "height": 1912,
+          "images": [],
+          "label": "Page 1",
+          "metadata": [],
+          "related": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=1",
+          "thumbnail": {
+            "@id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0001.gif",
+            "format": "image/jpeg",
+            "height": 150,
+            "width": 126
+          },
+          "type": "sc:Canvas",
+          "width": 1612
+        },
+        {
+          "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0002",
+          "height": 1912,
+          "images": [
+            {
+              "@id": "https://www.loc.gov/resource/g4314fm.g009961886/seq-2/",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0002",
+              "resource": {
+                "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0002/full/pct:25/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1912,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0002",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                },
+                "width": 1612
+              }
+            }
+          ],
+          "label": "Page 2",
+          "metadata": [
+            {
+              "label": "Library of Congress Resource URL",
+              "value": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=2"
+            }
+          ],
+          "related": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=2",
+          "thumbnail": {
+            "@id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0002.gif",
+            "format": "image/jpeg",
+            "height": 150,
+            "width": 126
+          },
+          "type": "sc:Canvas",
+          "width": 1612
+        },
+        {
+          "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0003",
+          "height": 1912,
+          "images": [
+            {
+              "@id": "https://www.loc.gov/resource/g4314fm.g009961886/seq-3/",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0003",
+              "resource": {
+                "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0003/full/pct:25/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1912,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0003",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                },
+                "width": 1612
+              }
+            }
+          ],
+          "label": "Page 3",
+          "metadata": [
+            {
+              "label": "Library of Congress Resource URL",
+              "value": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=3"
+            }
+          ],
+          "related": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=3",
+          "thumbnail": {
+            "@id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0003.gif",
+            "format": "image/jpeg",
+            "height": 150,
+            "width": 126
+          },
+          "type": "sc:Canvas",
+          "width": 1612
+        },
+        {
+          "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0004",
+          "height": 1912,
+          "images": [
+            {
+              "@id": "https://www.loc.gov/resource/g4314fm.g009961886/seq-4/",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0004",
+              "resource": {
+                "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0004/full/pct:25/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1912,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0004",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                },
+                "width": 1612
+              }
+            }
+          ],
+          "label": "Page 4",
+          "metadata": [
+            {
+              "label": "Library of Congress Resource URL",
+              "value": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=4"
+            }
+          ],
+          "related": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=4",
+          "thumbnail": {
+            "@id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0004.gif",
+            "format": "image/jpeg",
+            "height": 150,
+            "width": 126
+          },
+          "type": "sc:Canvas",
+          "width": 1612
+        }
+      ],
+      "label": "Order of the views"
+    }
+  ],
+  "thumbnail": [
+    {
+      "@id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0001.gif"
+    }
+  ],
+  "viewingDirection": "left-to-right",
+  "viewingHint": "paged"
+}

--- a/packages/iiif-parser/test/output/manifest.2.loc-sanborn00996_001.parsed.json
+++ b/packages/iiif-parser/test/output/manifest.2.loc-sanborn00996_001.parsed.json
@@ -1,0 +1,234 @@
+{
+  "canvases": [
+    {
+      "height": 1912,
+      "homepage": [
+        {
+          "id": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=2"
+        }
+      ],
+      "image": {
+        "embedded": true,
+        "height": 1912,
+        "majorVersion": 2,
+        "supportedFormats": ["jpg"],
+        "supportsAnyRegionAndSize": true,
+        "type": "image",
+        "uri": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0002",
+        "width": 1612
+      },
+      "label": {
+        "none": ["Page 2"]
+      },
+      "metadata": [
+        {
+          "label": {
+            "none": ["Library of Congress Resource URL"]
+          },
+          "value": {
+            "none": ["https://www.loc.gov/resource/g4314fm.g009961886/?sp=2"]
+          }
+        }
+      ],
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 150,
+          "id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0002.gif",
+          "width": 126
+        }
+      ],
+      "type": "canvas",
+      "uri": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0002",
+      "width": 1612
+    },
+    {
+      "height": 1912,
+      "homepage": [
+        {
+          "id": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=3"
+        }
+      ],
+      "image": {
+        "embedded": true,
+        "height": 1912,
+        "majorVersion": 2,
+        "supportedFormats": ["jpg"],
+        "supportsAnyRegionAndSize": true,
+        "type": "image",
+        "uri": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0003",
+        "width": 1612
+      },
+      "label": {
+        "none": ["Page 3"]
+      },
+      "metadata": [
+        {
+          "label": {
+            "none": ["Library of Congress Resource URL"]
+          },
+          "value": {
+            "none": ["https://www.loc.gov/resource/g4314fm.g009961886/?sp=3"]
+          }
+        }
+      ],
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 150,
+          "id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0003.gif",
+          "width": 126
+        }
+      ],
+      "type": "canvas",
+      "uri": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0003",
+      "width": 1612
+    },
+    {
+      "height": 1912,
+      "homepage": [
+        {
+          "id": "https://www.loc.gov/resource/g4314fm.g009961886/?sp=4"
+        }
+      ],
+      "image": {
+        "embedded": true,
+        "height": 1912,
+        "majorVersion": 2,
+        "supportedFormats": ["jpg"],
+        "supportsAnyRegionAndSize": true,
+        "type": "image",
+        "uri": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0004",
+        "width": 1612
+      },
+      "label": {
+        "none": ["Page 4"]
+      },
+      "metadata": [
+        {
+          "label": {
+            "none": ["Library of Congress Resource URL"]
+          },
+          "value": {
+            "none": ["https://www.loc.gov/resource/g4314fm.g009961886/?sp=4"]
+          }
+        }
+      ],
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 150,
+          "id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0004.gif",
+          "width": 126
+        }
+      ],
+      "type": "canvas",
+      "uri": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd431m:g4314m:g4314fm:g009961886:00996_1886-0004",
+      "width": 1612
+    }
+  ],
+  "description": {
+    "none": ["Jun 1886. 4 sheet(s)."]
+  },
+  "embedded": false,
+  "label": {
+    "none": [
+      "Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado."
+    ]
+  },
+  "majorVersion": 2,
+  "metadata": [
+    {
+      "label": {
+        "none": ["APA Citation Style"]
+      },
+      "value": {
+        "none": [
+          "(1886) <cite>Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado</cite>. Sanborn Map Company, Jun. [Map] Retrieved from the Library of Congress, https://www.loc.gov/item/sanborn00996_001/."
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["MLA Citation Style"]
+      },
+      "value": {
+        "none": [
+          "<cite>Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado</cite>. Sanborn Map Company, Jun, 1886. Map. Retrieved from the Library of Congress, &lt;www.loc.gov/item/sanborn00996_001/&gt;."
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["Chicago Citation Style"]
+      },
+      "value": {
+        "none": [
+          "<cite>Sanborn Fire Insurance Map from Fort Collins, Larimer County, Colorado</cite>. Sanborn Map Company, Jun, 1886. Map. https://www.loc.gov/item/sanborn00996_001/."
+        ]
+      }
+    },
+    {
+      "label": {
+        "none": ["Contributors"]
+      },
+      "value": {
+        "none": [""]
+      }
+    },
+    {
+      "label": {
+        "none": ["Created Published"]
+      },
+      "value": {
+        "none": ["Sanborn Map Company, Jun 1886"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Original Format"]
+      },
+      "value": {
+        "none": ["map"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Subjects"]
+      },
+      "value": {}
+    },
+    {
+      "label": {
+        "none": ["Online Format"]
+      },
+      "value": {
+        "none": ["image"]
+      }
+    },
+    {
+      "label": {
+        "none": ["Item Url"]
+      },
+      "value": {
+        "none": ["https://www.loc.gov/item/sanborn00996_001/"]
+      }
+    }
+  ],
+  "navDate": "1970-01-01T00:00:00.000Z",
+  "requiredStatement": {
+    "label": {
+      "none": ["Attribution"]
+    },
+    "value": {
+      "none": ["Provided by the Library of Congress"]
+    }
+  },
+  "thumbnail": [
+    {
+      "id": "https://tile.loc.gov/storage-services/service/gmd/gmd431m/g4314m/g4314fm/g009961886/00996_1886-0001.gif"
+    }
+  ],
+  "type": "manifest",
+  "uri": "https://www.loc.gov/item/sanborn00996_001/manifest.json"
+}


### PR DESCRIPTION
## Summary
- tolerate missing `@type` on Presentation 2 canvases
- skip image-less canvases while retaining the single-image invariant
- keep the generic IIIF 2 discriminated union unambiguous
- add a Library of Congress manifest fixture and expected parsed output

## Tests
- `pnpm --filter "@allmaps/iiif-parser" run types`
- `pnpm --filter "@allmaps/iiif-parser" run test`
- `pnpm --filter "@allmaps/iiif-parser" run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IIIF Presentation 2.0 manifest validation for canvases with missing type information.
  - Ensured manifests contain at least one canvas with exactly one image.

- **Tests**
  - Added coverage for parsing a Library of Congress Sanborn Fire Insurance Map manifest, including canvases, images, metadata, thumbnails, and IIIF image services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->