### PR TITLE
fix image URL format for non-jpg images

### DIFF
--- a/packages/iiif-parser/src/classes/image.ts
+++ b/packages/iiif-parser/src/classes/image.ts
@@ -370,7 +370,11 @@ export class EmbeddedImage {
     }
 
     const quality = this.majorVersion === 1 ? 'native' : 'default'
-    const format = getImageUrlFormat(this.supportedFormats, options)
+
+    const format = getImageUrlFormat(this.supportedFormats, {
+      ...options,
+      preferredFormats: options?.preferredFormats || this.preferredFormats
+    })
 
     return `${this.uri}/${urlRegion}/${urlSize}/0/${quality}.${format}`
   }

--- a/packages/iiif-parser/src/classes/image.ts
+++ b/packages/iiif-parser/src/classes/image.ts
@@ -201,6 +201,9 @@ export class EmbeddedImage {
         this.supportsAnyRegionAndSize = false
         this.supportedFormats = ['jpg']
       }
+      if ('preferredFormats' in imageService) {
+        this.preferredFormats = imageService.preferredFormats
+      }
 
       if (imageService.width) {
         width = imageService.width

--- a/packages/iiif-parser/test/urls.test.ts
+++ b/packages/iiif-parser/test/urls.test.ts
@@ -73,6 +73,22 @@ const preferredFormatTests = [
     preferredFormats: ['avif'],
     expectedUrl:
       'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/0,0,512,512/256,256/0/default.jpg'
+  },
+  {
+    filename: 'image.3.918ecd18c2592080851777620de9bcb5-gottingen.json',
+    region: { x: 0, y: 0, width: 512, height: 512 },
+    size: { width: 256, height: 256 },
+    preferredFormats: [],
+    expectedUrl:
+      'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/0,0,512,512/256,256/0/default.jpg'
+  },
+  // No preferredFormats specified: falls back to the first server's preferred format from the image JSON
+  {
+    filename: 'image.3.918ecd18c2592080851777620de9bcb5-gottingen.json',
+    region: { x: 0, y: 0, width: 512, height: 512 },
+    size: { width: 256, height: 256 },
+    expectedUrl:
+      'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/0,0,512,512/256,256/0/default.webp'
   }
 ]
 

--- a/packages/iiif-parser/test/urls.test.ts
+++ b/packages/iiif-parser/test/urls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { Image } from '../src/index.js'
+import { EmbeddedImage, Image } from '../src/index.js'
 
 import { readJson } from './lib/fs.js'
 
@@ -133,3 +133,54 @@ for (const {
     })
   })
 }
+
+describe('preferred formats for embedded image', () => {
+  const imageUrlBase =
+    'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen'
+  const imageRequest = {
+    region: { x: 0, y: 0, width: 512, height: 512 },
+    size: { width: 256, height: 256 }
+  }
+
+  const createEmbeddedImage = () => {
+    return new EmbeddedImage(
+      {
+        type: 'Image',
+        width: 4032,
+        height: 3024,
+        service: [
+          {
+            id: imageUrlBase,
+            type: 'ImageService3',
+            profile: 'level1',
+            extraFormats: ['jpg', 'png', 'webp'],
+            preferredFormats: ['webp', 'jpg']
+          }
+        ]
+      },
+      {
+        parsedCanvas: {
+          id: 'https://example.org/canvas/p1',
+          type: 'Canvas',
+          width: 4032,
+          height: 3024,
+          items: []
+        }
+      }
+    )
+  }
+
+  test('should use preferred format from the embedded image service', () => {
+    const embeddedImage = createEmbeddedImage()
+    const url = embeddedImage.getImageUrl(imageRequest)
+    expect(url).to.equal(`${imageUrlBase}/0,0,512,512/256,256/0/default.webp`)
+  })
+
+  test('should prefer explicitly passed formats over the embedded image service', () => {
+    const embeddedImage = createEmbeddedImage()
+    const url = embeddedImage.getImageUrl(imageRequest, {
+      preferredFormats: ['png']
+    })
+    expect(url).to.equal(`${imageUrlBase}/0,0,512,512/256,256/0/default.png`)
+  })
+})


### PR DESCRIPTION
`EmbeddedImage.getImageUrl()` always fell back to jpg when the caller didn't pass `preferredFormats`, so
image URLs were generated in a format the image server may not prefer (e.g. servers whose info.json lists
`png`, `webp` or `avif` as preferred formats).

`getImageUrl()` now falls back to the `preferredFormats` parsed from the image service JSON of the embedded
image when no caller-provided formats are given. Caller options still take precedence, and
`getImageUrlFormat()` still only picks formats the server supports, defaulting to jpg when nothing matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image URLs now correctly use configured preferred formats when no per-request format preference is provided.
  * Embedded images now honor the image service’s preferred format, such as WebP, when no caller preference is specified.
  * Explicit per-request preferences, such as PNG, continue to take priority.
  * Empty format preferences fall back to JPEG, while omitted preferences use the server’s preferred format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->