### PR TITLE
Fix MapLibre event handling and dependency compatibility

### DIFF
--- a/apps/editor/src/lib/shared/editor-map-guide-progress.ts
+++ b/apps/editor/src/lib/shared/editor-map-guide-progress.ts
@@ -170,12 +170,8 @@ export function getEditorMapGuideProgress({
       imageNumber: imageNumbersById.get(imageId) ?? 1,
       imageLabel: getImageLabel(sourceState, imageId, locale)
     }))
-  const mapsNeedingGeoreferencing = mapProgress
-    .filter((map) => !map.complete)
-    .map(({ complete, ...map }) => map)
-  const exportReadyMaps = mapProgress
-    .filter((map) => map.complete)
-    .map(({ complete, ...map }) => map)
+  const mapsNeedingGeoreferencing = mapProgress.filter((map) => !map.complete)
+  const exportReadyMaps = mapProgress.filter((map) => map.complete)
   const mapCount = inactiveMaps.length + activeMaps.length
   const georeferencedMapCount =
     inactiveMaps.filter(

--- a/packages/maplibre/src/WarpedMapLayer.ts
+++ b/packages/maplibre/src/WarpedMapLayer.ts
@@ -1,4 +1,8 @@
-import { Map as MaplibreMap, CustomLayerInterface } from 'maplibre-gl'
+import {
+  Map as MaplibreMap,
+  Event as MaplibreEvent,
+  CustomLayerInterface
+} from 'maplibre-gl'
 
 import { WebGL2Renderer } from '@allmaps/render/webgl2'
 import { MaskOptions, Viewport, WarpedMapEvent } from '@allmaps/render'
@@ -23,7 +27,9 @@ import { computeWarpedMapBearing } from '@allmaps/bearing'
 import type {
   CameraForBoundsOptions,
   CenterZoomBearing,
-  LngLatBoundsLike
+  Evented,
+  LngLatBoundsLike,
+  MapContextEvent
 } from 'maplibre-gl'
 
 import type { Rectangle, Point, Fit, Size } from '@allmaps/types'
@@ -75,6 +81,14 @@ export class WarpedMapLayer
 
   map?: MaplibreMap
 
+  private onContextLost = (event: MapContextEvent) => {
+    this.contextLost(event.originalEvent)
+  }
+
+  private onContextRestored = (event: MapContextEvent) => {
+    this.contextRestored(event.originalEvent)
+  }
+
   /**
    * Creates a WarpedMapLayer instance
    *
@@ -101,8 +115,8 @@ export class WarpedMapLayer
 
     this.addEventListeners()
 
-    this.map.on('webglcontextlost', this.contextLost.bind(this))
-    this.map.on('webglcontextrestored', this.contextRestored.bind(this))
+    this.map.on('webglcontextlost', this.onContextLost)
+    this.map.on('webglcontextrestored', this.onContextRestored)
   }
 
   /**
@@ -115,8 +129,8 @@ export class WarpedMapLayer
 
     this.removeEventListeners()
 
-    this.map?.off('webglcontextlost', this.contextLost.bind(this))
-    this.map?.off('webglcontextrestored', this.contextRestored.bind(this))
+    this.map?.off('webglcontextlost', this.onContextLost)
+    this.map?.off('webglcontextrestored', this.onContextRestored)
 
     this.renderer.destroy()
   }
@@ -397,11 +411,15 @@ export class WarpedMapLayer
   nativePassWarpedMapEvent(event: Event) {
     if (event instanceof WarpedMapEvent) {
       if (this.map) {
-        this.map.fire(event.type, {
-          ...event.data,
-          error: event.error,
-          layerId: this.id
-        })
+        // Allmaps events extend the built-in MapLibre map event names.
+        const eventedMap = this.map as Evented
+        eventedMap.fire(
+          new MaplibreEvent(event.type, {
+            ...event.data,
+            error: event.error,
+            layerId: this.id
+          })
+        )
       }
     }
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,7 +85,7 @@ catalog:
   '@types/leaflet': ^1.9.4
   d3-geo: ^3.1.1
   leaflet: ^1.9.4
-  maplibre-gl: ^6.4
+  maplibre-gl: ^6.6
   ol: ^10.8.0
   pmtiles: ^4.3.0
   point-in-polygon-hao: ^1.2.4
@@ -108,4 +108,4 @@ catalog:
 
 # Keep Elysia's optional Exact Mirror peer on the compatible release.
 overrides:
-  'elysia@1.4.29>exact-mirror': 'catalog:'
+  exact-mirror: 0.2.7


### PR DESCRIPTION
Use stable WebGL context listener references so removing a warped map layer correctly unregisters its listeners, and forward custom Allmaps events through MapLibre's typed Event API. Remove redundant map-guide progress projections that introduced unused bindings.

Update the MapLibre dependency range to ^6.6 and pin Exact Mirror to 0.2.7 across the workspace for Elysia compatibility.

Validation in the current workspace:
- `pnpm run test --only`: 17 tasks passed (16 cached); build prerequisites skipped.
- `pnpm --filter @allmaps/maplibre run types`
- `pnpm --filter @allmaps/maplibre run lint`
- ESLint and Prettier checks for the editor progress file and formatting check for the workspace manifest.

Checks ran with other local workspace changes present. This PR contains only the three commits on `fix-test-lint-types`; the develop workflow updates the lockfile after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map rendering resilience when the display context is lost and restored.
  * Preserved map completion status in progress information used by map management and export workflows.
* **Compatibility**
  * Updated mapping components to support the latest supported map-rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->